### PR TITLE
Fix logical flaw in permutation generator

### DIFF
--- a/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
+++ b/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
@@ -57,7 +57,7 @@ public class FoldedFigure_Worker {
     int makesuu1ijyouno_menno_amount = 0;//Number of faces that can only be ranked if there is one or more other faces on top
     private int top_face_id_ga_maketa_kazu_goukei_without_rated_face = 0;
 
-    SwappingAlgorithm swapper = new SwappingAlgorithm();
+    SwappingAlgorithm swapper;
 
     EquivalenceCondition errorPos = null;
 
@@ -294,11 +294,6 @@ public class FoldedFigure_Worker {
         hierarchyList.save();//Save the hierarchical relationship determined from the mountain fold and valley fold information.
         //************************************************************************
         bb.write("           Jyougehyou_settei   step5   start ");
-        //Make a guidebook for each SubFace
-        System.out.println("Smen毎に案内書を作る");
-        for (int i = 1; i <= SubFaceTotal; i++) {
-            s0[i].setGuideMap(hierarchyList);
-        }
 
         //s0に優先順位をつける(このときhierarchyListの-100のところが変るところがある)
         System.out.println("Smen(s0)に優先順位をつける");
@@ -332,6 +327,13 @@ public class FoldedFigure_Worker {
 
         for (int i = 1; i <= SubFaceTotal; i++) {
             s[i] = s0[priorityMap[i]];
+        }
+
+        // Make a guidebook for each valid SubFace.
+        // Previously this is done for all SubFaces, which is unnecessary.
+        System.out.println("Building guides for SubFace");
+        for (int i = 1; i <= SubFace_valid_number; i++) {
+            s[i].setGuideMap(hierarchyList);
         }
 
         //優先順位を逆転させる。これが有効かどうかは不明wwwww
@@ -373,7 +375,7 @@ public class FoldedFigure_Worker {
         isusumu = 0;
         //All SubFaces above ss + 1 are set to the initial values. An error occurs when the number of faces included in SubFace is 0.
 
-        for (int i = ss + 1; i <= SubFaceTotal; i++) {
+        for (int i = ss + 1; i <= SubFace_valid_number; i++) {
             s[i].Permutation_first();
         }
         //The overlapping state of the surfaces is changed in order from the one with the largest id number of the SubFace.
@@ -400,12 +402,14 @@ public class FoldedFigure_Worker {
     }
 
     //Start with the current permutation state and look for possible overlapping states. There is room for speeding up here.
-    public int possible_overlapping_search() throws InterruptedException {      //This should not change the hierarchyList.
+    public int possible_overlapping_search(boolean swap) throws InterruptedException {      //This should not change the hierarchyList.
         bb.write("_ _______");
         bb.write("__ ______");
         bb.write("___ _____");
         bb.write("____ ____");
         int ms, Sid;
+
+        swapper = new SwappingAlgorithm();
 
         Sid = 1;//The initial value of Sid can be anything other than 0.
         while (Sid != 0) { //If Sid == 0, it means that even the smallest number of SubFace has been searched.
@@ -417,7 +421,9 @@ public class FoldedFigure_Worker {
             Sid = next(ms - 1);
             bb.rewrite(9, "susumu(" + ms + "-1 = )" + Sid);
 
-            swapper.process(s);
+            if(swap) {
+                swapper.process(s);
+            }
 
             if (Thread.interrupted()) throw new InterruptedException();
         }
@@ -461,6 +467,10 @@ public class FoldedFigure_Worker {
                 SubFace temp = s[v];
                 s[v] = s[e];
                 s[e] = temp;
+
+                // The new SubFace doesn't have guidebook yet.
+                hierarchyList.restore();
+                s[v].setGuideMap(hierarchyList);
 
                 // record dead-end here since this SubFace is having a contradiction already
                 swapper.record(v);

--- a/src/main/java/origami/folding/algorithm/SwappingAlgorithm.java
+++ b/src/main/java/origami/folding/algorithm/SwappingAlgorithm.java
@@ -47,6 +47,7 @@ public class SwappingAlgorithm {
             SubFace temp = s[high];
             for (int i = high; i > low; i--) {
                 s[i] = s[i - 1];
+                s[i].clearTempGuide();
             }
             s[low] = temp;
 

--- a/src/main/java/origami/folding/element/SubFace.java
+++ b/src/main/java/origami/folding/element/SubFace.java
@@ -2,6 +2,7 @@ package origami.folding.element;
 
 import origami.folding.HierarchyList;
 import origami.folding.util.EquivalenceCondition;
+import origami.folding.permutation.ChainPermutationGenerator;
 import origami.folding.permutation.PermutationGenerator;
 import origami_editor.editor.component.BulletinBoard;
 
@@ -49,7 +50,7 @@ public class SubFace {//This class folds the development view and estimates the 
             fromTop_counted_position2FaceId[i] = 0;
         }
         if (FIdCount > 0) {
-            permutationGenerator = new PermutationGenerator(faceIdCount);
+            permutationGenerator = new ChainPermutationGenerator(faceIdCount);
             // Postpone the reset of the generator until the guides are set
         }
     }
@@ -151,6 +152,10 @@ public class SubFace {//This class folds the development view and estimates the 
         return permutationGenerator.getPermutation(i);
     }
 
+    public void clearTempGuide() {
+        permutationGenerator.clearTempGuide();
+    }
+
     // Check from the top side to find out at what digit the folds are inconsistent.
     // At this time, hierarchyList does not change. Here, the penetration condition of the boundary line of the adjacent surface is not checked.
     // This SubFace returns 1000 if there is no contradiction in the folds.
@@ -163,7 +168,7 @@ public class SubFace {//This class folds the development view and estimates the 
                     // Add a temporary guide to the generator, so that before the current SubFace
                     // runs out of permutation, it won't generate another permutation violating the
                     // same relation over and over. For some CPs this speeds things up like crazy.
-                    permutationGenerator.addGuide(I, J);
+                    permutationGenerator.addGuide(J, I);
                     return i;
                 }
             }
@@ -304,7 +309,7 @@ public class SubFace {//This class folds the development view and estimates the 
             // Add guides
             for (int i = 1; i <= ueFaceIdCount; i++) {
                 if (ueFaceIdFlg[i]) {
-                    permutationGenerator.addGuide(faceIndex, ueFaceId[i]);
+                    permutationGenerator.addGuide(ueFaceId[i], faceIndex);
                 }
             }
 
@@ -321,7 +326,7 @@ public class SubFace {//This class folds the development view and estimates the 
         int iret = 0;
         for (int i = 1; i <= faceIdCount - 1; i++) {
             for (int j = i + 1; j <= faceIdCount; j++) {
-                if (hierarchyList.get(faceIdList[getPermutation(i)], faceIdList[getPermutation(j)]) == HierarchyList.EMPTY_N100) {
+                if (hierarchyList.get(faceIdList[i], faceIdList[j]) == HierarchyList.EMPTY_N100) {
                     iret++;
                 }//20171021本当は-50のつもりだったが現状は-100となっている
             }
@@ -334,7 +339,7 @@ public class SubFace {//This class folds the development view and estimates the 
         int iret = 0;
         for (int i = 1; i <= faceIdCount - 1; i++) {
             for (int j = i + 1; j <= faceIdCount; j++) {
-                if (hierarchyList.get(faceIdList[getPermutation(i)], faceIdList[getPermutation(j)]) == HierarchyList.BELOW_0) {
+                if (hierarchyList.get(faceIdList[i], faceIdList[j]) == HierarchyList.BELOW_0) {
                     iret++;
                 }
             }

--- a/src/main/java/origami/folding/permutation/ChainPermutationGenerator.java
+++ b/src/main/java/origami/folding/permutation/ChainPermutationGenerator.java
@@ -1,0 +1,178 @@
+package origami.folding.permutation;
+
+/**
+ * Author: Mu-Tsun Tsai
+ * 
+ * This is a much more efficient permutation generator than the original
+ * implementation by Mr.Meguro. It uses the classical digit swapping idea to
+ * reduce half of the work searching for next available element. It is also
+ * equipped with an improved PairGuide to help skipping vast amount of
+ * permutations that won't work.
+ * 
+ * The idea behind ChainPermutationGenerator is that it locks the ordering of
+ * the longest chain found in the given PairGuide. This reduces as much as l!
+ * iterations, where l is the length of the chain.
+ */
+public class ChainPermutationGenerator extends PermutationGenerator {
+
+    // swapHistory[i] == j >= i means we swap index i with index j in step i;
+    // swapHistory[i] == i - 1 means we're not done yet.
+    private final int[] swapHistory;
+
+    private final PairGuide pairGuide;
+
+    // An initial permutation, where the lock sequence return by PairGuide is
+    // located at the end.
+    private final int[] initPermutation;
+
+    // If an element is in the lock sequence.
+    private final boolean[] isLocked;
+
+    private int lockCount;
+    private int lockRemain;
+
+    public ChainPermutationGenerator(int numDigits) {
+        super(numDigits);
+        this.initPermutation = new int[numDigits + 1];
+        this.isLocked = new boolean[numDigits + 1];
+        this.swapHistory = new int[numDigits + 1];
+        this.pairGuide = new PairGuide(numDigits);
+    }
+
+    public void reset() {
+        count = 0;
+        lockRemain = lockCount;
+        for (int i = 1; i <= numDigits; i++) {
+            digits[i] = initPermutation[i];
+            map[i] = i;
+            swapHistory[i] = i - 1;
+        }
+        pairGuide.reset();
+        next(0);
+    }
+
+    public int next(int digit) {
+        int curIndex = 1;
+
+        // swapHistory[1] == 0 means the generator has just reset, and we don't need to
+        // do anything. Otherwise we need to retract to the requested digit.
+        if (swapHistory[1] != 0) {
+            curIndex = numDigits;
+
+            // It is possible that temp guides are added, so that the last element is no
+            // longer a leaf node, and we must retract it to makes things consistent.
+            pairGuide.retract(digits[curIndex]);
+
+            do {
+                swapHistory[curIndex] = curIndex - 1;
+                retract(--curIndex);
+            } while (curIndex > digit);
+        }
+
+        while (curIndex < numDigits) {
+            int swapIndex = swapHistory[curIndex];
+            int curDigit = 0;
+
+            // Find the next available element.
+            do {
+                swapIndex++;
+                if (swapIndex > numDigits - lockRemain + 1) {
+                    break;
+                }
+                curDigit = digits[swapIndex];
+            } while (pairGuide.isNotReady(curDigit));
+
+            // If the current digit has no available element, retract.
+            if (swapIndex > numDigits - lockRemain + 1) {
+                swapHistory[curIndex] = curIndex - 1;
+                if (--curIndex == 0) {
+                    return 0;
+                }
+                retract(curIndex);
+                if (curIndex < digit) {
+                    digit = curIndex;
+                }
+                continue;
+            }
+
+            // Make the swap.
+            if (swapIndex != curIndex) {
+                digits[swapIndex] = digits[curIndex];
+                digits[curIndex] = curDigit;
+            }
+            swapHistory[curIndex] = swapIndex;
+            map[curDigit] = curIndex;
+            if (isLocked[curDigit]) {
+                lockRemain--;
+            }
+            pairGuide.confirm(curDigit);
+
+            curIndex++;
+        }
+
+        // Fill the last element into the map. There's no need to confirm the last
+        // element, because it is definitely a leaf node.
+        map[digits[numDigits]] = numDigits;
+
+        count++;
+        return digit;
+    }
+
+    @Override
+    public void clearTempGuide() {
+        pairGuide.clearTempGuide(count != 0);
+    }
+
+    @Override
+    public void addGuide(int upperFaceIndex, int faceIndex) {
+        pairGuide.add(upperFaceIndex, faceIndex);
+    }
+
+    public void initialize() {
+        // Determine locked elements.
+        int[] lock = pairGuide.lock();
+        if (lock != null) {
+            lockCount = lock[0];
+            for (int i = 1; i <= lockCount; i++) {
+                isLocked[lock[i]] = true;
+            }
+
+            // Prepare initial permutation.
+            int i, j = 1;
+            for (i = 1; i <= numDigits - lockCount; i++) {
+                while (isLocked[j]) {
+                    j++;
+                }
+                initPermutation[i] = j;
+                j++;
+            }
+            for (i = 1; i <= lockCount; i++) {
+                initPermutation[i + numDigits - lockCount] = lock[i];
+            }
+
+            // When generating permutations, the last locked element behaves the same as
+            // normal elements.
+            isLocked[lock[lockCount]] = false;
+        } else {
+            for (int i = 1; i <= numDigits; i++) {
+                initPermutation[i] = i;
+            }
+        }
+
+        reset();
+    }
+
+    private void retract(int index) {
+        int swapIndex = swapHistory[index];
+        int curDigit = digits[index];
+        if (swapIndex != index) {
+            digits[index] = digits[swapIndex];
+            digits[swapIndex] = curDigit;
+        }
+        map[curDigit] = 0;
+        if (isLocked[curDigit]) {
+            lockRemain++;
+        }
+        pairGuide.retract(curDigit);
+    }
+}

--- a/src/main/java/origami/folding/permutation/PairGuide.java
+++ b/src/main/java/origami/folding/permutation/PairGuide.java
@@ -76,16 +76,24 @@ public class PairGuide {
     public void reset() {
         for (int i = 1; i <= numDigits; i++) {
             score[i] = 0;
-            if (added) {
+        }
+        clearTempGuide(false);
+    }
+
+    public void clearTempGuide(boolean matchScore) {
+        if (added) {
+            for (int i = 1; i <= numDigits; i++) {
                 guide[i] = initGuide[i];
                 goal[i] = initGoal[i];
+                if (matchScore) {
+                    // If temp guide is cleared in the middle of permutation search,
+                    // then the score must match the initial score.
+                    score[i] = initGoal[i];
+                }
             }
-        }
-        if (added) {
             entries.subList(initEntries, entries.size()).clear();
             added = false;
         }
-
     }
 
     public void confirm(int curDigit) {
@@ -169,7 +177,7 @@ public class PairGuide {
         return score[curDigit] < goal[curDigit];
     }
 
-    public void add(int faceIndex, int upperFaceIndex) {
+    public void add(int upperFaceIndex, int faceIndex) {
         int next = guide[upperFaceIndex];
         entries.add(faceIndex | (next << 16));
         guide[upperFaceIndex] = entries.size() - 1;

--- a/src/main/java/origami/folding/permutation/PermutationGenerator.java
+++ b/src/main/java/origami/folding/permutation/PermutationGenerator.java
@@ -3,183 +3,52 @@ package origami.folding.permutation;
 /**
  * Author: Mu-Tsun Tsai
  * 
- * This is a much more efficient permutation generator than the original
- * implementation by Mr.Meguro. It uses the classical digit swapping idea to
- * reduce half of the work searching for next available element. It is also
- * equipped with an improved PairGuide to help skipping vast amount of
- * permutations that won't work.
+ * This is the base class for different permutation generator implementations.
  */
-public class PermutationGenerator {
+public abstract class PermutationGenerator {
 
-    private int count = 0;
-    private final int numDigits;
+    /** Number of valid permutations found. */
+    protected int count;
+
+    /** Total number of digits. */
+    protected final int numDigits;
 
     /** digits[i] gives the element at position i. */
-    private final int[] digits;
+    protected final int[] digits;
 
     /** map[i] gives the position of element i. */
-    private final int[] map;
-
-    // swapHistory[i] == j >= i means we swap index i with index j in step i;
-    // swapHistory[i] == i - 1 means we're not done yet.
-    private final int[] swapHistory;
-
-    private final PairGuide pairGuide;
-
-    // An initial permutation, where the lock sequence return by PairGuide is
-    // located at the end.
-    private final int[] initPermutation;
-
-    // If an element is in the lock sequence.
-    private final boolean[] isLocked;
-
-    private int lockCount;
-    private int lockRemain;
+    protected final int[] map;
 
     public PermutationGenerator(int numDigits) {
         this.numDigits = numDigits;
         this.digits = new int[numDigits + 1];
-        this.initPermutation = new int[numDigits + 1];
-        this.isLocked = new boolean[numDigits + 1];
         this.map = new int[numDigits + 1];
-        this.swapHistory = new int[numDigits + 1];
-        this.pairGuide = new PairGuide(numDigits);
     }
 
-    public void reset() {
-        count = 0;
-        lockRemain = lockCount;
-        for (int i = 1; i <= numDigits; i++) {
-            digits[i] = initPermutation[i];
-            map[i] = i;
-            swapHistory[i] = i - 1;
-        }
-        pairGuide.reset();
-        next(0);
-    }
-
-    public int next(int digit) {
-        int curIndex = 1;
-
-        // swapHistory[1] == 0 means the generator has just reset, and we don't need to
-        // do anything. Otherwise we need to retract to the requested digit.
-        if (swapHistory[1] != 0) {
-            curIndex = numDigits;
-            do {
-                swapHistory[curIndex] = curIndex - 1;
-                retract(--curIndex);
-            } while (curIndex > digit);
-        }
-
-        while (curIndex < numDigits) {
-            int swapIndex = swapHistory[curIndex];
-            int curDigit = 0;
-
-            // Find the next available element.
-            do {
-                swapIndex++;
-                if (swapIndex > numDigits - lockRemain + 1) {
-                    break;
-                }
-                curDigit = digits[swapIndex];
-            } while (pairGuide.isNotReady(curDigit));
-
-            // If the current digit has no available element, retract.
-            if (swapIndex > numDigits - lockRemain + 1) {
-                swapHistory[curIndex] = curIndex - 1;
-                if (--curIndex == 0) {
-                    return 0;
-                }
-                retract(curIndex);
-                if (curIndex < digit) {
-                    digit = curIndex;
-                }
-                continue;
-            }
-
-            // Make the swap.
-            if (swapIndex != curIndex) {
-                digits[swapIndex] = digits[curIndex];
-                digits[curIndex] = curDigit;
-            }
-            swapHistory[curIndex] = swapIndex;
-            map[curDigit] = curIndex;
-            if (isLocked[curDigit]) {
-                lockRemain--;
-            }
-            pairGuide.confirm(curDigit);
-
-            curIndex++;
-        }
-
-        // Fill the last element into the map
-        map[digits[numDigits]] = numDigits;
-
-        count++;
-        return digit;
-    }
-
-    public int locate(int i) {
+    public final int locate(int i) {
         return map[i];
     }
 
-    public int getCount() {
+    public final int getCount() {
         return count;
     }
 
-    public int getPermutation(int digit) {
+    public final int getPermutation(int digit) {
         return digits[digit];
     }
 
-    public void addGuide(int faceIndex, int upperFaceIndex) {
-        pairGuide.add(faceIndex, upperFaceIndex);
-    }
+    /** Remember to reset at the end of initialization. */
+    public abstract void initialize();
 
-    public void initialize() {
-        // Determine locked elements.
-        int[] lock = pairGuide.lock();
-        if (lock != null) {
-            lockCount = lock[0];
-            for (int i = 1; i <= lockCount; i++) {
-                isLocked[lock[i]] = true;
-            }
-    
-            // Prepare initial permutation.
-            int i, j = 1;
-            for (i = 1; i <= numDigits - lockCount; i++) {
-                while (isLocked[j]) {
-                    j++;
-                }
-                initPermutation[i] = j;
-                j++;
-            }
-            for (i = 1; i <= lockCount; i++) {
-                initPermutation[i + numDigits - lockCount] = lock[i];
-            }
-    
-            // When generating permutations, the last locked element behaves the same as
-            // normal elements.
-            isLocked[lock[lockCount]] = false;
-        } else {
-            for (int i = 1; i <= numDigits; i++) {
-                initPermutation[i] = i;
-            }
-        }
+    /** Reset to the first valid permutation. */
+    public abstract void reset();
 
-        reset();
-    }
+    /** Clear all temporary guides. */
+    public abstract void clearTempGuide();
 
-    private void retract(int index) {
-        int swapIndex = swapHistory[index];
-        int curDigit = digits[index];
-        if (swapIndex != index) {
-            digits[index] = digits[swapIndex];
-            digits[swapIndex] = curDigit;
-        }
-        map[curDigit] = 0;
-        if (isLocked[curDigit]) {
-            lockRemain++;
-        }
-        pairGuide.retract(curDigit);
-    }
+    /** Returns the lowest digit that was changed in the process. */
+    public abstract int next(int digit);
+
+    /** Add a constraint saying that "from" must appear before "to". */
+    public abstract void addGuide(int from, int to);
 }

--- a/src/main/java/origami_editor/editor/folded_figure/FoldedFigure.java
+++ b/src/main/java/origami_editor/editor/folded_figure/FoldedFigure.java
@@ -572,7 +572,7 @@ public class FoldedFigure {
         if ((estimationStep == EstimationStep.STEP_4) || (estimationStep == EstimationStep.STEP_5)) {
             if (findAnotherOverlapValid) {
 
-                ip2_possibleOverlap = ct_worker.possible_overlapping_search();//ip2_possibleOverlap = A variable that stores 0 if there is no possible overlap and 1000 if there is a possible overlap when the upper and lower table craftsmen search for a foldable overlap.
+                ip2_possibleOverlap = ct_worker.possible_overlapping_search(discovered_fold_cases == 0);//ip2_possibleOverlap = A variable that stores 0 if there is no possible overlap and 1000 if there is a possible overlap when the upper and lower table craftsmen search for a foldable overlap.
 
                 if (ip2_possibleOverlap == 1000) {
                     discovered_fold_cases = discovered_fold_cases + 1;


### PR DESCRIPTION
This PR fixed a critical logical flaw between the swapping algorithm and the chain guide that makes it possible for the search to skip valid solutions. It also did some minor refactoring and performance improvement.