### PR TITLE
Use ListPer2DArray in AdditionalEstimationAlgorithm

### DIFF
--- a/src/main/java/origami/folding/algorithm/AdditionalEstimationAlgorithm.java
+++ b/src/main/java/origami/folding/algorithm/AdditionalEstimationAlgorithm.java
@@ -29,7 +29,7 @@ public class AdditionalEstimationAlgorithm {
     private final SubFace[] subFaces; // indices start from 1
 
     private final ItalianoAlgorithm[] IA;
-    private ListPer2DArray<Integer> relationObservers;
+    private ListPer2DArray relationObservers;
 
     public int errorIndex;
 
@@ -39,7 +39,7 @@ public class AdditionalEstimationAlgorithm {
         this.hierarchyList = hierarchyList;
         this.subFaces = s;
         IA = new ItalianoAlgorithm[subFaces.length];
-        relationObservers = new ListPer2DArray<>(hierarchyList.getFacesTotal());
+        relationObservers = new ListPer2DArray(hierarchyList.getFacesTotal());
     }
 
     public HierarchyListStatus run(int completedSubFaces) {

--- a/src/main/java/origami/folding/algorithm/SubFacePriority.java
+++ b/src/main/java/origami/folding/algorithm/SubFacePriority.java
@@ -17,12 +17,12 @@ public class SubFacePriority {
     // These are all 1-based
     private final int[] newInfoCount;
     private final boolean[] processed;
-    private final ListPer2DArray<Integer> observers;
+    private final ListPer2DArray observers;
 
     public SubFacePriority(int totalFace, int totalSubFace) {
         newInfoCount = new int[totalSubFace + 1];
         processed = new boolean[totalSubFace + 1];
-        observers = new ListPer2DArray<>(totalFace);
+        observers = new ListPer2DArray(totalFace);
     }
 
     public void addSubFace(SubFace s, int index, HierarchyList hierarchyList) {


### PR DESCRIPTION
In order to make AdditionalEstimationAlgorithm run really fast, it needs to use the observer pattern, but previously such pattern is way too memory consuming for larger CP, leading to the fallback "linear mode". Now with the memory-efficient ListPer2DArray, we can again implement AEA with observer pattern and run the full Ryujin again under 12G memory setting. The new record is now 33 minutes, saving about 10 mintues comparing to the previous record.