### PR TITLE
implement "Smart Folding" from orihimeMod

### DIFF
--- a/src/main/java/origami/crease_pattern/element/LineSegment.java
+++ b/src/main/java/origami/crease_pattern/element/LineSegment.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Objects;
 
 public class LineSegment implements Serializable, Cloneable {
     protected final Point a = new Point(); //Branch a point
@@ -14,8 +15,7 @@ public class LineSegment implements Serializable, Cloneable {
     int customized = 0;//Custom property parameters
     Color customizedColor = new Color(100, 200, 200);//Color if custom made
 
-    int selected;//0 is not selected. 1 or more is set appropriately according to the situation
-
+    protected int selected;//0 is not selected. 1 or more is set appropriately according to the situation
 
 
     //コンストラクタ
@@ -255,6 +255,20 @@ public class LineSegment implements Serializable, Cloneable {
     }
 
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LineSegment that = (LineSegment) o;
+        return customized == that.customized && selected == that.selected && Objects.equals(a, that.a)
+                && Objects.equals(b, that.b) && active == that.active && color == that.color
+                && Objects.equals(customizedColor, that.customizedColor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(a, b, active, color, customized, customizedColor, selected);
+    }
 
     @Override
     public LineSegment clone() {

--- a/src/main/java/origami/crease_pattern/element/Point.java
+++ b/src/main/java/origami/crease_pattern/element/Point.java
@@ -1,6 +1,7 @@
 package origami.crease_pattern.element;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class Point implements Serializable {
     //Used to represent point coordinates, direction vectors, etc.
@@ -107,5 +108,25 @@ public class Point implements Serializable {
     public void move(Point addPoint) {
         x = x + addPoint.getX();
         y = y + addPoint.getY();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Point point = (Point) o;
+        return Double.compare(point.x, x) == 0 && Double.compare(point.y, y) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(x, y);
+    }
+
+    /**
+     * @return new Point with the coordinates rounded to full numbers
+     */
+    public Point rounded() {
+        return new Point(Math.round(x), Math.round(y));
     }
 }

--- a/src/main/java/origami_editor/editor/App.java
+++ b/src/main/java/origami_editor/editor/App.java
@@ -598,7 +598,9 @@ public class App {
             System.out.println(" oritatame 20180108");
         } else if ((foldType == FoldType.FOR_ALL_LINES_1) || (foldType == FoldType.FOR_SELECTED_LINES_2)) {
             if (foldType == FoldType.FOR_ALL_LINES_1) {
-                mainCreasePatternWorker.select_all();
+                //mainCreasePatternWorker.select_all();
+                Point cpPivot = this.mainCreasePatternWorker.getCameraPosition();
+                mainCreasePatternWorker.selectConnected(this.mainCreasePatternWorker.foldLineSet.closestPoint(cpPivot));
             }
             //
             if (applicationModel.getCorrectCpBeforeFolding()) {// Automatically correct strange parts (branch-shaped fold lines, etc.) in the crease pattern

--- a/src/main/java/origami_editor/editor/canvas/CreasePattern_Worker.java
+++ b/src/main/java/origami_editor/editor/canvas/CreasePattern_Worker.java
@@ -3,7 +3,6 @@ package origami_editor.editor.canvas;
 import origami.crease_pattern.FoldLineSet;
 import origami.crease_pattern.LineSegmentSet;
 import origami.crease_pattern.OritaCalc;
-import origami.crease_pattern.PointSet;
 import origami.crease_pattern.element.Point;
 import origami.crease_pattern.element.Polygon;
 import origami.crease_pattern.element.*;
@@ -957,6 +956,14 @@ public class CreasePattern_Worker {
     public void setData(HistoryStateModel historyStateModel) {
         setUndoTotal(historyStateModel.getHistoryTotal());
         setAuxUndoTotal(historyStateModel.getHistoryTotal());
+    }
+
+    public Point getCameraPosition() {
+        return this.camera.getCameraPosition();
+    }
+
+    public void selectConnected(Point p) {
+        this.foldLineSet.selectProbablyConnected(p);
     }
 
     //30 30 30 30 30 30 30 30 30 30 30 30 除け_線_変換


### PR DESCRIPTION
When you press fold without selecting anything, this automatically selects all connected creases, starting from the one closest to the green cross. This is useful when there are multiple cps in a file, so its not needed to select the one you want to fold before pressing fold. 
Also prevents the program from freezing if you forget to select a cp before pressing fold (#74) in most cases (if the squares are very close, or if multiple squares are selected manually, it would still freeze)