### PR TITLE
Improve findLineInFaceBorder and add InterruptedException

### DIFF
--- a/src/main/java/origami/crease_pattern/PointSet.java
+++ b/src/main/java/origami/crease_pattern/PointSet.java
@@ -441,7 +441,7 @@ public class PointSet implements Serializable {
     //--------------------------------
 
     //-------------------------------------
-    public void FaceOccurrence() {
+    public void FaceOccurrence() throws InterruptedException {
         int flag1;
         Face tempFace;
         numFaces = 0;
@@ -483,7 +483,7 @@ public class PointSet implements Serializable {
         findLineInFaceBorder();
     }
 
-    private void findLineInFaceBorder() {
+    private void findLineInFaceBorder() throws InterruptedException {
         int[] head = new int[numPoints + 1];
 
         // 1-based
@@ -519,6 +519,7 @@ public class PointSet implements Serializable {
                 lineInFaceBorder_min[i] = min;
                 lineInFaceBorder_max[i] = max;
             }
+            if (Thread.interrupted()) throw new InterruptedException();
         }
     }
 
@@ -623,7 +624,7 @@ public class PointSet implements Serializable {
         return (lines[lineId].getEnd() == faces[faceId].getPointId(faces[faceId].getNumPoints())) && (lines[lineId].getBegin() == faces[faceId].getPointId(1));
     }
 
-    private void Face_adjacent_create() {
+    private void Face_adjacent_create() throws InterruptedException {
         System.out.println("面となり作成　開始");
         for (int im = 1; im <= numFaces - 1; im++) {
             for (int in = im + 1; in <= numFaces; in++) {
@@ -652,8 +653,8 @@ public class PointSet implements Serializable {
                         }
                     }
                 }
-
             }
+            if (Thread.interrupted()) throw new InterruptedException();
         }
         System.out.println("面となり作成　終了");
     }

--- a/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
+++ b/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
@@ -109,7 +109,7 @@ public class FoldedFigure_Worker {
         return SubFace_valid_number;
     }
 
-    public void SubFace_configure(PointSet otta_Face_figure, PointSet SubFace_figure) {//js.Jyougehyou_settei(ts1,ts2.get(),ts3.get());
+    public void SubFace_configure(PointSet otta_Face_figure, PointSet SubFace_figure) throws InterruptedException {//js.Jyougehyou_settei(ts1,ts2.get(),ts3.get());
         // Make an upper and lower table of faces (the faces in the unfolded view before folding).
         // This includes the point set of ts2 (which has information on the positional relationship of the faces after folding) and <-------------otta_Face_figure
         // Use the point set of ts3 (which has the information of SubFace whose surface is subdivided in the wire diagram). <-------------SubFace_figure
@@ -154,6 +154,8 @@ public class FoldedFigure_Worker {
             for (int j = 1; j <= s0addFaceTotal; j++) {
                 s0[i].setFaceId(j, s0addFaceId[j]);//ここで面番号jは小さい方が先に追加される。
             }
+
+            if (Thread.interrupted()) throw new InterruptedException();
         }
 
         //ここまでで、SubFaceTotal＝	SubFace_figure.getMensuu()のままかわりなし。
@@ -228,6 +230,7 @@ public class FoldedFigure_Worker {
                     }
                 }
             }
+            if (Thread.interrupted()) throw new InterruptedException();
         }
         System.out.print("３面が関与する突き抜け条件の数　＝　");
         System.out.println(hierarchyList.getEquivalenceConditionTotal());
@@ -265,6 +268,7 @@ public class FoldedFigure_Worker {
                     }
                 }
             });
+            if (Thread.interrupted()) throw new InterruptedException();
         }
 
         // Done adding tasks, shut down ExecutorService
@@ -379,7 +383,7 @@ public class FoldedFigure_Worker {
         return false;
     }
 
-    public int next(int ss) {
+    public int next(int ss) throws InterruptedException {
         int isusumu;//When = 0, SubFace changes (image that digits change).
         int subfaceId;//SubFace id number that has changed
         isusumu = 0;
@@ -442,7 +446,7 @@ public class FoldedFigure_Worker {
 
     //-----------------------------------------------------------------------------------------------------------------
     //Search for SubFaces that fold inconsistently in ascending order of number. There is room for speeding up here as well.
-    private int inconsistent_subFace_request() { //hierarchyList changes.
+    private int inconsistent_subFace_request() throws InterruptedException { //hierarchyList changes.
         int kks;
         hierarchyList.restore();//<<<<<<<<<<<<<<<<<<<<<<<<<<<,,
 

--- a/src/main/java/origami/crease_pattern/worker/WireFrame_Worker.java
+++ b/src/main/java/origami/crease_pattern/worker/WireFrame_Worker.java
@@ -289,7 +289,7 @@ public class WireFrame_Worker {
         return new LineSegmentSet(pointSet);
     }
 
-    public void setLineSegmentSet(LineSegmentSet lineSegmentSet) {
+    public void setLineSegmentSet(LineSegmentSet lineSegmentSet) throws InterruptedException {
         Point ti;
         reset();
 

--- a/src/main/java/origami/folding/element/SubFace.java
+++ b/src/main/java/origami/folding/element/SubFace.java
@@ -76,7 +76,7 @@ public class SubFace {//This class folds the development view and estimates the 
         return permutationGenerator.getCount();
     }
 
-    public void Permutation_first() {
+    public void Permutation_first() throws InterruptedException {
         if (getFaceIdCount() > 0) {
             permutationGenerator.reset();
         }
@@ -90,13 +90,13 @@ public class SubFace {//This class folds the development view and estimates the 
     // Advance the k-th digit permutation generator and change the overlapping state of the faces to the next state. Normally returns 0.
     // Return 1 if the current overlapping state of the faces is the last one.
     // In this case, the overlapping state of the faces remains the last one.
-    public int next(int k) {
+    public int next(int k) throws InterruptedException {
         return permutationGenerator.next(k);
     }   //<<<<<<<<<<<<<<<<<<<ここは後で機能を強化して高速化したい。
     // ここは　class SubFace の中だよ。
 
     //Start with the current permutation state and look for possible permutations that overlap
-    public int possible_overlapping_search(HierarchyList hierarchyList) {//This should not change hierarchyList.
+    public int possible_overlapping_search(HierarchyList hierarchyList) throws InterruptedException {//This should not change hierarchyList.
         int mk, ijh;
         ijh = 1;//The initial value of ijh can be anything other than 0.
         while (ijh != 0) { //If ijh == 0, you have reached the end of the digit.
@@ -280,7 +280,7 @@ public class SubFace {//This class folds the development view and estimates the 
     }
 
     /** Prepare a guidebook for the permutation generator in SubFace. */
-    public void setGuideMap(HierarchyList hierarchyList) {
+    public void setGuideMap(HierarchyList hierarchyList) throws InterruptedException {
         int[] ueFaceId = new int[faceIdCount + 1];
         boolean[] ueFaceIdFlg = new boolean[faceIdCount + 1];//1 if ueFaceId [] is enabled, 0 if disabled
 

--- a/src/main/java/origami/folding/permutation/ChainPermutationGenerator.java
+++ b/src/main/java/origami/folding/permutation/ChainPermutationGenerator.java
@@ -39,7 +39,7 @@ public class ChainPermutationGenerator extends PermutationGenerator {
         this.pairGuide = new PairGuide(numDigits);
     }
 
-    public void reset() {
+    public void reset() throws InterruptedException {
         count = 0;
         lockRemain = lockCount;
         for (int i = 1; i <= numDigits; i++) {
@@ -51,7 +51,7 @@ public class ChainPermutationGenerator extends PermutationGenerator {
         next(0);
     }
 
-    public int next(int digit) {
+    public int next(int digit) throws InterruptedException {
         int curIndex = 1;
 
         // swapHistory[1] == 0 means the generator has just reset, and we don't need to
@@ -108,6 +108,8 @@ public class ChainPermutationGenerator extends PermutationGenerator {
             pairGuide.confirm(curDigit);
 
             curIndex++;
+
+            if (Thread.interrupted()) throw new InterruptedException();
         }
 
         // Fill the last element into the map. There's no need to confirm the last
@@ -128,7 +130,7 @@ public class ChainPermutationGenerator extends PermutationGenerator {
         pairGuide.add(upperFaceIndex, faceIndex);
     }
 
-    public void initialize() {
+    public void initialize() throws InterruptedException {
         // Determine locked elements.
         int[] lock = pairGuide.lock();
         if (lock != null) {

--- a/src/main/java/origami/folding/permutation/PermutationGenerator.java
+++ b/src/main/java/origami/folding/permutation/PermutationGenerator.java
@@ -38,16 +38,16 @@ public abstract class PermutationGenerator {
     }
 
     /** Remember to reset at the end of initialization. */
-    public abstract void initialize();
+    public abstract void initialize() throws InterruptedException;
 
     /** Reset to the first valid permutation. */
-    public abstract void reset();
+    public abstract void reset() throws InterruptedException;
 
     /** Clear all temporary guides. */
     public abstract void clearTempGuide();
 
     /** Returns the lowest digit that was changed in the process. */
-    public abstract int next(int digit);
+    public abstract int next(int digit) throws InterruptedException;
 
     /** Add a constraint saying that "from" must appear before "to". */
     public abstract void addGuide(int from, int to);


### PR DESCRIPTION
This PR contains two things:
1. Improve the algorithm of findLineInFaceBorder (previously another runtime bottleneck). Ryujin now runs in 14 minutes.
2. Add InterruptedException in several timely loops, as requested.