### PR TITLE
Fix precision errors in detailed crease patterns

### DIFF
--- a/src/main/java/origami/Epsilon.java
+++ b/src/main/java/origami/Epsilon.java
@@ -1,0 +1,70 @@
+package origami;
+
+/**
+ * Author: Mu-Tsun Tsai
+ * 
+ * This class organizes all epsilon constants used throughout the source code.
+ * Hopefully it will eventually replace all related comparisons.
+ */
+public class Epsilon {
+
+    /**
+     * In the following, all constants after "factor" are the original epsilon
+     * constants used by Orihime. Those epsilons are, however, too big for
+     * super-complex models such as full Ryujin with shaped scales. Before we have a
+     * better understanding of the purpose of these different epsilons, let's just
+     * multiply all of them by a factor to fix this problem. By using a factor of
+     * 0.1, that essentially means all CPs are now 10x larger than the origin.
+     */
+    private static final double factor = 0.1;
+
+    // These are the constants of which purpose is uncertain.
+ 
+    public static final double UNKNOWN_01 = factor * 0.1;
+    public static final double UNKNOWN_05 = factor * 0.5;
+    public static final double UNKNOWN_001 = factor * 1E-2;
+    public static final double UNKNOWN_0001 = factor * 1E-3;
+    public static final double UNKNOWN_1EN4 = factor * 1E-4;
+    public static final double UNKNOWN_1EN5 = factor * 1E-5;
+    public static final double UNKNOWN_1EN6 = factor * 1E-6;
+    public static final double UNKNOWN_1EN7 = factor * 1E-7;
+
+    // These are the constants with a known purpose.
+
+    public static final double PARALLEL = factor * 0.5;
+    public static final double QUAD_TREE_ITEM = factor * 0.5;
+
+    /**
+     * This is the smallest epsilon used in the code. Any value that is even smaller
+     * is considered zero.
+     */
+    private static final double ZERO_COMPARISON = factor * 1E-8;
+
+    /**
+     * This is the default instance of the Epsilon class. In the future I expect
+     * more instance are created for different purposes.
+     */
+    public static final Epsilon high = new Epsilon(ZERO_COMPARISON);
+
+    ////////////////////////////////////////////////////////////////////////////////////
+    // Instance
+    ////////////////////////////////////////////////////////////////////////////////////
+
+    private final double precision;
+
+    private Epsilon(double precision) {
+        this.precision = precision;
+    }
+
+    public boolean eq0(double value) {
+        return -precision < value && value < precision;
+    }
+
+    public boolean le0(double value) {
+        return value < precision;
+    }
+
+    public boolean gt0(double value) {
+        return value > precision;
+    }
+}

--- a/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -2,6 +2,7 @@ package origami.crease_pattern;
 
 import origami.crease_pattern.element.Point;
 import origami.crease_pattern.element.Polygon;
+import origami.Epsilon;
 import origami.crease_pattern.element.*;
 import origami_editor.editor.Save;
 import origami_editor.sortingbox.SortingBox;
@@ -1056,7 +1057,7 @@ public class FoldLineSet {
 
             //setiactive(j,100)とされた折線は、kousabunkatu(int i1,int i2,int i3,int i4)の操作が戻った後で削除される。
 
-            LineSegment.Intersection i_intersection_decision = OritaCalc.determineLineSegmentIntersection(si, sj, 0.000001, 0.000001);//iは加える方(2)、jは元からある方(1)
+            LineSegment.Intersection i_intersection_decision = OritaCalc.determineLineSegmentIntersection(si, sj, Epsilon.UNKNOWN_1EN6, Epsilon.UNKNOWN_1EN6);//iは加える方(2)、jは元からある方(1)
 
 
             switch (i_intersection_decision) {
@@ -1383,16 +1384,16 @@ public class FoldLineSet {
             jymin = sj.determineBY();
         }
 
-        if (ixmax + 0.5 < jxmin) {
+        if (ixmax + Epsilon.UNKNOWN_05 < jxmin) {
             return false;
         }
-        if (jxmax + 0.5 < ixmin) {
+        if (jxmax + Epsilon.UNKNOWN_05 < ixmin) {
             return false;
         }
-        if (iymax + 0.5 < jymin) {
+        if (iymax + Epsilon.UNKNOWN_05 < jymin) {
             return false;
         }
-        if (jymax + 0.5 < iymin) {
+        if (jymax + Epsilon.UNKNOWN_05 < iymin) {
             return false;
         }
 
@@ -1422,8 +1423,8 @@ public class FoldLineSet {
                 addLine(p2, pk, si.getColor());
                 return true;
             case NO_INTERSECTION_0: //このifないと本来この後で処理されるべき条件がここで処理されてしまうことある
-                if (OritaCalc.determineLineSegmentDistance(si.getA(), sj) < 0.01) {
-                    if (OritaCalc.determineClosestLineSegmentEndpoint(si.getA(), sj, 0.01) == 3) { //20161107 わずかに届かない場合
+                if (OritaCalc.determineLineSegmentDistance(si.getA(), sj) < Epsilon.UNKNOWN_001) {
+                    if (OritaCalc.determineClosestLineSegmentEndpoint(si.getA(), sj, Epsilon.UNKNOWN_001) == 3) { //20161107 わずかに届かない場合
                         pk.set(OritaCalc.findIntersection(si, sj));
                         sj.setA(p3);
                         sj.setB(pk);
@@ -1432,8 +1433,8 @@ public class FoldLineSet {
                     }
                 }
 
-                if (OritaCalc.determineLineSegmentDistance(si.getB(), sj) < 0.01) {
-                    if (OritaCalc.determineClosestLineSegmentEndpoint(si.getB(), sj, 0.01) == 3) { //20161107 わずかに届かない場合
+                if (OritaCalc.determineLineSegmentDistance(si.getB(), sj) < Epsilon.UNKNOWN_001) {
+                    if (OritaCalc.determineClosestLineSegmentEndpoint(si.getB(), sj, Epsilon.UNKNOWN_001) == 3) { //20161107 わずかに届かない場合
                         pk.set(OritaCalc.findIntersection(si, sj));
                         sj.setA(p3);
                         sj.setB(pk);
@@ -1442,8 +1443,8 @@ public class FoldLineSet {
                     }
                 }
 
-                if (OritaCalc.determineLineSegmentDistance(sj.getA(), si) < 0.01) {
-                    if (OritaCalc.determineClosestLineSegmentEndpoint(sj.getA(), si, 0.01) == 3) { //20161107 わずかに届かない場合
+                if (OritaCalc.determineLineSegmentDistance(sj.getA(), si) < Epsilon.UNKNOWN_001) {
+                    if (OritaCalc.determineClosestLineSegmentEndpoint(sj.getA(), si, Epsilon.UNKNOWN_001) == 3) { //20161107 わずかに届かない場合
                         pk.set(OritaCalc.findIntersection(si, sj));
                         si.setA(p1);
                         si.setB(pk);
@@ -1452,8 +1453,8 @@ public class FoldLineSet {
                     }
                 }
 
-                if (OritaCalc.determineLineSegmentDistance(sj.getB(), si) < 0.01) {
-                    if (OritaCalc.determineClosestLineSegmentEndpoint(sj.getB(), si, 0.01) == 3) { //20161107 わずかに届かない場合
+                if (OritaCalc.determineLineSegmentDistance(sj.getB(), si) < Epsilon.UNKNOWN_001) {
+                    if (OritaCalc.determineClosestLineSegmentEndpoint(sj.getB(), si, Epsilon.UNKNOWN_001) == 3) { //20161107 わずかに届かない場合
                         pk.set(OritaCalc.findIntersection(si, sj));    //<<<<<<<<<<<<<<<<<<<<<<<
                         si.setA(p1);
                         si.setB(pk);
@@ -1682,20 +1683,20 @@ public class FoldLineSet {
         for (int i = imin; i <= imax; i++) {
             Circle ei = new Circle();
             ei.set(circles.get(i));
-            if (ei.getRadius() > 0.0000001) {//Circles with a radius of 0 are not applicable
+            if (ei.getRadius() > Epsilon.UNKNOWN_1EN7) {//Circles with a radius of 0 are not applicable
                 for (int j = jmin; j <= jmax; j++) {
 
                     Circle ej = new Circle();
                     ej.set(circles.get(j));
-                    if (ej.getRadius() > 0.0000001) {//Circles with a radius of 0 are not applicable
-                        if (OritaCalc.distance(ei.determineCenter(), ej.determineCenter()) < 0.000001) {
+                    if (ej.getRadius() > Epsilon.UNKNOWN_1EN7) {//Circles with a radius of 0 are not applicable
+                        if (OritaCalc.distance(ei.determineCenter(), ej.determineCenter()) < Epsilon.UNKNOWN_1EN6) {
                             //Two circles are concentric and do not intersect
-                        } else if (Math.abs(OritaCalc.distance(ei.determineCenter(), ej.determineCenter()) - ei.getRadius() - ej.getRadius()) < 0.0001) {
+                        } else if (Math.abs(OritaCalc.distance(ei.determineCenter(), ej.determineCenter()) - ei.getRadius() - ej.getRadius()) < Epsilon.UNKNOWN_1EN4) {
                             //Two circles intersect at one point
                             addCircle(OritaCalc.internalDivisionRatio(ei.determineCenter(), ej.determineCenter(), ei.getRadius(), ej.getRadius()), 0.0);
                         } else if (OritaCalc.distance(ei.determineCenter(), ej.determineCenter()) > ei.getRadius() + ej.getRadius()) {
                             //Two circles do not intersect
-                        } else if (Math.abs(OritaCalc.distance(ei.determineCenter(), ej.determineCenter()) - Math.abs(ei.getRadius() - ej.getRadius())) < 0.0001) {
+                        } else if (Math.abs(OritaCalc.distance(ei.determineCenter(), ej.determineCenter()) - Math.abs(ei.getRadius() - ej.getRadius())) < Epsilon.UNKNOWN_1EN4) {
                             //Two circles intersect at one point
                             addCircle(OritaCalc.internalDivisionRatio(ei.determineCenter(), ej.determineCenter(), -ei.getRadius(), ej.getRadius()), 0.0);
                         } else if (OritaCalc.distance(ei.determineCenter(), ej.determineCenter()) < Math.abs(ei.getRadius() - ej.getRadius())) {
@@ -1724,11 +1725,11 @@ public class FoldLineSet {
 
                 Circle ej = new Circle();
                 ej.set(circles.get(j));
-                if (ej.getRadius() > 0.0000001) {//Circles with a radius of 0 are not applicable
+                if (ej.getRadius() > Epsilon.UNKNOWN_1EN7) {//Circles with a radius of 0 are not applicable
                     double tc_kyori = ti.calculateDistance(ej.determineCenter()); //Distance between the center of a straight line and a circle
 
-                    if (Math.abs(tc_kyori - ej.getRadius()) < 0.000001) {//Circle and straight line intersect at one point
-                        if (Math.abs(OritaCalc.determineLineSegmentDistance(ej.determineCenter(), si) - ej.getRadius()) < 0.000001) {
+                    if (Math.abs(tc_kyori - ej.getRadius()) < Epsilon.UNKNOWN_1EN6) {//Circle and straight line intersect at one point
+                        if (Math.abs(OritaCalc.determineLineSegmentDistance(ej.determineCenter(), si) - ej.getRadius()) < Epsilon.UNKNOWN_1EN6) {
                             addCircle(OritaCalc.findProjection(ti, ej.determineCenter()), 0.0);
                         }
                     } else if (tc_kyori > ej.getRadius()) {
@@ -1737,10 +1738,10 @@ public class FoldLineSet {
                         LineSegment k_senb = new LineSegment();
                         k_senb.set(OritaCalc.circle_to_straightLine_no_intersect_wo_connect_LineSegment(ej, ti));
 
-                        if (OritaCalc.determineLineSegmentDistance(k_senb.getA(), si) < 0.00001) {
+                        if (OritaCalc.determineLineSegmentDistance(k_senb.getA(), si) < Epsilon.UNKNOWN_1EN5) {
                             addCircle(k_senb.getA(), 0.0);
                         }
-                        if (OritaCalc.determineLineSegmentDistance(k_senb.getB(), si) < 0.00001) {
+                        if (OritaCalc.determineLineSegmentDistance(k_senb.getB(), si) < Epsilon.UNKNOWN_1EN5) {
                             addCircle(k_senb.getB(), 0.0);
                         }
                     }
@@ -1808,20 +1809,20 @@ public class FoldLineSet {
         int ir4 = 0;
         int ir5 = 0;
 
-        if (er_0 < 0.0000001) {
+        if (er_0 < Epsilon.UNKNOWN_1EN7) {
             for (int i = 0; i < circles.size(); i++) {
                 if (i != i0) {
                     e_temp.set(circles.get(i));
                     er_1 = e_temp.getRadius();
                     ec_1.set(e_temp.determineCenter());
-                    if (er_1 < 0.0000001) {//The radius of the other circle is 0
-                        if (ec_0.distance(ec_1) < 0.0000001) {
+                    if (er_1 < Epsilon.UNKNOWN_1EN7) {//The radius of the other circle is 0
+                        if (ec_0.distance(ec_1) < Epsilon.UNKNOWN_1EN7) {
                             ir1 = ir1 + 1;
                         }
                     } else {//The radius of the other circle is not 0
-                        if (ec_0.distance(ec_1) < 0.0000001) {
+                        if (ec_0.distance(ec_1) < Epsilon.UNKNOWN_1EN7) {
                             ir2 = ir2 + 1;
-                        } else if (Math.abs(ec_0.distance(ec_1) - er_1) < 0.0000001) {
+                        } else if (Math.abs(ec_0.distance(ec_1) - er_1) < Epsilon.UNKNOWN_1EN7) {
                             ir3 = ir3 + 1;
                         }
                     }
@@ -1831,7 +1832,7 @@ public class FoldLineSet {
             for (int i = 1; i <= total; i++) {
                 LineSegment si;
                 si = lineSegments.get(i);
-                if (OritaCalc.determineLineSegmentDistance(ec_0, si) < 0.000001) {
+                if (OritaCalc.determineLineSegmentDistance(ec_0, si) < Epsilon.UNKNOWN_1EN6) {
 
                     if (si.getColor().getNumber() <= 2) {
                         ir4 = ir4 + 1;
@@ -1964,7 +1965,8 @@ public class FoldLineSet {
     }
 
     //Remove the branching line segments without forming a closed polygon.
-    public void applyBranchTrim(double r) {
+    public void applyBranchTrim() {
+        double r = Epsilon.UNKNOWN_1EN6;
         boolean iflga;
         boolean iflgb;
         for (int i = 1; i <= total; i++) {
@@ -2007,8 +2009,8 @@ public class FoldLineSet {
         pb.set(s.getB());
         deleteLine(i);
 
-        del_V(pa, 0.000001, 0.000001);
-        del_V(pb, 0.000001, 0.000001);
+        del_V(pa, Epsilon.UNKNOWN_1EN6, Epsilon.UNKNOWN_1EN6);
+        del_V(pb, Epsilon.UNKNOWN_1EN6, Epsilon.UNKNOWN_1EN6);
     }
 
     public void deleteLineSegment_vertex(LineSegment s) {//When erasing the i-th fold line, if the end point of the fold line can also be erased, erase it.
@@ -2018,8 +2020,8 @@ public class FoldLineSet {
         pb.set(s.getB());
         deleteLine(s);
 
-        del_V(pa, 0.000001, 0.000001);
-        del_V(pb, 0.000001, 0.000001);
+        del_V(pa, Epsilon.UNKNOWN_1EN6, Epsilon.UNKNOWN_1EN6);
+        del_V(pb, Epsilon.UNKNOWN_1EN6, Epsilon.UNKNOWN_1EN6);
     }
 
     //Find and return the number of the circle closest to the point p in reverse order (the higher the number means priority)
@@ -2119,7 +2121,7 @@ public class FoldLineSet {
     public double closestLineSegmentDistanceExcludingParallel(Point p, LineSegment s0) {
         double minr = 100000.0;
         for (int i = 1; i <= total; i++) {
-            if (OritaCalc.isLineSegmentParallel(get(i), s0, 0.0001) == OritaCalc.ParallelJudgement.NOT_PARALLEL) {
+            if (OritaCalc.isLineSegmentParallel(get(i), s0, Epsilon.UNKNOWN_1EN4) == OritaCalc.ParallelJudgement.NOT_PARALLEL) {
 
                 double sk = OritaCalc.determineLineSegmentDistance(p, get(i));
                 if (minr > sk) {
@@ -2147,7 +2149,7 @@ public class FoldLineSet {
     public LineSegment getClosestLineSegment(Point p) {
         int minrid = 0;
         double minr = 100000.0;
-        LineSegment s1 = new LineSegment(100000.0, 100000.0, 100000.0, 100000.1);
+        LineSegment s1 = new LineSegment(100000.0, 100000.0, 100000.0, 100000.0 + Epsilon.UNKNOWN_01);
         for (int i = 1; i <= total; i++) {
             double sk = OritaCalc.determineLineSegmentDistance(p, get(i));
             if (minr > sk) {
@@ -2222,7 +2224,7 @@ public class FoldLineSet {
     }
 
     public void del_V(int i, int j) {//Erasing when two fold lines are the same color and there are no end points for other fold lines
-        LineSegment.Intersection i_lineSegment_intersection_decision = OritaCalc.determineLineSegmentIntersection(get(i), get(j), 0.00001, 0.00001);
+        LineSegment.Intersection i_lineSegment_intersection_decision = OritaCalc.determineLineSegmentIntersection(get(i), get(j), Epsilon.UNKNOWN_1EN5, Epsilon.UNKNOWN_1EN5);
 
         LineSegment si = lineSegments.get(i);
         LineSegment sj = lineSegments.get(j);
@@ -2231,19 +2233,19 @@ public class FoldLineSet {
         int i_ten = 0;
         if (i_lineSegment_intersection_decision == LineSegment.Intersection.PARALLEL_START_OF_S1_INTERSECTS_START_OF_S2_323) {
             addLine.set(si.getB(), sj.getB());
-            i_ten = vertex_surrounding_lineCount(si.getA(), 0.00001);
+            i_ten = vertex_surrounding_lineCount(si.getA(), Epsilon.UNKNOWN_1EN5);
         }
         if (i_lineSegment_intersection_decision == LineSegment.Intersection.PARALLEL_START_OF_S1_INTERSECTS_END_OF_S2_333) {
             addLine.set(si.getB(), sj.getA());
-            i_ten = vertex_surrounding_lineCount(si.getA(), 0.00001);
+            i_ten = vertex_surrounding_lineCount(si.getA(), Epsilon.UNKNOWN_1EN5);
         }
         if (i_lineSegment_intersection_decision == LineSegment.Intersection.PARALLEL_END_OF_S1_INTERSECTS_START_OF_S2_343) {
             addLine.set(si.getA(), sj.getB());
-            i_ten = vertex_surrounding_lineCount(si.getB(), 0.00001);
+            i_ten = vertex_surrounding_lineCount(si.getB(), Epsilon.UNKNOWN_1EN5);
         }
         if (i_lineSegment_intersection_decision == LineSegment.Intersection.PARALLEL_END_OF_S1_INTERSECTS_END_OF_S2_353) {
             addLine.set(si.getA(), sj.getA());
-            i_ten = vertex_surrounding_lineCount(si.getB(), 0.00001);
+            i_ten = vertex_surrounding_lineCount(si.getB(), Epsilon.UNKNOWN_1EN5);
         }
 
         if (i_ten == 2) {
@@ -2363,7 +2365,7 @@ public class FoldLineSet {
             boolean i_decision;
             i_decision = false;//If i_hantei is 1, the two line segments do not overlap and are connected in a straight line.
             LineSegment.Intersection i_lineSegment_intersection_decision;
-            i_lineSegment_intersection_decision = OritaCalc.determineLineSegmentIntersection(lix, liy, 0.000001, 0.000001);
+            i_lineSegment_intersection_decision = OritaCalc.determineLineSegmentIntersection(lix, liy, Epsilon.UNKNOWN_1EN6, Epsilon.UNKNOWN_1EN6);
 
             if (i_lineSegment_intersection_decision == LineSegment.Intersection.PARALLEL_START_OF_S1_INTERSECTS_START_OF_S2_323) {
                 i_decision = true;
@@ -2437,7 +2439,7 @@ public class FoldLineSet {
             LineSegment liy = lineSegments.get(iy);
             boolean i_decision = false;//i_hanteiは１なら2線分は重ならず、直線状に繋がっている
             LineSegment.Intersection lineSegment_intersection_decision;
-            lineSegment_intersection_decision = OritaCalc.determineLineSegmentIntersection(lix, liy, 0.000001, 0.000001);
+            lineSegment_intersection_decision = OritaCalc.determineLineSegmentIntersection(lix, liy, Epsilon.UNKNOWN_1EN6, Epsilon.UNKNOWN_1EN6);
 
             if (lineSegment_intersection_decision == LineSegment.Intersection.PARALLEL_START_OF_S1_INTERSECTS_START_OF_S2_323) {
                 i_decision = true;
@@ -2768,7 +2770,7 @@ public class FoldLineSet {
         }
     }
 
-    public void check1(double r_hitosii, double parallel_decision) {
+    public void check1() {
         Check1LineSegment.clear();
         unselect_all();
         for (int i = 1; i <= total - 1; i++) {
@@ -2785,7 +2787,7 @@ public class FoldLineSet {
                         LineSegment sj1 = new LineSegment();
                         sj1.set(sj);
 
-                        LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersection(si, sj, r_hitosii, parallel_decision);
+                        LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersection(si, sj, Epsilon.UNKNOWN_0001, Epsilon.PARALLEL);
                         switch (intersection) {
                             case PARALLEL_EQUAL_31:
                             case PARALLEL_START_OF_S1_CONTAINS_START_OF_S2_321:
@@ -2811,7 +2813,7 @@ public class FoldLineSet {
         }
     }
 
-    public boolean fix1(double r_hitosii, double parallel_decision) {//Returns 0 if nothing is done, 1 if something is modified.
+    public boolean fix1() {//Returns 0 if nothing is done, 1 if something is modified.
         unselect_all();
         for (int i = 1; i <= total - 1; i++) {
             LineSegment si = lineSegments.get(i);
@@ -2820,7 +2822,7 @@ public class FoldLineSet {
                     LineSegment sj = lineSegments.get(j);//r_hitosiiとr_heikouhanteiは、hitosiiとheikou_hanteiのずれの許容程度
                     if (sj.getColor() != LineColor.CYAN_3) {
                         //T字型交差
-                        LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersection(si, sj, r_hitosii, parallel_decision);
+                        LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersection(si, sj, Epsilon.UNKNOWN_0001, Epsilon.PARALLEL);
                         switch (intersection) {
                             case PARALLEL_EQUAL_31:
                                 si.setColor(sj.getColor());
@@ -2849,7 +2851,7 @@ public class FoldLineSet {
         return false;
     }
 
-    public void check2(double r_hitosii, double parallel_decision) {
+    public void check2() {
         Check2LineSegment.clear();
 
         unselect_all();
@@ -2867,7 +2869,7 @@ public class FoldLineSet {
                         sj1.set(sj);
 
                         //T-shaped intersection
-                        LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersectionSweet(si, sj, r_hitosii, parallel_decision);
+                        LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersectionSweet(si, sj, Epsilon.UNKNOWN_0001, Epsilon.PARALLEL);
                         switch (intersection) {
                             case INTERSECTS_TSHAPE_S1_VERTICAL_BAR_25:
                             case INTERSECTS_TSHAPE_S1_VERTICAL_BAR_26:
@@ -2883,7 +2885,7 @@ public class FoldLineSet {
         }
     }
 
-    public boolean fix2(double r_hitosii, double heikou_hantei) {//何もしなかったら0、何か修正したら1を返す。
+    public boolean fix2() {//何もしなかったら0、何か修正したら1を返す。
         unselect_all();
         for (int i = 1; i <= total - 1; i++) {
             LineSegment si = lineSegments.get(i);
@@ -2895,7 +2897,7 @@ public class FoldLineSet {
                         //T字型交差
                         //折線iをその点pの影で分割する。ただし、点pの影がどれか折線の端点と同じとみなされる場合は何もしない。
                         //	public void senbun_bunkatu(Ten p,int i){
-                        LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersectionSweet(si, sj, r_hitosii, heikou_hantei);
+                        LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersectionSweet(si, sj, Epsilon.UNKNOWN_0001, Epsilon.PARALLEL);
                         switch (intersection) {
                             case INTERSECTS_TSHAPE_S1_VERTICAL_BAR_25:
                                 if (applyLineSegmentDivide(si.getA(), j)) {
@@ -2952,7 +2954,8 @@ public class FoldLineSet {
         return Check4LineSegment;
     }
 
-    public void check3(double r) {//Check the number of lines around the vertex
+    public void check3() {//Check the number of lines around the vertex
+        double r = Epsilon.UNKNOWN_1EN4;
         Check3LineSegment.clear();
         unselect_all();
         for (int i = 1; i <= total; i++) {
@@ -3030,16 +3033,14 @@ public class FoldLineSet {
 
     public int Check4Point_overlapping_check(Point p0) {
         for (Point p : check4Point) {
-            if ((-0.00000001 < p0.getX() - p.getX()) && (p0.getX() - p.getX() < 0.00000001)) {
-                if ((-0.00000001 < p0.getY() - p.getY()) && (p0.getY() - p.getY() < 0.00000001)) {
-                    return 1;
-                }
+            if (Epsilon.high.eq0(p0.getX() - p.getX()) && Epsilon.high.eq0(p0.getY() - p.getY())) {
+                return 1;
             }
         }
         return 0;
     }
 
-    public void check4(double r) throws InterruptedException {//Check the number of lines around the apex
+    public void check4() throws InterruptedException {//Check the number of lines around the apex
         Check4LineSegment.clear();
         check4Point.clear();
 
@@ -3075,7 +3076,7 @@ public class FoldLineSet {
                 Point p = new Point(point);
 
                 try {
-                    if (!i_flat_ok(p, r)) {
+                    if (!i_flat_ok(p, Epsilon.UNKNOWN_1EN4)) {
                         Check4LineSegment.add(new LineSegment(p, p));
                     }
                 } catch (InterruptedException e) {
@@ -3099,7 +3100,7 @@ public class FoldLineSet {
     }
 
     public boolean i_flat_ok(Point p, double r) throws InterruptedException {//Foldable flat = 1
-        double hantei_kyori = 0.00001;
+        double hantei_kyori = Epsilon.UNKNOWN_1EN5;
         //If the end point of the line segment closest to the point p and the end point closer to the point p is the apex, how many line segments are present (the number of line segments having an end point within the apex and r).
         int i_customized = 0;    //i_customized% 2 == 0 even, == 1 odd
         int i_tss_red = 0;
@@ -3155,7 +3156,7 @@ public class FoldLineSet {
 
     //Point p に最も近い用紙辺部の端点が拡張伏見定理を満たすか判定
     public boolean extended_fushimi_decide_sides(Point p) {//return　0=満たさない、　1=満たす。　
-        double hantei_kyori = 0.00001;
+        double hantei_kyori = Epsilon.UNKNOWN_1EN5;
 
         Point t1 = new Point();
         t1.set(closestPointOfFoldLine(p));//点pに最も近い、「線分の端点」を返すori_s.closestPointは近い点がないと p_return.set(100000.0,100000.0)と返してくる
@@ -3246,7 +3247,7 @@ public class FoldLineSet {
     //Obtain SortingBox<Integer> with a polygonal line starting at b. They are arranged in ascending order of angle with the line segment ba.
     public SortingBox<LineSegment> get_SortingBox_of_vertex_b_surrounding_foldLine(Point a, Point b) {
         SortingBox<LineSegment> r_nbox = new SortingBox<>();
-        double hantei_kyori = 0.00001;
+        double hantei_kyori = Epsilon.UNKNOWN_1EN5;
 
         //Put a polygonal line with b as the end point in Narabebako
 
@@ -3280,7 +3281,7 @@ public class FoldLineSet {
         }
 
         temp_angle = nbox0.getWeight(2) - nbox0.getWeight(1);
-        if (Math.abs(temp_angle - angle_min) < 0.00001) {// 折線を1つ減らせる条件に適合したので、新たにnbox1を作ってリターンする。
+        if (Math.abs(temp_angle - angle_min) < Epsilon.UNKNOWN_1EN5) {// 折線を1つ減らせる条件に適合したので、新たにnbox1を作ってリターンする。
             for (int i = 2; i <= nbox0.getTotal(); i++) {
                 WeightedValue<LineSegment> i_d_0 = new WeightedValue<>();
                 i_d_0.set(nbox0.getWeightedValue(i));
@@ -3290,7 +3291,7 @@ public class FoldLineSet {
         }
 
         temp_angle = nbox0.getWeight(nbox0.getTotal()) - nbox0.getWeight(nbox0.getTotal() - 1);
-        if (Math.abs(temp_angle - angle_min) < 0.00001) {// 折線を1つ減らせる条件に適合したので、新たにnbox1を作ってリターンする。
+        if (Math.abs(temp_angle - angle_min) < Epsilon.UNKNOWN_1EN5) {// 折線を1つ減らせる条件に適合したので、新たにnbox1を作ってリターンする。
             for (int i = 1; i <= nbox0.getTotal() - 1; i++) {
                 WeightedValue<LineSegment> i_d_0 = new WeightedValue<>();
                 i_d_0.set(nbox0.getWeightedValue(i));
@@ -3301,7 +3302,7 @@ public class FoldLineSet {
 
         for (int k = 2; k <= nbox0.getTotal() - 2; k++) {//kは角度の順番
             temp_angle = nbox0.getWeight(k + 1) - nbox0.getWeight(k);
-            if (Math.abs(temp_angle - angle_min) < 0.00001) {
+            if (Math.abs(temp_angle - angle_min) < Epsilon.UNKNOWN_1EN5) {
                 if (nbox0.getValue(k).getColor() != nbox0.getValue(k + 1).getColor()) {//この場合に隣接する３角度を1つの角度にする
                     // 折線を2つ減らせる条件に適合したので、新たにnbox1を作ってリターンする。
 
@@ -3334,7 +3335,7 @@ public class FoldLineSet {
 
     //Determine if the endpoint inside the paper closest to Point p satisfies the extended Fushimi theorem
     public boolean extended_fushimi_decide_inside(Point p) {//return　0=満たさない、　1=満たす。　
-        double hantei_kyori = 0.00001;
+        double hantei_kyori = Epsilon.UNKNOWN_1EN5;
 
         Point t1 = new Point();
         t1.set(closestPointOfFoldLine(p));//点pに最も近い、「線分の端点」を返すori_s.mottomo_tikai_Tenは近い点がないと p_return.set(100000.0,100000.0)と返してくる
@@ -3356,7 +3357,7 @@ public class FoldLineSet {
     }
 
     public boolean extended_fushimi_decide_inside(Point p, SortingBox<LineSegment> nbox) {//return　0=満たさない、　1=満たす。　
-        double hantei_kyori = 0.00001;
+        double hantei_kyori = Epsilon.UNKNOWN_1EN5;
 
         if (nbox.getTotal() % 2 == 1) {//t1を端点とする折線の数が奇数のとき
             return false;
@@ -3368,7 +3369,7 @@ public class FoldLineSet {
             }
 
             //The following is when the two line types are blue-blue or red-red
-            LineSegment.Intersection i_senbun_kousa_hantei = OritaCalc.determineLineSegmentIntersection(nbox.getValue(1), nbox.getValue(2), 0.00001, 0.00001);
+            LineSegment.Intersection i_senbun_kousa_hantei = OritaCalc.determineLineSegmentIntersection(nbox.getValue(1), nbox.getValue(2), Epsilon.UNKNOWN_1EN5, Epsilon.UNKNOWN_1EN5);
 
             switch (i_senbun_kousa_hantei) {
                 case PARALLEL_START_OF_S1_INTERSECTS_START_OF_S2_323:
@@ -3422,7 +3423,7 @@ public class FoldLineSet {
             for (int k = 1; k <= nbox.getTotal(); k++) {//kは角度の順番
                 double temp_kakudo = OritaCalc.angle_between_0_kmax(nbox.getWeight(2) - nbox.getWeight(1), fushimi_decision_angle_goukei);
 
-                if (Math.abs(temp_kakudo - kakudo_min) < 0.00001) {
+                if (Math.abs(temp_kakudo - kakudo_min) < Epsilon.UNKNOWN_1EN5) {
                     if (nbox.getValue(1).getColor() != nbox.getValue(2).getColor()) {//この場合に隣接する３角度を1つの角度にする
                         // 折線を2つ減らせる条件に適合したので、新たにnbox1を作ってリターンする。
 

--- a/src/main/java/origami/crease_pattern/LineSegmentSet.java
+++ b/src/main/java/origami/crease_pattern/LineSegmentSet.java
@@ -1,5 +1,6 @@
 package origami.crease_pattern;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
@@ -133,7 +134,7 @@ public class LineSegmentSet {
 
     public void overlapping_line_removal() {
         // The same epsilon value as in OritaCalc.determineLineSegmentIntersection
-        overlapping_line_removal(0.01);
+        overlapping_line_removal(Epsilon.UNKNOWN_001);
     }
 
     /**

--- a/src/main/java/origami/crease_pattern/OritaCalc.java
+++ b/src/main/java/origami/crease_pattern/OritaCalc.java
@@ -2,6 +2,7 @@ package origami.crease_pattern;
 
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
+import origami.Epsilon;
 import origami.crease_pattern.element.Circle;
 import origami.crease_pattern.element.StraightLine;
 
@@ -34,7 +35,7 @@ public class OritaCalc {
 
     //A function that determines whether two points are in the same position (true) or different (false) -------------------------------- -
     public static boolean equal(Point p1, Point p2) {
-        return equal(p1, p2, 0.1);//The error is defined here.
+        return equal(p1, p2, Epsilon.UNKNOWN_01);//The error is defined here.
     }
 
     public static boolean equal(Point p1, Point p2, double r) {//r is the error tolerance. Strict judgment if r is negative.
@@ -127,10 +128,10 @@ public class OritaCalc {
         StraightLine u2 = new StraightLine(p1, p2);
         u2.orthogonalize(p2);//Find the straight line u2 that passes through the point p2 and is orthogonal to t.
 
-        if (u1.calculateDistance(pa) < 0.00001) {
+        if (u1.calculateDistance(pa) < Epsilon.UNKNOWN_1EN5) {
             return 1;
         }
-        if (u2.calculateDistance(pa) < 0.00001) {
+        if (u2.calculateDistance(pa) < Epsilon.UNKNOWN_1EN5) {
             return 1;
         }
 
@@ -197,11 +198,11 @@ public class OritaCalc {
     // Note! If p1 and p2 are the same, or p3 and p4 are the same, the result will be strange,
     // This function itself does not have a check mechanism, so it may be difficult to notice.
     public static LineSegment.Intersection determineLineSegmentIntersection(LineSegment s1, LineSegment s2) {
-        return determineLineSegmentIntersection(s1, s2, 0.01, 0.01);
+        return determineLineSegmentIntersection(s1, s2, Epsilon.UNKNOWN_001, Epsilon.UNKNOWN_001);
     }
 
     public static LineSegment.Intersection determineLineSegmentIntersectionSweet(LineSegment s1, LineSegment s2) {
-        return determineLineSegmentIntersectionSweet(s1, s2, 0.01, 0.01);
+        return determineLineSegmentIntersectionSweet(s1, s2, Epsilon.UNKNOWN_001, Epsilon.UNKNOWN_001);
     }
 
     public static LineSegment.Intersection determineLineSegmentIntersection(LineSegment s1, LineSegment s2, double rhit, double rhei) {    //r_hitosii and r_heikouhantei are the allowable degree of deviation between hitosii and heikou_hantei
@@ -238,16 +239,16 @@ public class OritaCalc {
             y2min = s2.determineBY();
         }
 
-        if (x1max + rhit + 0.1 < x2min) {
+        if (x1max + rhit + Epsilon.UNKNOWN_01 < x2min) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
-        if (x1min - rhit - 0.1 > x2max) {
+        if (x1min - rhit - Epsilon.UNKNOWN_01 > x2max) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
-        if (y1max + rhit + 0.1 < y2min) {
+        if (y1max + rhit + Epsilon.UNKNOWN_01 < y2min) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
-        if (y1min - rhit - 0.1 > y2max) {
+        if (y1min - rhit - Epsilon.UNKNOWN_01 > y2max) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
 
@@ -461,16 +462,16 @@ public class OritaCalc {
             y2min = s2.determineBY();
         }
 
-        if (x1max + rhit + 0.1 < x2min) {
+        if (x1max + rhit + Epsilon.UNKNOWN_01 < x2min) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
-        if (x1min - rhit - 0.1 > x2max) {
+        if (x1min - rhit - Epsilon.UNKNOWN_01 > x2max) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
-        if (y1max + rhit + 0.1 < y2min) {
+        if (y1max + rhit + Epsilon.UNKNOWN_01 < y2min) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
-        if (y1min - rhit - 0.1 > y2max) {
+        if (y1min - rhit - Epsilon.UNKNOWN_01 > y2max) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
 
@@ -645,7 +646,7 @@ public class OritaCalc {
 
     //A function that determines whether two straight lines are parallel.
     public static ParallelJudgement isLineSegmentParallel(StraightLine t1, StraightLine t2) {
-        return isLineSegmentParallel(t1, t2, 0.1);
+        return isLineSegmentParallel(t1, t2, Epsilon.UNKNOWN_01);
     }
 
     //A function that determines whether two line segments are parallel.
@@ -941,7 +942,7 @@ public class OritaCalc {
     //Find the internal division point.
     public static Point internalDivisionRatio(Point a, Point b, double d_internalDivisionRatio_s, double d_internalDivisionRatio_t) {
         Point r_point = new Point(-10000.0, -10000.0);
-        if (distance(a, b) < 0.000001) {
+        if (distance(a, b) < Epsilon.UNKNOWN_1EN6) {
             return r_point;
         }
 
@@ -1065,14 +1066,14 @@ public class OritaCalc {
 
     //--------------------------------------------------------
     public static boolean isLineSegmentOverlapping(LineSegment s1, LineSegment s2) {//false do not overlap. true overlaps. 20201012 added
-        LineSegment.Intersection intersection = determineLineSegmentIntersection(s1, s2, 0.0001, 0.0001);
+        LineSegment.Intersection intersection = determineLineSegmentIntersection(s1, s2, Epsilon.UNKNOWN_1EN4, Epsilon.UNKNOWN_1EN4);
 
         return intersection.isSegmentOverlapping();
     }
 
     //--------------------------------------------------------
     public static boolean lineSegment_X_kousa_decide(LineSegment s1, LineSegment s2) {//0はX交差しない。1は交差する。20201017追加
-        return determineLineSegmentIntersection(s1, s2, 0.0001, 0.0001) == LineSegment.Intersection.INTERSECTS_1;
+        return determineLineSegmentIntersection(s1, s2, Epsilon.UNKNOWN_1EN4, Epsilon.UNKNOWN_1EN4) == LineSegment.Intersection.INTERSECTS_1;
     }
 
     public enum ParallelJudgement {

--- a/src/main/java/origami/crease_pattern/element/Circle.java
+++ b/src/main/java/origami/crease_pattern/element/Circle.java
@@ -3,6 +3,8 @@ package origami.crease_pattern.element;
 import java.awt.Color;
 import java.io.Serializable;
 
+import origami.Epsilon;
+
 public class Circle implements Serializable {//Used to represent point coordinates, direction vectors, etc.
 
     double x, y, r;//Center coordinates and radius
@@ -154,7 +156,7 @@ public class Circle implements Serializable {//Used to represent point coordinat
         double d1 = Math.sqrt(x1 * x1 + y1 * y1);
         double d2, x2, y2, x3, y3;
 
-        if (Math.abs(d1 - r) < 0.0000001) {
+        if (Math.abs(d1 - r) < Epsilon.UNKNOWN_1EN7) {
             return t0;
         }
         d2 = r * r / d1;
@@ -178,7 +180,7 @@ public class Circle implements Serializable {//Used to represent point coordinat
         double xb1, yb1;
         double xb0, yb0;
 
-        if (d1 < 0.000001) {
+        if (d1 < Epsilon.UNKNOWN_1EN6) {
             xa1 = da1;
             ya1 = 0.0;
             xa0 = xa1 + x;

--- a/src/main/java/origami/crease_pattern/element/Point.java
+++ b/src/main/java/origami/crease_pattern/element/Point.java
@@ -29,6 +29,10 @@ public class Point implements Serializable {
         y = j;
     }
 
+    public static Point mid(Point p, Point q) {
+        return new Point((p.x + q.x) / 2, (p.y + q.y) / 2);
+    }
+
     public Point(double a, Point p, double b, Point q) {
         x = a * p.getX() + b * q.getX();
         y = a * p.getY() + b * q.getY();

--- a/src/main/java/origami/crease_pattern/element/Polygon.java
+++ b/src/main/java/origami/crease_pattern/element/Polygon.java
@@ -1,5 +1,6 @@
 package origami.crease_pattern.element;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami_editor.sortingbox.SortingBox;
 import origami_editor.sortingbox.WeightedValue;
@@ -232,15 +233,15 @@ public class Polygon {
         }
 
         if (iflag == 0) {
-            return inside(new Point(0.5, s0.getA(), 0.5, s0.getB())) == Intersection.INSIDE;
+            return inside(Point.mid(s0.getA(), s0.getB())) == Intersection.INSIDE;
         }
 
         if (iflag == 1) {
-            return inside(new Point(0.5, s0.getA(), 0.5, s0.getB())) == Intersection.INSIDE;
+            return inside(Point.mid(s0.getA(), s0.getB())) == Intersection.INSIDE;
         }
 
         if (iflag == 2) {
-            if (inside(new Point(0.5, s0.getA(), 0.5, s0.getB())) == Intersection.INSIDE) {
+            if (inside(Point.mid(s0.getA(), s0.getB())) == Intersection.INSIDE) {
                 return true;
             }
             if (inside(s0.getA()) == Intersection.INSIDE) {
@@ -296,7 +297,7 @@ public class Polygon {
             return true;
         }
 
-        return inside(new Point(0.5, s0.getA(), 0.5, s0.getB())) == Intersection.INSIDE;
+        return inside(Point.mid(s0.getA(), s0.getB())) == Intersection.INSIDE;
     }
 
     //A function that determines if a point is inside this polygon (true) or not (false)----------------------------------
@@ -313,12 +314,12 @@ public class Polygon {
         //First, it is determined whether the point p is on the boundary line of the polygon.
         for (int i = 1; i <= vertexCount - 1; i++) {
             s.set(vertices[i], vertices[i + 1]);
-            if (OritaCalc.determineLineSegmentDistance(p, s) < 0.01) {
+            if (OritaCalc.determineLineSegmentDistance(p, s) < Epsilon.UNKNOWN_001) {
                 return Intersection.BORDER;
             }
         }
         s.set(vertices[vertexCount], vertices[1]);
-        if (OritaCalc.determineLineSegmentDistance(p, s) < 0.01) {
+        if (OritaCalc.determineLineSegmentDistance(p, s) < Epsilon.UNKNOWN_001) {
             return Intersection.OUTSIDE;
         }
 
@@ -373,7 +374,7 @@ public class Polygon {
             area = area + (vertices[i - 1].getX() - vertices[i + 1].getX()) * vertices[i].getY();
         }
         area = area + (vertices[vertexCount - 1].getX() - vertices[1].getX()) * vertices[vertexCount].getY();
-        area = -0.5 * area;
+        area = -area / 2;
 
         return area;
     }

--- a/src/main/java/origami/crease_pattern/element/StraightLine.java
+++ b/src/main/java/origami/crease_pattern/element/StraightLine.java
@@ -1,5 +1,7 @@
 package origami.crease_pattern.element;
 
+import origami.Epsilon;
+
 public class StraightLine {
     //Note! If p1 = p2, the result will be strange, but it may be hard to notice because this function does not have a check mechanism.
     // a is 0 or more. If a = 0, make sure b is greater than or equal to 0. Otherwise, the sign of the distance to the straight line will be incorrect.
@@ -59,7 +61,7 @@ public class StraightLine {
             b = -b;
             c = -c;
         }
-        if ((-0.1 < a) && (a < 0.1)) {
+        if ((-Epsilon.UNKNOWN_01 < a) && (a < Epsilon.UNKNOWN_01)) {
             if (b < 0.0) {
                 a = -a;
                 b = -b;
@@ -146,14 +148,14 @@ public class StraightLine {
         double d_a2 = calculateDistanceSquared(s0.getA());
         double d_b2 = calculateDistanceSquared(s0.getB());
 
-        if (d_a2 < 0.00000001 && d_b2 < 0.00000001) {
+        if (Epsilon.high.le0(d_a2) && Epsilon.high.le0(d_b2)) {
             return Intersection.INCLUDED_3;
         }
 
-        if (d_a2 < 0.00000001 && d_b2 >= 0.00000001) {
+        if (Epsilon.high.le0(d_a2) && Epsilon.high.gt0(d_b2)) {
             return Intersection.INTERSECT_T_A_21;
         }
-        if (d_a2 >= 0.00000001 && d_b2 < 0.00000001) {
+        if (Epsilon.high.gt0(d_a2) && Epsilon.high.le0(d_b2)) {
             return Intersection.INTERSECT_T_B_22;
         }
 

--- a/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
+++ b/src/main/java/origami/crease_pattern/worker/FoldedFigure_Worker.java
@@ -25,6 +25,7 @@ import origami_editor.sortingbox.SortingBox;
 import origami_editor.sortingbox.WeightedValue;
 import origami_editor.editor.component.BulletinBoard;
 import origami_editor.tools.Camera;
+import origami.Epsilon;
 import origami.crease_pattern.PointSet;
 
 import java.awt.*;
@@ -231,8 +232,8 @@ public class FoldedFigure_Worker {
                     if ((im != faceId_min) && (im != faceId_max)) {
                         if (otta_face_figure.convex_inside(ib, im)) {
                             //下の２つのifは暫定的な処理。あとで置き換え予定
-                            if (otta_face_figure.convex_inside(0.5, ib, im)) {
-                                if (otta_face_figure.convex_inside(-0.5, ib, im)) {
+                            if (otta_face_figure.convex_inside(Epsilon.UNKNOWN_05, ib, im)) {
+                                if (otta_face_figure.convex_inside(-Epsilon.UNKNOWN_05, ib, im)) {
                                     hierarchyList.addEquivalenceCondition(im, faceId_min, im, faceId_max);
                                 }
                             }
@@ -781,7 +782,7 @@ public class FoldedFigure_Worker {
                     o_bmtx = o_bmx + o_btx;
                     o_bmty = o_bmy + o_bty;
 
-                    if (subFace_figure.inside(new Point(o_bmx + 0.01 * o_btx, o_bmy + 0.01 * o_bty), im) != Polygon.Intersection.OUTSIDE) {//0=外部、　1=境界、　2=内部
+                    if (subFace_figure.inside(new Point(o_bmx + Epsilon.UNKNOWN_001 * o_btx, o_bmy + Epsilon.UNKNOWN_001 * o_bty), im) != Polygon.Intersection.OUTSIDE) {//0=外部、　1=境界、　2=内部
                         t0.setX(o_bmtx);
                         t0.setY(o_bmty);
                         t1.set(camera.object2TV(t0));
@@ -840,7 +841,7 @@ public class FoldedFigure_Worker {
                     o_bmtx = o_bmx + o_btx;
                     o_bmty = o_bmy + o_bty;
 
-                    if (subFace_figure.inside(new Point(o_bmx + 0.01 * o_btx, o_bmy + 0.01 * o_bty), im) != Polygon.Intersection.OUTSIDE) {//0=外部、　1=境界、　2=内部
+                    if (subFace_figure.inside(new Point(o_bmx + Epsilon.UNKNOWN_001 * o_btx, o_bmy + Epsilon.UNKNOWN_001 * o_bty), im) != Polygon.Intersection.OUTSIDE) {//0=外部、　1=境界、　2=内部
 
                         t0.setX(o_bmtx);
                         t0.setY(o_bmty);

--- a/src/main/java/origami/data/quadTree/QuadTreeItem.java
+++ b/src/main/java/origami/data/quadTree/QuadTreeItem.java
@@ -1,9 +1,10 @@
 package origami.data.quadTree;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.Point;
 
 public class QuadTreeItem {
-    public static final double EPSILON = 0.5;
+    public static final double EPSILON = Epsilon.QUAD_TREE_ITEM;
     public final double l, r, b, t;
 
     public QuadTreeItem(double l, double r, double b, double t) {

--- a/src/main/java/origami/data/quadTree/comparator/QuadTreeComparator.java
+++ b/src/main/java/origami/data/quadTree/comparator/QuadTreeComparator.java
@@ -1,5 +1,6 @@
 package origami.data.quadTree.comparator;
 
+import origami.Epsilon;
 import origami.data.quadTree.QuadTreeItem;
 import origami.data.quadTree.QuadTree.Node;
 
@@ -11,7 +12,7 @@ import origami.data.quadTree.QuadTree.Node;
  */
 public abstract class QuadTreeComparator {
 
-    protected static final double EPSILON = 0.001;
+    protected static final double EPSILON = Epsilon.UNKNOWN_0001;
 
     public abstract boolean contains(Node node, double l, double r, double b, double t);
 

--- a/src/main/java/origami_editor/editor/App.java
+++ b/src/main/java/origami_editor/editor/App.java
@@ -599,7 +599,7 @@ public class App {
                 creasePatternWorker2.setSave_for_reading(mainCreasePatternWorker.foldLineSet.getSaveForSelectFolding());
                 creasePatternWorker2.point_removal();
                 creasePatternWorker2.overlapping_line_removal();
-                creasePatternWorker2.branch_trim(0.000001);
+                creasePatternWorker2.branch_trim();
                 creasePatternWorker2.organizeCircles();
                 lineSegmentsForFolding = creasePatternWorker2.getForFolding();
             } else {

--- a/src/main/java/origami_editor/editor/LeftPanel.java
+++ b/src/main/java/origami_editor/editor/LeftPanel.java
@@ -441,7 +441,7 @@ public class LeftPanel {
         trimBranchesButton.addActionListener(e -> {
             app.mainCreasePatternWorker.point_removal();
             app.mainCreasePatternWorker.overlapping_line_removal();
-            app.mainCreasePatternWorker.branch_trim(0.000001);
+            app.mainCreasePatternWorker.branch_trim();
             app.mainCreasePatternWorker.organizeCircles();
             app.mainCreasePatternWorker.record();
             app.mainCreasePatternWorker.unselect_all();

--- a/src/main/java/origami_editor/editor/RightPanel.java
+++ b/src/main/java/origami_editor/editor/RightPanel.java
@@ -134,7 +134,7 @@ public class RightPanel {
             app.mainCreasePatternWorker.unselect_all();
 
             if (ckOCheckBox.isSelected()) {
-                app.mainCreasePatternWorker.check1(0.001, 0.5);//r_hitosiiとr_heikouhanteiは、hitosiiとheikou_hanteiのずれの許容程度
+                app.mainCreasePatternWorker.check1();//r_hitosiiとr_heikouhanteiは、hitosiiとheikou_hanteiのずれの許容程度
                 app.mainCreasePatternWorker.set_i_check1(true);
             } else {
                 app.mainCreasePatternWorker.set_i_check1(false);
@@ -144,15 +144,15 @@ public class RightPanel {
         fxOButton.addActionListener(e -> {
 
             app.mainCreasePatternWorker.unselect_all();
-            app.mainCreasePatternWorker.fix1(0.001, 0.5);
-            app.mainCreasePatternWorker.check1(0.001, 0.5);
+            app.mainCreasePatternWorker.fix1();
+            app.mainCreasePatternWorker.check1();
             app.repaintCanvas();
         });
         ckTCheckBox.addActionListener(e -> {
             app.mainCreasePatternWorker.unselect_all();
 
             if (ckTCheckBox.isSelected()) {
-                app.mainCreasePatternWorker.check2(0.01, 0.5);//r_hitosiiとr_heikouhanteiは、hitosiiとheikou_hanteiのずれの許容程度
+                app.mainCreasePatternWorker.check2();//r_hitosiiとr_heikouhanteiは、hitosiiとheikou_hanteiのずれの許容程度
                 app.mainCreasePatternWorker.setCheck2(true);
             } else {
                 app.mainCreasePatternWorker.setCheck2(false);
@@ -161,8 +161,8 @@ public class RightPanel {
         });
         fxTButton.addActionListener(e -> {
             app.mainCreasePatternWorker.unselect_all();
-            app.mainCreasePatternWorker.fix2(0.001, 0.5);
-            app.mainCreasePatternWorker.check2(0.001, 0.5);
+            app.mainCreasePatternWorker.fix2();
+            app.mainCreasePatternWorker.check2();
             app.repaintCanvas();
         });
         cAMVCheckBox.addActionListener(e -> {

--- a/src/main/java/origami_editor/editor/canvas/CreasePattern_Worker.java
+++ b/src/main/java/origami_editor/editor/canvas/CreasePattern_Worker.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.FoldLineSet;
 import origami.crease_pattern.LineSegmentSet;
 import origami.crease_pattern.OritaCalc;
@@ -203,8 +204,8 @@ public class CreasePattern_Worker {
         foldLineSet.allMountainValleyChange();
     }
 
-    public void branch_trim(double r) {
-        foldLineSet.applyBranchTrim(r);
+    public void branch_trim() {
+        foldLineSet.applyBranchTrim();
     }
 
     public LineSegmentSet get() {
@@ -294,16 +295,16 @@ public class CreasePattern_Worker {
         s_title = setMemo_for_redo_undo(historyState.undo());
 
         if (check1) {
-            check1(0.001, 0.5);
+            check1();
         }
         if (check2) {
-            check2(0.01, 0.5);
+            check2();
         }
         if (check3) {
-            check3(0.0001);
+            check3();
         }
         if (check4) {
-            check4(0.0001);
+            check4();
         }
 
         return s_title;
@@ -313,16 +314,16 @@ public class CreasePattern_Worker {
         s_title = setMemo_for_redo_undo(historyState.redo());
 
         if (check1) {
-            check1(0.001, 0.5);
+            check1();
         }
         if (check2) {
-            check2(0.01, 0.5);
+            check2();
         }
         if (check3) {
-            check3(0.0001);
+            check3();
         }
         if (check4) {
-            check4(0.0001);
+            check4();
         }
 
         return s_title;
@@ -334,16 +335,16 @@ public class CreasePattern_Worker {
 
     public void record() {
         if (check1) {
-            check1(0.001, 0.5);
+            check1();
         }
         if (check2) {
-            check2(0.01, 0.5);
+            check2();
         }
         if (check3) {
-            check3(0.0001);
+            check3();
         }
         if (check4) {
-            check4(0.0001);
+            check4();
         }
 
         if (!historyState.isEmpty()) {
@@ -606,7 +607,7 @@ public class CreasePattern_Worker {
     //------------------------------------------------------
     public LineSegment get_moyori_step_lineSegment(Point t0, int imin, int imax) {
         int minrid = -100;
-        double minr = 100000;//Senbun s1 =new Senbun(100000.0,100000.0,100000.0,100000.1);
+        double minr = 100000;
         for (int i = imin; i <= imax; i++) {
             double sk = OritaCalc.determineLineSegmentDistance(t0, lineStep.get(i - 1));
             if (minr > sk) {
@@ -714,7 +715,7 @@ public class CreasePattern_Worker {
 
             if (i_kousa_flg.isIntersecting()) {
                 kousa_point.set(OritaCalc.findIntersection(tyoku1, foldLineSet.get(i)));
-                if (kousa_point.distance(add_sen.getA()) > 0.00001) {
+                if (kousa_point.distance(add_sen.getA()) > Epsilon.UNKNOWN_1EN5) {
                     if (kousa_point.distance(add_sen.getA()) < kousa_ten_kyori) {
                         double d_kakudo = OritaCalc.angle(add_sen.getA(), add_sen.getB(), add_sen.getA(), kousa_point);
                         if (d_kakudo < 1.0 || d_kakudo > 359.0) {
@@ -755,7 +756,7 @@ public class CreasePattern_Worker {
 
         LineSegment add_sen = new LineSegment();
         for (LineSegment s : lineStep) {
-            if (s.determineLength() > 0.00000001) {
+            if (Epsilon.high.gt0(s.determineLength())) {
                 add_sen.set(s);
                 add_sen.setColor(lineColor);
                 addLineSegment(add_sen);
@@ -815,26 +816,26 @@ public class CreasePattern_Worker {
         i_foldLine_additional = i;
     }
 
-    public void check1(double r_hitosii, double parallel_decision) {
-        foldLineSet.check1(r_hitosii, parallel_decision);
+    public void check1() {
+        foldLineSet.check1();
     }//In foldLineSet, check and set the funny fold line to the selected state.
 
-    public void fix1(double r_hitosii, double heikou_hantei) {
+    public void fix1() {
         while (true) {
-            if (!foldLineSet.fix1(r_hitosii, heikou_hantei)) break;
+            if (!foldLineSet.fix1()) break;
         }
         //foldLineSet.addsenbun  delsenbunを実施しているところでcheckを実施
         if (check1) {
-            check1(0.001, 0.5);
+            check1();
         }
         if (check2) {
-            check2(0.01, 0.5);
+            check2();
         }
         if (check3) {
-            check3(0.0001);
+            check3();
         }
         if (check4) {
-            check4(0.0001);
+            check4();
         }
 
     }
@@ -843,26 +844,26 @@ public class CreasePattern_Worker {
         check1 = i;
     }
 
-    public void check2(double r_hitosii, double heikou_hantei) {
-        foldLineSet.check2(r_hitosii, heikou_hantei);
+    public void check2() {
+        foldLineSet.check2();
     }
 
-    public void fix2(double r_hitosii, double heikou_hantei) {
+    public void fix2() {
         while (true) {
-            if (!foldLineSet.fix2(r_hitosii, heikou_hantei)) break;
+            if (!foldLineSet.fix2()) break;
         }
         //foldLineSet.addsenbun  delsenbunを実施しているところでcheckを実施
         if (check1) {
-            check1(0.001, 0.5);
+            check1();
         }
         if (check2) {
-            check2(0.01, 0.5);
+            check2();
         }
         if (check3) {
-            check3(0.0001);
+            check3();
         }
         if (check4) {
-            check4(0.0001);
+            check4();
         }
 
     }
@@ -871,16 +872,16 @@ public class CreasePattern_Worker {
         check2 = i;
     }
 
-    public void check3(double r) {
-        foldLineSet.check3(r);
+    public void check3() {
+        foldLineSet.check3();
     }
 
-    public void check4(double r) {
+    public void check4() {
         TaskExecutor.executeTask(new CheckCAMVTask(this, app.canvas));
     }
 
-    public void ap_check4(double r) throws InterruptedException {
-        foldLineSet.check4(r);
+    public void ap_check4() throws InterruptedException {
+        foldLineSet.check4();
     }
 
     public void setCheck3(boolean i) {
@@ -936,7 +937,7 @@ public class CreasePattern_Worker {
 
         if (e.getPropertyName() == null || e.getPropertyName().equals("check4Enabled")) {
             if (data.getCheck4Enabled()) {
-                check4(0.0001);
+                check4();
             }
         }
     }

--- a/src/main/java/origami_editor/editor/canvas/DrawingUtil.java
+++ b/src/main/java/origami_editor/editor/canvas/DrawingUtil.java
@@ -3,6 +3,7 @@ package origami_editor.editor.canvas;
 import origami.crease_pattern.element.Circle;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.Colors;
@@ -148,8 +149,8 @@ public class DrawingUtil {
 
         Point a = new Point();
         Point b = new Point();
-        a.set(s_tv.determineAX() + 0.000001, s_tv.determineAY() + 0.000001);
-        b.set(s_tv.determineBX() + 0.000001, s_tv.determineBY() + 0.000001);//なぜ0.000001を足すかというと,ディスプレイに描画するとき元の折線が新しい折線に影響されて動いてしまうのを防ぐため
+        a.set(s_tv.determineAX() + Epsilon.UNKNOWN_1EN6, s_tv.determineAY() + Epsilon.UNKNOWN_1EN6);
+        b.set(s_tv.determineBX() + Epsilon.UNKNOWN_1EN6, s_tv.determineBY() + Epsilon.UNKNOWN_1EN6);//なぜEpsilon.UNKNOWN_0000001を足すかというと,ディスプレイに描画するとき元の折線が新しい折線に影響されて動いてしまうのを防ぐため
 
         g.drawLine((int) a.getX(), (int) a.getY(), (int) b.getX(), (int) b.getY()); //直線
     }
@@ -163,8 +164,8 @@ public class DrawingUtil {
         s_tv.set(camera.object2TV(as));
         Point a = new Point();
         Point b = new Point();
-        a.set(s_tv.determineAX() + 0.000001, s_tv.determineAY() + 0.000001);
-        b.set(s_tv.determineBX() + 0.000001, s_tv.determineBY() + 0.000001);//なぜ0.000001を足すかというと,ディスプレイに描画するとき元の折線が新しい折線に影響されて動いてしまうのを防ぐため
+        a.set(s_tv.determineAX() + Epsilon.UNKNOWN_1EN6, s_tv.determineAY() + Epsilon.UNKNOWN_1EN6);
+        b.set(s_tv.determineBX() + Epsilon.UNKNOWN_1EN6, s_tv.determineBY() + Epsilon.UNKNOWN_1EN6);//なぜEpsilon.UNKNOWN_0000001を足すかというと,ディスプレイに描画するとき元の折線が新しい折線に影響されて動いてしまうのを防ぐため
 
         g.drawLine((int) a.getX(), (int) a.getY(), (int) b.getX(), (int) b.getY()); //直線
 
@@ -255,8 +256,8 @@ public class DrawingUtil {
         s_tv.set(camera.object2TV(s));
         Point a= new Point();
         Point b = new Point();
-        a.set(s_tv.determineAX() + 0.000001, s_tv.determineAY() + 0.000001);
-        b.set(s_tv.determineBX() + 0.000001, s_tv.determineBY() + 0.000001);//なぜ0.000001を足すかというと,ディスプレイに描画するとき元の折線が新しい折線に影響されて動いてしまうのを防ぐため
+        a.set(s_tv.determineAX() + Epsilon.UNKNOWN_1EN6, s_tv.determineAY() + Epsilon.UNKNOWN_1EN6);
+        b.set(s_tv.determineBX() + Epsilon.UNKNOWN_1EN6, s_tv.determineBY() + Epsilon.UNKNOWN_1EN6);//なぜEpsilon.UNKNOWN_0000001を足すかというと,ディスプレイに描画するとき元の折線が新しい折線に影響されて動いてしまうのを防ぐため
 
         g.drawLine((int) a.getX(), (int) a.getY(), (int) b.getX(), (int) b.getY()); //直線
 
@@ -295,8 +296,8 @@ public class DrawingUtil {
         s_tv.set(camera.object2TV(s));
         Point a = new Point();
         Point b = new Point();
-        a.set(s_tv.determineAX() + 0.000001, s_tv.determineAY() + 0.000001);
-        b.set(s_tv.determineBX() + 0.000001, s_tv.determineBY() + 0.000001);//The reason for adding 0.000001 is to prevent the original fold line from being affected by the new fold line when drawing on the display.
+        a.set(s_tv.determineAX() + Epsilon.UNKNOWN_1EN6, s_tv.determineAY() + Epsilon.UNKNOWN_1EN6);
+        b.set(s_tv.determineBX() + Epsilon.UNKNOWN_1EN6, s_tv.determineBY() + Epsilon.UNKNOWN_1EN6);//The reason for adding Epsilon.UNKNOWN_0000001 is to prevent the original fold line from being affected by the new fold line when drawing on the display.
 
 
         g.drawLine((int) a.getX(), (int) a.getY(), (int) b.getX(), (int) b.getY()); //直線
@@ -326,8 +327,8 @@ public class DrawingUtil {
         s_tv.set(camera.object2TV(s));
         Point a = new Point();
         Point b = new Point();
-        a.set(s_tv.determineAX() + 0.000001, s_tv.determineAY() + 0.000001);
-        b.set(s_tv.determineBX() + 0.000001, s_tv.determineBY() + 0.000001);//なぜ0.000001を足すかというと,ディスプレイに描画するとき元の折線が新しい折線に影響されて動いてしまうのを防ぐため
+        a.set(s_tv.determineAX() + Epsilon.UNKNOWN_1EN6, s_tv.determineAY() + Epsilon.UNKNOWN_1EN6);
+        b.set(s_tv.determineBX() + Epsilon.UNKNOWN_1EN6, s_tv.determineBY() + Epsilon.UNKNOWN_1EN6);//なぜEpsilon.UNKNOWN_0000001を足すかというと,ディスプレイに描画するとき元の折線が新しい折線に影響されて動いてしまうのを防ぐため
 
         g.drawLine((int) a.getX(), (int) a.getY(), (int) b.getX(), (int) b.getY()); //直線
         int i_width = pointSize + 5;
@@ -357,7 +358,7 @@ public class DrawingUtil {
         Point a = new Point();
 
         a.set(camera.object2TV(c.determineCenter()));//この場合のs_tvは描画座標系での円の中心の位置
-        a.set(a.getX() + 0.000001, a.getY() + 0.000001);//なぜ0.000001を足すかというと,ディスプレイに描画するとき元の折線が新しい折線に影響されて動いてしまうのを防ぐため
+        a.set(a.getX() + Epsilon.UNKNOWN_1EN6, a.getY() + Epsilon.UNKNOWN_1EN6);//なぜEpsilon.UNKNOWN_0000001を足すかというと,ディスプレイに描画するとき元の折線が新しい折線に影響されて動いてしまうのを防ぐため
 
         double d_width = c.getRadius() * camera.getCameraZoomX();//d_habaは描画時の円の半径。なお、camera.get_camera_bairitsu_x()＝camera.get_camera_bairitsu_y()を前提としている。
 
@@ -415,8 +416,8 @@ public class DrawingUtil {
         s_tv.set(camera.object2TV(s));
         Point a = new Point();
         Point b = new Point();
-        a.set(s_tv.determineAX() + 0.000001, s_tv.determineAY() + 0.000001);
-        b.set(s_tv.determineBX() + 0.000001, s_tv.determineBY() + 0.000001);//なぜ0.000001を足すかというと,ディスプレイに描画するとき元の折線が新しい折線に影響されて動いてしまうのを防ぐため
+        a.set(s_tv.determineAX() + Epsilon.UNKNOWN_1EN6, s_tv.determineAY() + Epsilon.UNKNOWN_1EN6);
+        b.set(s_tv.determineBX() + Epsilon.UNKNOWN_1EN6, s_tv.determineBY() + Epsilon.UNKNOWN_1EN6);//なぜEpsilon.UNKNOWN_0000001を足すかというと,ディスプレイに描画するとき元の折線が新しい折線に影響されて動いてしまうのを防ぐため
 
         g2.draw(new Line2D.Double(a.getX(), a.getY(), b.getX(), b.getY()));
 

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerAngleSystem.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerAngleSystem.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -153,7 +154,7 @@ public class MouseHandlerAngleSystem extends BaseMouseHandlerInputRestricted {
             Point kousa_point = new Point();
             kousa_point.set(OritaCalc.findIntersection(d.lineStep.get(2 + (honsuu)), d.lineStep.get(2 + (honsuu) + 1)));
             LineSegment add_sen = new LineSegment(kousa_point, d.lineStep.get(0).getA(), d.lineColor);
-            if (add_sen.determineLength() > 0.00000001) {
+            if (Epsilon.high.gt0(add_sen.determineLength())) {
                 d.addLineSegment(add_sen);
                 d.record();
             }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleChangeColor.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleChangeColor.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
@@ -19,13 +20,13 @@ public class MouseHandlerCircleChangeColor extends BaseMouseHandlerBoxSelect {
     //マウス操作(mouseMode==59 "特注プロパティ指定" でボタンを離したとき)を行う関数----------------------------------------------------
     public void mouseReleased(Point p0) {//補助活線と円
         d.lineStep.clear();
-        if (selectionStart.distance(p0) > 0.000001) {//現状では削除しないときもUNDO用に記録されてしまう20161218
+        if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {//現状では削除しないときもUNDO用に記録されてしまう20161218
 
             if (d.change_property_in_4kakukei(selectionStart, p0)) {
             }
         }
 
-        if (selectionStart.distance(p0) <= 0.000001) {
+        if (selectionStart.distance(p0) <= Epsilon.UNKNOWN_1EN6) {
             Point p = new Point();
             p.set(d.camera.TV2object(p0));
             double rs_min;

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDraw.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDraw.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.Circle;
 import origami.crease_pattern.element.LineColor;
@@ -52,7 +53,7 @@ public class MouseHandlerCircleDraw extends BaseMouseHandler {
             Point closestPoint = d.getClosestPoint(p);
             d.lineStep.get(0).setA(closestPoint);
             if (p.distance(closestPoint) <= d.selectionDistance) {
-                if (d.lineStep.get(0).determineLength() > 0.00000001) {
+                if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
                     d.addCircle(d.lineStep.get(0).determineBX(), d.lineStep.get(0).determineBY(), d.lineStep.get(0).determineLength(), LineColor.CYAN_3);
                     d.record();
                 }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawConcentric.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawConcentric.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.Circle;
 import origami.crease_pattern.element.LineColor;
@@ -70,7 +71,7 @@ public class MouseHandlerCircleDrawConcentric extends BaseMouseHandler {
             Point closestPoint = d.getClosestPoint(p);
             d.lineStep.get(0).setA(closestPoint);
             if (p.distance(closestPoint) <= d.selectionDistance) {
-                if (d.lineStep.get(0).determineLength() > 0.00000001) {
+                if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
                     d.addLineSegment(d.lineStep.get(0));
                     circle2.setR(circle1.getRadius() + d.lineStep.get(0).determineLength());
                     d.addCircle(circle2);

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawConcentricSelect.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawConcentricSelect.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.Circle;
 import origami.crease_pattern.element.LineColor;
@@ -60,10 +61,10 @@ public class MouseHandlerCircleDrawConcentricSelect extends BaseMouseHandler {
             Circle circle3 = d.circleStep.get(2);
             d.circleStep.clear();
             double add_r = circle3.getRadius() - circle2.getRadius();
-            if (Math.abs(add_r) > 0.00000001) {
+            if (!Epsilon.high.eq0(add_r)) {
                 double new_r = add_r + circle1.getRadius();
 
-                if (new_r > 0.00000001) {
+                if (Epsilon.high.gt0(new_r)) {
                     circle1.setR(new_r);
                     circle1.setColor(LineColor.CYAN_3);
                     d.addCircle(circle1);

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawConcentricTwoCircleSelect.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawConcentricTwoCircleSelect.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.Circle;
 import origami.crease_pattern.element.LineColor;
@@ -52,13 +53,13 @@ public class MouseHandlerCircleDrawConcentricTwoCircleSelect extends BaseMouseHa
             Circle circle1 = d.circleStep.get(0);
             Circle circle2 = d.circleStep.get(1);
             d.circleStep.clear();
-            double add_r = (OritaCalc.distance(circle1.determineCenter(), circle2.determineCenter()) - circle1.getRadius() - circle2.getRadius()) * 0.5;
+            double add_r = (OritaCalc.distance(circle1.determineCenter(), circle2.determineCenter()) - circle1.getRadius() - circle2.getRadius()) / 2;
 
-            if (Math.abs(add_r) > 0.00000001) {
+            if (!Epsilon.high.eq0(add_r)) {
                 double new_r1 = add_r + circle1.getRadius();
                 double new_r2 = add_r + circle2.getRadius();
 
-                if ((new_r1 > 0.00000001) && (new_r2 > 0.00000001)) {
+                if (Epsilon.high.gt0(new_r1) && Epsilon.high.gt0(new_r2)) {
                     circle1.setR(new_r1);
                     circle1.setColor(LineColor.CYAN_3);
                     d.addCircle(circle1);

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawFree.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawFree.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.Circle;
 import origami.crease_pattern.element.LineColor;
@@ -63,7 +64,7 @@ public class MouseHandlerCircleDrawFree extends BaseMouseHandler {
                 d.lineStep.get(0).setA(p);
             }
 
-            if (d.lineStep.get(0).determineLength() > 0.00000001) {
+            if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
                 d.addCircle(d.lineStep.get(0).determineBX(), d.lineStep.get(0).determineBY(), d.lineStep.get(0).determineLength(), LineColor.CYAN_3);
                 d.record();
             }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawInverted.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawInverted.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.*;
 import origami_editor.editor.MouseMode;
@@ -75,7 +76,7 @@ public class MouseHandlerCircleDrawInverted extends BaseMouseHandler {
 
     public void add_hanten(Circle e0, Circle eh) {
         //e0の円周が(x,y)を通るとき
-        if (Math.abs(OritaCalc.distance(e0.determineCenter(), eh.determineCenter()) - e0.getRadius()) < 0.0000001) {
+        if (Math.abs(OritaCalc.distance(e0.determineCenter(), eh.determineCenter()) - e0.getRadius()) < Epsilon.UNKNOWN_1EN7) {
             LineSegment s_add = new LineSegment();
             s_add.set(eh.turnAround_CircleToLineSegment(e0));
             //s_add.setcolor(3);
@@ -94,7 +95,7 @@ public class MouseHandlerCircleDrawInverted extends BaseMouseHandler {
     public void add_hanten(LineSegment s0, Circle eh) {
         StraightLine ty = new StraightLine(s0);
         //s0上に(x,y)がくるとき
-        if (ty.calculateDistance(eh.determineCenter()) < 0.0000001) {
+        if (ty.calculateDistance(eh.determineCenter()) < Epsilon.UNKNOWN_1EN7) {
             return;
         }
 

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawSeparate.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawSeparate.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.Circle;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -62,7 +63,7 @@ public class MouseHandlerCircleDrawSeparate extends BaseMouseHandler {
             Point closest_point = d.getClosestPoint(p);
             d.lineStep.get(1).setA(closest_point);
             if (p.distance(closest_point) <= d.selectionDistance) {
-                if (d.lineStep.get(1).determineLength() > 0.00000001) {
+                if (Epsilon.high.gt0(d.lineStep.get(1).determineLength())) {
                     d.addLineSegment(d.lineStep.get(1));
                     d.addCircle(d.lineStep.get(0).getA(), d.lineStep.get(1).determineLength(), LineColor.CYAN_3);
                     d.record();

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawTangentLine.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawTangentLine.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.*;
 import origami_editor.editor.MouseMode;
@@ -73,7 +74,7 @@ public class MouseHandlerCircleDrawTangentLine extends BaseMouseHandler {
             double xp = x2 - x1;
             double yp = y2 - y1;
 
-            if (c1.distance(c2) < 0.000001) {
+            if (c1.distance(c2) < Epsilon.UNKNOWN_1EN6) {
                 d.circleStep.clear();
                 return;
             }//接線0本の場合
@@ -83,7 +84,7 @@ public class MouseHandlerCircleDrawTangentLine extends BaseMouseHandler {
                 return;
             }//接線0本の場合
 
-            if (Math.abs((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2)) < 0.0000001) {//外接線1本の場合
+            if (Math.abs((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2)) < Epsilon.UNKNOWN_1EN7) {//外接線1本の場合
                 Point kouten = new Point();
                 kouten.set(OritaCalc.internalDivisionRatio(c1, c2, -r1, r2));
                 StraightLine ty = new StraightLine(c1, kouten);
@@ -108,7 +109,7 @@ public class MouseHandlerCircleDrawTangentLine extends BaseMouseHandler {
 
                 d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
                 d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
-            } else if (Math.abs((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2)) < 0.0000001) {//外接線2本と内接線1本の場合
+            } else if (Math.abs((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2)) < Epsilon.UNKNOWN_1EN7) {//外接線2本と内接線1本の場合
                 double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
                 double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
                 double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawThreePoint.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCircleDrawThreePoint.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -35,45 +36,45 @@ public class MouseHandlerCircleDrawThreePoint extends BaseMouseHandler {
     public void mouseReleased(Point p0) {
         if (d.lineStep.size() == 3) {
             LineSegment sen1 = new LineSegment(d.lineStep.get(0).getA(), d.lineStep.get(1).getA());
-            if (sen1.determineLength() < 0.00000001) {
+            if (Epsilon.high.le0(sen1.determineLength())) {
                 return;
             }
             LineSegment sen2 = new LineSegment(d.lineStep.get(1).getA(), d.lineStep.get(2).getA());
-            if (sen2.determineLength() < 0.00000001) {
+            if (Epsilon.high.le0(sen2.determineLength())) {
                 return;
             }
             LineSegment sen3 = new LineSegment(d.lineStep.get(2).getA(), d.lineStep.get(0).getA());
-            if (sen3.determineLength() < 0.00000001) {
+            if (Epsilon.high.le0(sen3.determineLength())) {
                 return;
             }
 
-            if (Math.abs(OritaCalc.angle(sen1, sen2) - 0.0) < 0.000001) {
+            if (Math.abs(OritaCalc.angle(sen1, sen2) - 0.0) < Epsilon.UNKNOWN_1EN6) {
                 return;
             }
-            if (Math.abs(OritaCalc.angle(sen1, sen2) - 180.0) < 0.000001) {
+            if (Math.abs(OritaCalc.angle(sen1, sen2) - 180.0) < Epsilon.UNKNOWN_1EN6) {
                 return;
             }
-            if (Math.abs(OritaCalc.angle(sen1, sen2) - 360.0) < 0.000001) {
-                return;
-            }
-
-            if (Math.abs(OritaCalc.angle(sen2, sen3) - 0.0) < 0.000001) {
-                return;
-            }
-            if (Math.abs(OritaCalc.angle(sen2, sen3) - 180.0) < 0.000001) {
-                return;
-            }
-            if (Math.abs(OritaCalc.angle(sen2, sen3) - 360.0) < 0.000001) {
+            if (Math.abs(OritaCalc.angle(sen1, sen2) - 360.0) < Epsilon.UNKNOWN_1EN6) {
                 return;
             }
 
-            if (Math.abs(OritaCalc.angle(sen3, sen1) - 0.0) < 0.000001) {
+            if (Math.abs(OritaCalc.angle(sen2, sen3) - 0.0) < Epsilon.UNKNOWN_1EN6) {
                 return;
             }
-            if (Math.abs(OritaCalc.angle(sen3, sen1) - 180.0) < 0.000001) {
+            if (Math.abs(OritaCalc.angle(sen2, sen3) - 180.0) < Epsilon.UNKNOWN_1EN6) {
                 return;
             }
-            if (Math.abs(OritaCalc.angle(sen3, sen1) - 360.0) < 0.000001) {
+            if (Math.abs(OritaCalc.angle(sen2, sen3) - 360.0) < Epsilon.UNKNOWN_1EN6) {
+                return;
+            }
+
+            if (Math.abs(OritaCalc.angle(sen3, sen1) - 0.0) < Epsilon.UNKNOWN_1EN6) {
+                return;
+            }
+            if (Math.abs(OritaCalc.angle(sen3, sen1) - 180.0) < Epsilon.UNKNOWN_1EN6) {
+                return;
+            }
+            if (Math.abs(OritaCalc.angle(sen3, sen1) - 360.0) < Epsilon.UNKNOWN_1EN6) {
                 return;
             }
 

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseAdvanceType.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseAdvanceType.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -26,7 +27,7 @@ public class MouseHandlerCreaseAdvanceType extends BaseMouseHandler {
         if (d.foldLineSet.closestLineSegmentDistance(p) < d.selectionDistance) {//点pに最も近い線分の番号での、その距離を返す	public double mottomo_tikai_senbun_kyori(Ten p)
             lineSegment = d.foldLineSet.closestLineSegmentSearch(p);
             LineSegment s01 = new LineSegment();
-            s01.set(OritaCalc.lineSegment_double(lineSegment, 0.01));
+            s01.set(OritaCalc.lineSegment_double(lineSegment, Epsilon.UNKNOWN_001));
             lineSegment.setB(s01.getB());
         }
     }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseCopy.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseCopy.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.FoldLineSet;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
@@ -22,7 +23,7 @@ public class MouseHandlerCreaseCopy extends BaseMouseHandlerLineSelect {
         if (p.distance(closestPoint) <= d.selectionDistance) {
             d.lineStep.get(0).setA(closestPoint);
         }
-        if (d.lineStep.get(0).determineLength() > 0.00000001) {
+        if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
             //やりたい動作はここに書く
 
             double addx = -d.lineStep.get(0).determineBX() + d.lineStep.get(0).determineAX();

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseCopy4p.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseCopy4p.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.FoldLineSet;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
@@ -39,7 +40,7 @@ public class MouseHandlerCreaseCopy4p extends BaseMouseHandlerInputRestricted {
             if (p.distance(closestPoint) < d.selectionDistance) {
                 d.lineStepAdd(new LineSegment(closestPoint, closestPoint, LineColor.BLUE_2));
             }
-            if (OritaCalc.distance(d.lineStep.get(0).getA(), d.lineStep.get(0).getA()) < 0.00000001) {
+            if (Epsilon.high.le0(OritaCalc.distance(d.lineStep.get(0).getA(), d.lineStep.get(0).getA()))) {
                 d.lineStep.clear();
                 d.app.canvasModel.setSelectionOperationMode(CanvasModel.SelectionOperationMode.NORMAL_0);//  <-------20180919この行はセレクトした線の端点を選ぶと、移動とかコピー等をさせると判断するが、その操作が終わったときに必要だから追加した。
             }
@@ -73,7 +74,7 @@ public class MouseHandlerCreaseCopy4p extends BaseMouseHandlerInputRestricted {
             if (p.distance(closestPoint) < d.selectionDistance) {
                 d.lineStepAdd(new LineSegment(closestPoint, closestPoint, LineColor.ORANGE_4));
             }
-            if (OritaCalc.distance(d.lineStep.get(2).getA(), d.lineStep.get(3).getA()) < 0.00000001) {
+            if (Epsilon.high.le0(OritaCalc.distance(d.lineStep.get(2).getA(), d.lineStep.get(3).getA()))) {
                 d.lineStep.clear();
                 d.app.canvasModel.setSelectionOperationMode(CanvasModel.SelectionOperationMode.NORMAL_0);//  <-------20180919この行はセレクトした線の端点を選ぶと、移動とかコピー等をさせると判断するが、その操作が終わったときに必要だから追加した。
             }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseDeleteIntersecting.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseDeleteIntersecting.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
 
@@ -24,7 +25,7 @@ public class MouseHandlerCreaseDeleteIntersecting extends BaseMouseHandlerLineSe
         if (p.distance(closestPoint) <= d.selectionDistance) {
             d.lineStep.get(0).setA(closestPoint);
         }
-        if (d.lineStep.get(0).determineLength() > 0.00000001) {
+        if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
             //やりたい動作はここに書く
             d.foldLineSet.deleteInsideLine(d.lineStep.get(0), "lX");//lXは小文字のエルと大文字のエックス
             d.record();

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseDeleteOverlapping.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseDeleteOverlapping.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
@@ -46,7 +47,7 @@ public class MouseHandlerCreaseDeleteOverlapping extends BaseMouseHandlerInputRe
             Point closest_point = d.getClosestPoint(p);
             d.lineStep.get(0).setA(closest_point);
             if (p.distance(closest_point) <= d.selectionDistance) {
-                if (d.lineStep.get(0).determineLength() > 0.00000001) {
+                if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
                     d.foldLineSet.deleteInsideLine(d.lineStep.get(0), "l");//lは小文字のエル
 
                     d.record();

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMakeAux.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMakeAux.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
@@ -20,7 +21,7 @@ public class MouseHandlerCreaseMakeAux extends BaseMouseHandlerBoxSelect {
     public void mouseReleased(Point p0) {
         d.lineStep.clear();
 
-        if (selectionStart.distance(p0) > 0.000001) {
+        if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {
             if (d.insideToAux(selectionStart, p0)) {
                 d.record();
             }//この関数は不完全なのでまだ未公開20171126

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMakeEdge.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMakeEdge.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
@@ -16,12 +17,12 @@ public class MouseHandlerCreaseMakeEdge extends BaseMouseHandlerBoxSelect {
     }
 
     //マウス操作(mouseMode==25 でボタンを離したとき)を行う関数----------------------------------------------------
-    public void mouseReleased(Point p0) {//ここの処理の終わりに fix2(0.001,0.5);　をするのは、元から折線だったものと、補助線から変換した折線との組合せで頻発するT字型不接続を修正するため
+    public void mouseReleased(Point p0) {//ここの処理の終わりに fix2();　をするのは、元から折線だったものと、補助線から変換した折線との組合せで頻発するT字型不接続を修正するため
         d.lineStep.clear();
 
-        if (selectionStart.distance(p0) > 0.000001) {
+        if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {
             if (d.insideToEdge(selectionStart, p0)) {
-                d.fix2(0.001, 0.5);
+                d.fix2();
                 d.record();
             }
         } else {
@@ -29,7 +30,7 @@ public class MouseHandlerCreaseMakeEdge extends BaseMouseHandlerBoxSelect {
             p.set(d.camera.TV2object(p0));
             if (d.foldLineSet.closestLineSegmentDistance(p) < d.selectionDistance) {//点pに最も近い線分の番号での、その距離を返す	public double mottomo_tikai_senbun_kyori(Ten p)
                 d.foldLineSet.closestLineSegmentSearch(p).setColor(LineColor.BLACK_0);
-                d.fix2(0.001, 0.5);
+                d.fix2();
                 d.record();
             }
         }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMakeMV.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMakeMV.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -52,7 +53,7 @@ public class MouseHandlerCreaseMakeMV extends BaseMouseHandlerInputRestricted {
             Point closest_point = d.getClosestPoint(p);
             d.lineStep.get(0).setA(closest_point);
             if (p.distance(closest_point) <= d.selectionDistance) {
-                if (d.lineStep.get(0).determineLength() > 0.00000001) {
+                if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
                     for (int i = 1; i <= d.foldLineSet.getTotal(); i++) {
                         LineSegment s = d.foldLineSet.get(i);
                         if (OritaCalc.isLineSegmentOverlapping(s, d.lineStep.get(0))) {

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMakeMountain.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMakeMountain.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
@@ -16,12 +17,12 @@ public class MouseHandlerCreaseMakeMountain extends BaseMouseHandlerBoxSelect {
     }
 
     //マウス操作(mouseMode==23 でボタンを離したとき)を行う関数----------------------------------------------------
-    public void mouseReleased(Point p0) {//ここの処理の終わりに fix2(0.001,0.5);　をするのは、元から折線だったものと、補助線から変換した折線との組合せで頻発するT字型不接続を修正するため
+    public void mouseReleased(Point p0) {//ここの処理の終わりに fix2();　をするのは、元から折線だったものと、補助線から変換した折線との組合せで頻発するT字型不接続を修正するため
         d.lineStep.clear();
 
-        if (selectionStart.distance(p0) > 0.000001) {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218
+        if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218
             if (d.insideToMountain(selectionStart, p0)) {
-                d.fix2(0.001, 0.5);
+                d.fix2();
                 d.record();
             }
         } else {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218
@@ -29,7 +30,7 @@ public class MouseHandlerCreaseMakeMountain extends BaseMouseHandlerBoxSelect {
             p.set(d.camera.TV2object(p0));
             if (d.foldLineSet.closestLineSegmentDistance(p) < d.selectionDistance) {//点pに最も近い線分の番号での、その距離を返す	public double closestLineSegmentDistance(Ten p)
                 d.foldLineSet.closestLineSegmentSearch(p).setColor(LineColor.RED_1);
-                d.fix2(0.001, 0.5);
+                d.fix2();
                 d.record();
             }
         }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMakeValley.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMakeValley.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
@@ -16,21 +17,21 @@ public class MouseHandlerCreaseMakeValley extends BaseMouseHandlerBoxSelect {
     }
 
     //マウス操作(mouseMode==24 でボタンを離したとき)を行う関数----------------------------------------------------
-    public void mouseReleased(Point p0) {//ここの処理の終わりに fix2(0.001,0.5);　をするのは、元から折線だったものと、補助線から変換した折線との組合せで頻発するT字型不接続を修正するため
+    public void mouseReleased(Point p0) {//ここの処理の終わりに fix2();　をするのは、元から折線だったものと、補助線から変換した折線との組合せで頻発するT字型不接続を修正するため
         d.lineStep.clear();
 
-        if (selectionStart.distance(p0) > 0.000001) {
+        if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {
             if (d.insideToValley(selectionStart, p0)) {
-                d.fix2(0.001, 0.5);
+                d.fix2();
                 d.record();
             }
         }
-        if (selectionStart.distance(p0) <= 0.000001) {
+        if (selectionStart.distance(p0) <= Epsilon.UNKNOWN_1EN6) {
             Point p = new Point();
             p.set(d.camera.TV2object(p0));
             if (d.foldLineSet.closestLineSegmentDistance(p) < d.selectionDistance) {//点pに最も近い線分の番号での、その距離を返す	public double mottomo_tikai_senbun_kyori(Ten p)
                 d.foldLineSet.closestLineSegmentSearch(p).setColor(LineColor.BLUE_2);
-                d.fix2(0.001, 0.5);
+                d.fix2();
                 d.record();
             }
         }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMove.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMove.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.FoldLineSet;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
@@ -23,7 +24,7 @@ public class MouseHandlerCreaseMove extends BaseMouseHandlerLineSelect {
         if (p.distance(closestPoint) <= d.selectionDistance) {
             d.lineStep.get(0).setA(closestPoint);
         }
-        if (d.lineStep.get(0).determineLength() > 0.00000001) {
+        if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
             //やりたい動作はここに書く
 
             double addx, addy;

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMove4p.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseMove4p.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.FoldLineSet;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
@@ -32,7 +33,7 @@ public class MouseHandlerCreaseMove4p extends BaseMouseHandlerInputRestricted {
                 if (p.distance(closestPoint) < d.selectionDistance) {
                     d.lineStepAdd(new LineSegment(closestPoint, closestPoint, LineColor.BLUE_2));
 
-                    if (OritaCalc.distance(d.lineStep.get(0).getA(), d.lineStep.get(1).getA()) < 0.00000001) {
+                    if (Epsilon.high.le0(OritaCalc.distance(d.lineStep.get(0).getA(), d.lineStep.get(1).getA()))) {
                         d.lineStep.clear();
                         d.app.canvasModel.setSelectionOperationMode(CanvasModel.SelectionOperationMode.NORMAL_0);//  <-------20180919この行はセレクトした線の端点を選ぶと、移動とかコピー等をさせると判断するが、その操作が終わったときに必要だから追加した。
                     }
@@ -56,7 +57,7 @@ public class MouseHandlerCreaseMove4p extends BaseMouseHandlerInputRestricted {
                 if (p.distance(closestPoint) < d.selectionDistance) {
                     d.lineStepAdd(new LineSegment(closestPoint, closestPoint, LineColor.ORANGE_4));
 
-                    if (OritaCalc.distance(d.lineStep.get(2).getA(), d.lineStep.get(3).getA()) < 0.00000001) {
+                    if (Epsilon.high.le0(OritaCalc.distance(d.lineStep.get(2).getA(), d.lineStep.get(3).getA()))) {
                         d.lineStep.clear();
                         d.app.canvasModel.setSelectionOperationMode(CanvasModel.SelectionOperationMode.NORMAL_0);//  <-------20180919この行はセレクトした線の端点を選ぶと、移動とかコピー等をさせると判断するが、その操作が終わったときに必要だから追加した。
                     }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseSelect.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseSelect.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
 
@@ -118,7 +119,7 @@ public class MouseHandlerCreaseSelect extends BaseMouseHandlerBoxSelect {
         d.lineStep.clear();
 
         d.select(selectionStart, p0);
-        if (selectionStart.distance(p0) <= 0.000001) {
+        if (selectionStart.distance(p0) <= Epsilon.UNKNOWN_1EN6) {
             Point p = new Point();
             p.set(d.camera.TV2object(p0));
             if (d.foldLineSet.closestLineSegmentDistance(p) < d.selectionDistance) {//点pに最も近い線分の番号での、その距離を返す	public double mottomo_tikai_senbun_kyori(Ten p)

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseToggleMV.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseToggleMV.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
@@ -17,17 +18,17 @@ public class MouseHandlerCreaseToggleMV extends BaseMouseHandlerBoxSelect {
     }
 
     //マウス操作(mouseMode==58線_変換　でボタンを離したとき)を行う関数
-    public void mouseReleased(Point p0) {//ここの処理の終わりに fix2(0.001,0.5);　をするのは、元から折線だったものと、補助線から変換した折線との組合せで頻発するT字型不接続を修正するため
+    public void mouseReleased(Point p0) {//ここの処理の終わりに fix2();　をするのは、元から折線だったものと、補助線から変換した折線との組合せで頻発するT字型不接続を修正するため
         d.lineStep.clear();
 
-        if (selectionStart.distance(p0) > 0.000001) {//
+        if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {//
             if (d.MV_change(selectionStart, p0) != 0) {
-                d.fix2(0.001, 0.5);
+                d.fix2();
                 d.record();
             }
         }
 
-        if (selectionStart.distance(p0) <= 0.000001) {//
+        if (selectionStart.distance(p0) <= Epsilon.UNKNOWN_1EN6) {//
             Point p = new Point();
             p.set(d.camera.TV2object(p0));
             if (d.foldLineSet.closestLineSegmentDistance(p) < d.selectionDistance) {//点pに最も近い線分の番号での、その距離を返す	public double mottomo_tikai_senbun_kyori(Ten p)
@@ -39,7 +40,7 @@ public class MouseHandlerCreaseToggleMV extends BaseMouseHandlerBoxSelect {
                     s.setColor(LineColor.RED_1);
                 }
 
-                d.fix2(0.001, 0.5);
+                d.fix2();
                 d.record();
             }
 

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseUnselect.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreaseUnselect.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
 
@@ -19,7 +20,7 @@ public class MouseHandlerCreaseUnselect extends BaseMouseHandlerBoxSelect {
         d.lineStep.clear();
         d.unselect(selectionStart, p0);
 
-        if (selectionStart.distance(p0) <= 0.000001) {
+        if (selectionStart.distance(p0) <= Epsilon.UNKNOWN_1EN6) {
             Point p = new Point();
             p.set(d.camera.TV2object(p0));
             if (d.foldLineSet.closestLineSegmentDistance(p) < d.selectionDistance) {//点pに最も近い線分の番号での、その距離を返す	public double mottomo_tikai_senbun_kyori(Ten p)

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerCreasesAlternateMV.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerCreasesAlternateMV.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -51,10 +52,10 @@ public class MouseHandlerCreasesAlternateMV extends BaseMouseHandlerInputRestric
                 closestPoint.set(p);
             }
             d.lineStep.get(0).setA(closestPoint);
-            if (d.lineStep.get(0).determineLength() > 0.00000001) {
+            if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
                 for (int i = 1; i <= d.foldLineSet.getTotal(); i++) {
                     LineSegment s = d.foldLineSet.get(i);
-                    LineSegment.Intersection i_senbun_kousa_hantei = OritaCalc.determineLineSegmentIntersection(s, d.lineStep.get(0), 0.0001, 0.0001);
+                    LineSegment.Intersection i_senbun_kousa_hantei = OritaCalc.determineLineSegmentIntersection(s, d.lineStep.get(0), Epsilon.UNKNOWN_1EN4, Epsilon.UNKNOWN_1EN4);
                     int i_jikkou = 0;
                     if (i_senbun_kousa_hantei == LineSegment.Intersection.INTERSECTS_1) {
                         i_jikkou = 1;

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerDeletePoint.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerDeletePoint.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
 
@@ -20,7 +21,7 @@ public class MouseHandlerDeletePoint extends BaseMouseHandler {
 
         //点pに最も近い線分の、点pに近い方の端点を、頂点とした場合、何本の線分が出ているか（頂点とr以内に端点がある線分の数）	public int tyouten_syuui_sennsuu(Ten p) {
 
-        d.foldLineSet.del_V(p, d.selectionDistance, 0.000001);
+        d.foldLineSet.del_V(p, d.selectionDistance, Epsilon.UNKNOWN_1EN6);
         d.record();
     }
 

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerDoubleSymmetricDraw.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerDoubleSymmetricDraw.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
@@ -48,11 +49,11 @@ public class MouseHandlerDoubleSymmetricDraw extends BaseMouseHandlerInputRestri
 
             d.lineStep.get(0).setA(closestPoint);
             if (p.distance(closestPoint) <= d.selectionDistance) {
-                if (d.lineStep.get(0).determineLength() > 0.00000001) {
+                if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
                     int imax = d.foldLineSet.getTotal();
                     for (int i = 1; i <= imax; i++) {
                         LineSegment s = d.foldLineSet.get(i);
-                        LineSegment.Intersection i_lineSegment_intersection_decision = OritaCalc.determineLineSegmentIntersectionSweet(s, d.lineStep.get(0), 0.01, 0.01);
+                        LineSegment.Intersection i_lineSegment_intersection_decision = OritaCalc.determineLineSegmentIntersectionSweet(s, d.lineStep.get(0), Epsilon.UNKNOWN_001, Epsilon.UNKNOWN_001);
                         boolean i_jikkou = false;
                         if (i_lineSegment_intersection_decision == LineSegment.Intersection.INTERSECTS_TSHAPE_S1_VERTICAL_BAR_25) {
                             i_jikkou = true;
@@ -77,7 +78,7 @@ public class MouseHandlerDoubleSymmetricDraw extends BaseMouseHandlerInputRestri
 
                             add_sen.set(d.extendToIntersectionPoint(add_sen));
                             add_sen.setColor(s.getColor());
-                            if (add_sen.determineLength() > 0.00000001) {
+                            if (Epsilon.high.gt0(add_sen.determineLength())) {
                                 d.addLineSegment(add_sen);
                             }
                         }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseAngleRestricted.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseAngleRestricted.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -179,7 +180,7 @@ public class MouseHandlerDrawCreaseAngleRestricted extends BaseMouseHandler {
                 //２つの線分が平行かどうかを判定する関数。oc.heikou_hantei(Tyokusen t1,Tyokusen t2)//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
                 //0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
 
-                if (OritaCalc.isLineSegmentParallel(d.lineStep.get(d.lineStep.size() - 1 - 1), d.lineStep.get(d.lineStep.size() - 1), 0.1) != OritaCalc.ParallelJudgement.NOT_PARALLEL) {//ここは安全を見て閾値を0.1と大目にとっておこのがよさそう
+                if (OritaCalc.isLineSegmentParallel(d.lineStep.get(d.lineStep.size() - 1 - 1), d.lineStep.get(d.lineStep.size() - 1), Epsilon.UNKNOWN_01) != OritaCalc.ParallelJudgement.NOT_PARALLEL) {//ここは安全を見て閾値を0.1と大目にとっておこのがよさそう
                     d.lineStep.clear();
                     return;
                 }
@@ -190,13 +191,13 @@ public class MouseHandlerDrawCreaseAngleRestricted extends BaseMouseHandler {
 
                 LineSegment add_sen = new LineSegment(kousa_point, d.lineStep.get(1 + (honsuu) + (honsuu)).getA());
                 add_sen.setColor(d.lineColor);
-                if (add_sen.determineLength() > 0.00000001) {
+                if (Epsilon.high.gt0(add_sen.determineLength())) {
                     d.addLineSegment(add_sen);
                 }
 
                 LineSegment add_sen2 = new LineSegment(kousa_point, d.lineStep.get(1 + (honsuu) + (honsuu) + 1).getA());
                 add_sen2.setColor(d.lineColor);
-                if (add_sen.determineLength() > 0.00000001) {
+                if (Epsilon.high.gt0(add_sen.determineLength())) {
                     d.addLineSegment(add_sen2);
                 }
                 d.record();

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseAngleRestricted2.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseAngleRestricted2.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -177,7 +178,7 @@ public class MouseHandlerDrawCreaseAngleRestricted2 extends BaseMouseHandlerInpu
                 //２つの線分が平行かどうかを判定する関数。oc.heikou_hantei(Tyokusen t1,Tyokusen t2)//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
                 //0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
 
-                if (OritaCalc.isLineSegmentParallel(d.lineStep.get(d.lineStep.size() - 1 - 1), d.lineStep.get(d.lineStep.size() - 1), 0.1) != OritaCalc.ParallelJudgement.NOT_PARALLEL) {//ここは安全を見て閾値を0.1と大目にとっておこのがよさそう
+                if (OritaCalc.isLineSegmentParallel(d.lineStep.get(d.lineStep.size() - 1 - 1), d.lineStep.get(d.lineStep.size() - 1), Epsilon.UNKNOWN_01) != OritaCalc.ParallelJudgement.NOT_PARALLEL) {//ここは安全を見て閾値を0.1と大目にとっておこのがよさそう
                     d.lineStep.clear();
                     return;
                 }
@@ -189,13 +190,13 @@ public class MouseHandlerDrawCreaseAngleRestricted2 extends BaseMouseHandlerInpu
 
                 LineSegment add_sen = new LineSegment(kousa_point, d.lineStep.get(2 + (honsuu) + (honsuu)).getA());
                 add_sen.setColor(d.lineColor);
-                if (add_sen.determineLength() > 0.00000001) {
+                if (Epsilon.high.gt0(add_sen.determineLength())) {
                     d.addLineSegment(add_sen);
                 }
 
                 LineSegment add_sen2 = new LineSegment(kousa_point, d.lineStep.get(2 + (honsuu) + (honsuu) + 1).getA());
                 add_sen2.setColor(d.lineColor);
-                if (add_sen.determineLength() > 0.00000001) {
+                if (Epsilon.high.gt0(add_sen.determineLength())) {
                     d.addLineSegment(add_sen2);
                 }
                 d.record();

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseAngleRestricted3_2.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseAngleRestricted3_2.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -114,7 +115,7 @@ public class MouseHandlerDrawCreaseAngleRestricted3_2 extends BaseMouseHandlerIn
         }
 
         if (d.lineStep.size() == 2 + (honsuu)) {
-            LineSegment closest_step_lineSegment = new LineSegment(100000.0, 100000.0, 100000.0, 100000.1); //マウス最寄のstep線分(線分追加のための準備をするための線分)。なお、ここで宣言する必要はないので、どこで宣言すべきか要検討20161113
+            LineSegment closest_step_lineSegment = new LineSegment(100000.0, 100000.0, 100000.0, 100000.0 + Epsilon.UNKNOWN_01); //マウス最寄のstep線分(線分追加のための準備をするための線分)。なお、ここで宣言する必要はないので、どこで宣言すべきか要検討20161113
 
             closest_step_lineSegment.set(d.get_moyori_step_lineSegment(p, 3, 2 + (honsuu)));
             if (OritaCalc.determineLineSegmentDistance(p, closest_step_lineSegment) >= d.selectionDistance) {
@@ -129,7 +130,7 @@ public class MouseHandlerDrawCreaseAngleRestricted3_2 extends BaseMouseHandlerIn
                 LineSegment closestLineSegment = new LineSegment();
                 closestLineSegment.set(d.getClosestLineSegment(p));
                 if (OritaCalc.determineLineSegmentDistance(p, closestLineSegment) < d.selectionDistance) {//最寄折線が近い場合
-                    if (OritaCalc.isLineSegmentParallel(closest_step_lineSegment, closestLineSegment, 0.000001) == OritaCalc.ParallelJudgement.NOT_PARALLEL) {//最寄折線が最寄step折線と平行の場合は除外
+                    if (OritaCalc.isLineSegmentParallel(closest_step_lineSegment, closestLineSegment, Epsilon.UNKNOWN_1EN6) == OritaCalc.ParallelJudgement.NOT_PARALLEL) {//最寄折線が最寄step折線と平行の場合は除外
                         Point mokuhyou_point2 = new Point();
                         mokuhyou_point2.set(OritaCalc.findIntersection(closest_step_lineSegment, closestLineSegment));
                         if (p.distance(mokuhyou_point) * 2.0 > p.distance(mokuhyou_point2)) {

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseAngleRestricted5.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseAngleRestricted5.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
@@ -51,7 +52,7 @@ public class MouseHandlerDrawCreaseAngleRestricted5 extends BaseMouseHandlerInpu
         if (d.lineStep.size() == 1) {
             Point syuusei_point = new Point(syuusei_point_A_37(p0));
             d.lineStep.get(0).setA(kouho_point_A_37(syuusei_point));
-            if (d.lineStep.get(0).determineLength() > 0.00000001) {
+            if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
                 d.addLineSegment(d.lineStep.get(0));
                 d.record();
             }
@@ -96,7 +97,7 @@ public class MouseHandlerDrawCreaseAngleRestricted5 extends BaseMouseHandlerInpu
     public Point kouho_point_A_37(Point syuusei_point) {
         Point closestPoint = d.getClosestPoint(syuusei_point);
         double zure_kakudo = OritaCalc.angle(d.lineStep.get(0).getB(), syuusei_point, d.lineStep.get(0).getB(), closestPoint);
-        boolean zure_flg = (0.00001 < zure_kakudo) && (zure_kakudo <= 359.99999);
+        boolean zure_flg = (Epsilon.UNKNOWN_1EN5 < zure_kakudo) && (zure_kakudo <= 360.0 - Epsilon.UNKNOWN_1EN5);
         if (zure_flg || (syuusei_point.distance(closestPoint) > d.selectionDistance)) {
             return syuusei_point;
         } else {//最寄点が角度系にのっていて、修正点とも近い場合

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseFree.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseFree.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
@@ -105,7 +106,7 @@ public class MouseHandlerDrawCreaseFree extends BaseMouseHandler {
         if (p.distance(closestPoint) <= d.selectionDistance) {
             d.lineStep.get(0).setA(closestPoint);
         }
-        if (d.lineStep.get(0).determineLength() > 0.00000001) {
+        if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
             if (d.i_foldLine_additional == FoldLineAdditionalInputMode.POLY_LINE_0) {
                 d.addLineSegment(d.lineStep.get(0));
                 d.record();

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseRestricted.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseRestricted.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
@@ -57,7 +58,7 @@ public class MouseHandlerDrawCreaseRestricted extends BaseMouseHandlerInputRestr
             Point closestPoint = d.getClosestPoint(p);
             d.lineStep.get(0).setA(closestPoint);
             if (p.distance(closestPoint) <= d.selectionDistance) {
-                if (d.lineStep.get(0).determineLength() > 0.00000001) {
+                if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
                     d.addLineSegment(d.lineStep.get(0));
                     d.record();
                 }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseSymmetric.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerDrawCreaseSymmetric.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -35,7 +36,7 @@ public class MouseHandlerDrawCreaseSymmetric extends BaseMouseHandlerInputRestri
                 return;
             }
 
-            if (d.lineStep.get(0).determineLength() < 0.00000001) {
+            if (Epsilon.high.le0(d.lineStep.get(0).determineLength())) {
                 d.lineStep.clear();
                 d.app.canvasModel.setSelectionOperationMode(CanvasModel.SelectionOperationMode.NORMAL_0);//  <-------20180919この行はセレクトした線の端点を選ぶと、移動とかコピー等をさせると判断するが、その操作が終わったときに必要だから追加した。
             }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerFishBoneDraw.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerFishBoneDraw.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -51,7 +52,7 @@ public class MouseHandlerFishBoneDraw extends BaseMouseHandlerInputRestricted {
             d.lineStep.get(0).setA(closest_point);
 
             if (p.distance(closest_point) <= d.selectionDistance) {  //マウスで指定した点が、最寄点と近かったときに実施
-                if (d.lineStep.get(0).determineLength() > 0.00000001) {  //lineStep.get(0)が、線の時（=点状ではない時）に実施
+                if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {  //lineStep.get(0)が、線の時（=点状ではない時）に実施
                     double dx = (d.lineStep.get(0).determineAX() - d.lineStep.get(0).determineBX()) * d.grid.getGridWidth() / d.lineStep.get(0).determineLength();
                     double dy = (d.lineStep.get(0).determineAY() - d.lineStep.get(0).determineBY()) * d.grid.getGridWidth() / d.lineStep.get(0).determineLength();
                     LineColor icol_temp = d.lineColor;
@@ -63,7 +64,7 @@ public class MouseHandlerFishBoneDraw extends BaseMouseHandlerInputRestricted {
                         pxy.set(px, py);
 
 
-                        if (d.foldLineSet.closestLineSegmentDistanceExcludingParallel(pxy, d.lineStep.get(0)) > 0.001) {
+                        if (d.foldLineSet.closestLineSegmentDistanceExcludingParallel(pxy, d.lineStep.get(0)) > Epsilon.UNKNOWN_0001) {
 
                             int i_sen = 0;
 
@@ -87,7 +88,7 @@ public class MouseHandlerFishBoneDraw extends BaseMouseHandlerInputRestricted {
                             }
 
                             if (i_sen == 2) {
-                                d.foldLineSet.del_V(pxy, d.selectionDistance, 0.000001);
+                                d.foldLineSet.del_V(pxy, d.selectionDistance, Epsilon.UNKNOWN_1EN6);
                             }
 
                         }
@@ -117,7 +118,7 @@ public class MouseHandlerFishBoneDraw extends BaseMouseHandlerInputRestricted {
 
             if (i_intersection_flg.isIntersecting()) {
                 intersection_point.set(OritaCalc.findIntersection(tyoku1, d.foldLineSet.get(i)));
-                if (intersection_point.distance(add_line.getA()) > 0.00001) {
+                if (intersection_point.distance(add_line.getA()) > Epsilon.UNKNOWN_1EN5) {
                     double d_kakudo = OritaCalc.angle(add_line.getA(), add_line.getB(), add_line.getA(), intersection_point);
                     if (d_kakudo < 1.0 || d_kakudo > 359.0) {
                         return 1;

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerFlatFoldableCheck.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerFlatFoldableCheck.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -88,7 +89,7 @@ public class MouseHandlerFlatFoldableCheck extends BaseMouseHandler {
                 for (int i = 1; i <= d.foldLineSet.getTotal(); i++) {
                     LineSegment s = d.foldLineSet.get(i);
 
-                    LineSegment.Intersection i_senbun_kousa_hantei = OritaCalc.determineLineSegmentIntersection(s, s2, 0.0001, 0.0001);
+                    LineSegment.Intersection i_senbun_kousa_hantei = OritaCalc.determineLineSegmentIntersection(s, s2, Epsilon.UNKNOWN_1EN4, Epsilon.UNKNOWN_1EN4);
                     int i_jikkou = 0;
 
                     if ((i_senbun_kousa_hantei != LineSegment.Intersection.NO_INTERSECTION_0) && (i_senbun_kousa_hantei != LineSegment.Intersection.INTERSECTS_1)) {
@@ -134,8 +135,8 @@ public class MouseHandlerFlatFoldableCheck extends BaseMouseHandler {
                         s_idou.set(OritaCalc.findLineSymmetryLineSegment(s_idou, goukei_nbox.getValue(i)));
                     }
                     i_hantai_color = LineColor.MAGENTA_5;
-                    if (OritaCalc.equal(goukei_nbox.getValue(1).getA(), s_idou.getA(), 0.0001)) {
-                        if (OritaCalc.equal(goukei_nbox.getValue(1).getB(), s_idou.getB(), 0.0001)) {
+                    if (OritaCalc.equal(goukei_nbox.getValue(1).getA(), s_idou.getA(), Epsilon.UNKNOWN_1EN4)) {
+                        if (OritaCalc.equal(goukei_nbox.getValue(1).getB(), s_idou.getB(), Epsilon.UNKNOWN_1EN4)) {
                             i_hantai_color = LineColor.CYAN_3;
                         }
                     }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerFoldableLineDraw.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerFoldableLineDraw.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
@@ -47,7 +48,7 @@ public class MouseHandlerFoldableLineDraw extends BaseMouseHandler {
         operationModeChangeable = false;
         Point p = new Point();
         p.set(d.camera.TV2object(p0));
-        double hantei_kyori = 0.000001;
+        double decision_distance = Epsilon.UNKNOWN_1EN6;
 
         if (p.distance(moyori_point_memo) <= d.selectionDistance) {
             d.lineStep.clear();
@@ -67,9 +68,9 @@ public class MouseHandlerFoldableLineDraw extends BaseMouseHandler {
             for (int i = 1; i <= d.foldLineSet.getTotal(); i++) {
                 LineSegment s = d.foldLineSet.get(i);
                 if (s.getColor().isFoldingLine()) {
-                    if (closest_point.distance(s.getA()) < hantei_kyori) {
+                    if (closest_point.distance(s.getA()) < decision_distance) {
                         nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getA(), s.getB())));
-                    } else if (closest_point.distance(s.getB()) < hantei_kyori) {
+                    } else if (closest_point.distance(s.getB()) < decision_distance) {
                         nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getB(), s.getA())));
                     }
                 }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerFoldableLineInput.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerFoldableLineInput.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -56,7 +57,7 @@ public class MouseHandlerFoldableLineInput extends BaseMouseHandlerInputRestrict
                 case STEP_2: {//i_step_for_copy_4p==2であれば、以下でs_step[1]を入力折線を確定する
                     Point closest_point = d.getClosestPoint(p);
 
-                    if (closest_point.distance(d.lineStep.get(0).getA()) < 0.00000001) {
+                    if (Epsilon.high.le0(closest_point.distance(d.lineStep.get(0).getA()))) {
                         d.lineCandidate.clear();
                         d.lineCandidate.add(new LineSegment(closest_point, closest_point, d.lineColor));
                         System.out.println("i_step_for39_2_   1");
@@ -113,7 +114,7 @@ public class MouseHandlerFoldableLineInput extends BaseMouseHandlerInputRestrict
 
         switch (i_step_for_copy_4p) {
             case STEP_0: {
-                double decision_distance = 0.000001;
+                double decision_distance = Epsilon.UNKNOWN_1EN6;
 
                 //任意の点が与えられたとき、端点もしくは格子点で最も近い点を得る
                 Point closest_point = d.getClosestPoint(p);
@@ -173,7 +174,7 @@ public class MouseHandlerFoldableLineInput extends BaseMouseHandlerInputRestrict
                                 add_kakudo_1 = 360.0;
                             }
 
-                            if ((kakukagenti / 2.0 > 0.0 + 0.000001) && (kakukagenti / 2.0 < add_kakudo_1 - 0.000001)) {
+                            if ((kakukagenti / 2.0 > 0.0 + Epsilon.UNKNOWN_1EN6) && (kakukagenti / 2.0 < add_kakudo_1 - Epsilon.UNKNOWN_1EN6)) {
                                 //線分abをaを中心にd度回転した線分を返す関数（元の線分は変えずに新しい線分を返す）public oc.Senbun_kaiten(Senbun s0,double d)
                                 LineSegment s_kiso = new LineSegment();
                                 LineSegment nboxLineSegment = nbox.getValue(i);
@@ -234,7 +235,7 @@ public class MouseHandlerFoldableLineInput extends BaseMouseHandlerInputRestrict
             case STEP_2: {//i_step_for_copy_4p==2であれば、以下でs_step[1]を入力折線を確定する
                 Point closest_point = d.getClosestPoint(p);
 
-                if (closest_point.distance(d.lineStep.get(0).getA()) < 0.00000001) {
+                if (Epsilon.high.le0(closest_point.distance(d.lineStep.get(0).getA()))) {
                     d.lineStep.clear();
                     d.lineCandidate.clear();
                     return;
@@ -243,7 +244,7 @@ public class MouseHandlerFoldableLineInput extends BaseMouseHandlerInputRestrict
                 if ((p.distance(d.lineStep.get(0).getB()) < d.selectionDistance) &&
                         (
                                 p.distance(d.lineStep.get(0).getB()) <= p.distance(closest_point)
-                                //moyori_ten.kyori(line_step[1].getb())<0.00000001
+                                //moyori_ten.kyori(line_step[1].getb())<Epsilon.UNKNOWN_1en8
                         )) {
                     LineSegment add_sen = new LineSegment(d.lineStep.get(0).getA(), d.lineStep.get(0).getB(), d.lineColor);
                     d.addLineSegment(add_sen);
@@ -282,7 +283,7 @@ public class MouseHandlerFoldableLineInput extends BaseMouseHandlerInputRestrict
                     Point kousa_point = new Point();
                     kousa_point.set(OritaCalc.findIntersection(d.lineStep.get(0), d.lineStep.get(1)));
                     LineSegment add_sen = new LineSegment(kousa_point, d.lineStep.get(0).getA(), d.lineColor);
-                    if (add_sen.determineLength() > 0.00000001) {//最寄の既存折線が有効の場合
+                    if (Epsilon.high.gt0(add_sen.determineLength())) {//最寄の既存折線が有効の場合
                         d.addLineSegment(add_sen);
                         d.record();
                         d.lineStep.clear();

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerInward.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerInward.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
@@ -33,15 +34,15 @@ public class MouseHandlerInward extends BaseMouseHandlerInputRestricted {
             center.set(OritaCalc.center(d.lineStep.get(0).getA(), d.lineStep.get(1).getA(), d.lineStep.get(2).getA()));
 
             LineSegment add_sen1 = new LineSegment(d.lineStep.get(0).getA(), center, d.lineColor);
-            if (add_sen1.determineLength() > 0.00000001) {
+            if (Epsilon.high.gt0(add_sen1.determineLength())) {
                 d.addLineSegment(add_sen1);
             }
             LineSegment add_sen2 = new LineSegment(d.lineStep.get(1).getA(), center, d.lineColor);
-            if (add_sen2.determineLength() > 0.00000001) {
+            if (Epsilon.high.gt0(add_sen2.determineLength())) {
                 d.addLineSegment(add_sen2);
             }
             LineSegment add_sen3 = new LineSegment(d.lineStep.get(2).getA(), center, d.lineColor);
-            if (add_sen3.determineLength() > 0.00000001) {
+            if (Epsilon.high.gt0(add_sen3.determineLength())) {
                 d.addLineSegment(add_sen3);
             }
             d.record();

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerLengthenCrease.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerLengthenCrease.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -71,7 +72,7 @@ public class MouseHandlerLengthenCrease extends BaseMouseHandler {
 
             for (int i = 1; i <= d.foldLineSet.getTotal(); i++) {
                 LineSegment s = d.foldLineSet.get(i);
-                LineSegment.Intersection i_lineSegment_intersection_decision = OritaCalc.determineLineSegmentIntersection(s, d.lineStep.get(0), 0.0001, 0.0001);
+                LineSegment.Intersection i_lineSegment_intersection_decision = OritaCalc.determineLineSegmentIntersection(s, d.lineStep.get(0), Epsilon.UNKNOWN_1EN4, Epsilon.UNKNOWN_1EN4);
                 boolean i_jikkou = i_lineSegment_intersection_decision == LineSegment.Intersection.INTERSECTS_1;
 
                 if (i_jikkou) {
@@ -80,7 +81,7 @@ public class MouseHandlerLengthenCrease extends BaseMouseHandler {
                 }
             }
 
-            if ((entyou_kouho_nbox.getTotal() == 0) && (d.lineStep.get(0).determineLength() <= 0.000001)) {//延長する候補になる折線を選ぶために描いた線分s_step[1]が点状のときの処理
+            if ((entyou_kouho_nbox.getTotal() == 0) && (d.lineStep.get(0).determineLength() <= Epsilon.UNKNOWN_1EN6)) {//延長する候補になる折線を選ぶために描いた線分s_step[1]が点状のときの処理
                 if (OritaCalc.determineLineSegmentDistance(p, closestLineSegment) < d.selectionDistance) {
                     WeightedValue<LineSegment> i_d = new WeightedValue<>(d.foldLineSet.closestLineSegmentSearch(p), 1.0);//entyou_kouho_nboxに1本の情報しか入らないのでdoubleの部分はどうでもよいので適当に1.0にした。
                     entyou_kouho_nbox.container_i_smallest_first(i_d);
@@ -88,9 +89,9 @@ public class MouseHandlerLengthenCrease extends BaseMouseHandler {
                     d.lineStep.get(0).setB(OritaCalc.findLineSymmetryPoint(closestLineSegment.getA(), closestLineSegment.getB(), p));
 
                     d.lineStep.get(0).set(//lineStep.get(0)を短くして、表示時に目立たない様にする。
-                            OritaCalc.point_double(OritaCalc.midPoint(d.lineStep.get(0).getA(), d.lineStep.get(0).getB()), d.lineStep.get(0).getA(), 0.00001 / d.lineStep.get(0).determineLength())
+                            OritaCalc.point_double(OritaCalc.midPoint(d.lineStep.get(0).getA(), d.lineStep.get(0).getB()), d.lineStep.get(0).getA(), Epsilon.UNKNOWN_1EN5 / d.lineStep.get(0).determineLength())
                             ,
-                            OritaCalc.point_double(OritaCalc.midPoint(d.lineStep.get(0).getA(), d.lineStep.get(0).getB()), d.lineStep.get(0).getB(), 0.00001 / d.lineStep.get(0).determineLength())
+                            OritaCalc.point_double(OritaCalc.midPoint(d.lineStep.get(0).getA(), d.lineStep.get(0).getB()), d.lineStep.get(0).getB(), Epsilon.UNKNOWN_1EN5 / d.lineStep.get(0).determineLength())
                     );
 
                 }
@@ -130,7 +131,7 @@ public class MouseHandlerLengthenCrease extends BaseMouseHandler {
                 //最初に選んだ延長候補線分群中に2番目に選んだ線分と等しいものがあるかどうかを判断する。
                 boolean i_senbun_entyou_mode = false;// i_senbun_entyou_mode=0なら最初に選んだ延長候補線分群中に2番目に選んだ線分と等しいものがない。1ならある。
                 for (int i = 1; i <= entyou_kouho_nbox.getTotal(); i++) {
-                    if (OritaCalc.determineLineSegmentIntersection(entyou_kouho_nbox.getValue(i), closestLineSegment, 0.000001, 0.000001) == LineSegment.Intersection.PARALLEL_EQUAL_31) {//線分が同じならoc.senbun_kousa_hantei==31
+                    if (OritaCalc.determineLineSegmentIntersection(entyou_kouho_nbox.getValue(i), closestLineSegment, Epsilon.UNKNOWN_1EN6, Epsilon.UNKNOWN_1EN6) == LineSegment.Intersection.PARALLEL_EQUAL_31) {//線分が同じならoc.senbun_kousa_hantei==31
                         i_senbun_entyou_mode = true;
                     }
                 }
@@ -142,7 +143,7 @@ public class MouseHandlerLengthenCrease extends BaseMouseHandler {
                     int sousuu_old = d.foldLineSet.getTotal();//(1)
                     for (int i = 1; i <= entyou_kouho_nbox.getTotal(); i++) {
                         //最初に選んだ線分と2番目に選んだ線分が平行でない場合
-                        if (OritaCalc.isLineSegmentParallel(entyou_kouho_nbox.getValue(i), closestLineSegment, 0.000001) == OritaCalc.ParallelJudgement.NOT_PARALLEL) { //２つの線分が平行かどうかを判定する関数。oc.heikou_hantei(Tyokusen t1,Tyokusen t2)//0=平行でない
+                        if (OritaCalc.isLineSegmentParallel(entyou_kouho_nbox.getValue(i), closestLineSegment, Epsilon.UNKNOWN_1EN6) == OritaCalc.ParallelJudgement.NOT_PARALLEL) { //２つの線分が平行かどうかを判定する関数。oc.heikou_hantei(Tyokusen t1,Tyokusen t2)//0=平行でない
                             //line_step[1]とs_step[2]の交点はoc.kouten_motome(Senbun s1,Senbun s2)で求める//２つの線分を直線とみなして交点を求める関数。線分としては交差しなくても、直線として交差している場合の交点を返す
                             Point kousa_point = new Point();
                             kousa_point.set(OritaCalc.findIntersection(entyou_kouho_nbox.getValue(i), closestLineSegment));
@@ -151,7 +152,7 @@ public class MouseHandlerLengthenCrease extends BaseMouseHandler {
                             addLineSegment.setB(entyou_kouho_nbox.getValue(i).determineClosestEndpoint(kousa_point));
 
 
-                            if (addLineSegment.determineLength() > 0.00000001) {
+                            if (Epsilon.high.gt0(addLineSegment.determineLength())) {
                                 if (getMouseMode() == MouseMode.LENGTHEN_CREASE_5) {
                                     addLineSegment.setColor(d.lineColor);
                                 }
@@ -184,7 +185,7 @@ public class MouseHandlerLengthenCrease extends BaseMouseHandler {
                         addLineSegment.set(extendToIntersectionPoint_2(moto_no_sen));
 
 
-                        if (addLineSegment.determineLength() > 0.00000001) {
+                        if (Epsilon.high.gt0(addLineSegment.determineLength())) {
                             if (getMouseMode() == MouseMode.LENGTHEN_CREASE_5) {
                                 addLineSegment.setColor(d.lineColor);
                             }
@@ -224,13 +225,13 @@ public class MouseHandlerLengthenCrease extends BaseMouseHandler {
         for (int i = 1; i <= d.foldLineSet.getTotal(); i++) {
             i_intersection_flg = tyoku1.lineSegment_intersect_reverse_detail(d.foldLineSet.get(i));//0=この直線は与えられた線分と交差しない、1=X型で交差する、2=T型で交差する、3=線分は直線に含まれる。
 
-            //i_lineSegment_intersection_flg=oc.senbun_kousa_hantei_amai( add_sen,foldLineSet.get(i),0.00001,0.00001);//20180408なぜかこの行の様にadd_senを使うと、i_senbun_kousa_flgがおかしくなる
-            i_lineSegment_intersection_flg = OritaCalc.determineLineSegmentIntersectionSweet(s0, d.foldLineSet.get(i), 0.00001, 0.00001);//20180408なぜかこの行の様にs0のままだと、i_senbun_kousa_flgがおかしくならない。
+            //i_lineSegment_intersection_flg=oc.senbun_kousa_hantei_amai( add_sen,foldLineSet.get(i),Epsilon.UNKNOWN_000001,Epsilon.UNKNOWN_000001);//20180408なぜかこの行の様にadd_senを使うと、i_senbun_kousa_flgがおかしくなる
+            i_lineSegment_intersection_flg = OritaCalc.determineLineSegmentIntersectionSweet(s0, d.foldLineSet.get(i), Epsilon.UNKNOWN_1EN5, Epsilon.UNKNOWN_1EN5);//20180408なぜかこの行の様にs0のままだと、i_senbun_kousa_flgがおかしくならない。
             if (i_intersection_flg.isIntersecting()) {
                 if (!i_lineSegment_intersection_flg.isEndpointIntersection()) {
                     //System.out.println("i_intersection_flg = "+i_intersection_flg  +      " ; i_lineSegment_intersection_flg = "+i_lineSegment_intersection_flg);
                     kousa_point.set(OritaCalc.findIntersection(tyoku1, d.foldLineSet.get(i)));
-                    if (kousa_point.distance(add_sen.getA()) > 0.00001) {
+                    if (kousa_point.distance(add_sen.getA()) > Epsilon.UNKNOWN_1EN5) {
                         if (kousa_point.distance(add_sen.getA()) < kousa_point_distance) {
                             double d_kakudo = OritaCalc.angle(add_sen.getA(), add_sen.getB(), add_sen.getA(), kousa_point);
                             if (d_kakudo < 1.0 || d_kakudo > 359.0) {
@@ -250,7 +251,7 @@ public class MouseHandlerLengthenCrease extends BaseMouseHandler {
 
 
                     kousa_point.set(d.foldLineSet.get(i).getA());
-                    if (kousa_point.distance(add_sen.getA()) > 0.00001) {
+                    if (kousa_point.distance(add_sen.getA()) > Epsilon.UNKNOWN_1EN5) {
                         if (kousa_point.distance(add_sen.getA()) < kousa_point_distance) {
                             double d_kakudo = OritaCalc.angle(add_sen.getA(), add_sen.getB(), add_sen.getA(), kousa_point);
                             if (d_kakudo < 1.0 || d_kakudo > 359.0) {
@@ -261,7 +262,7 @@ public class MouseHandlerLengthenCrease extends BaseMouseHandler {
                     }
 
                     kousa_point.set(d.foldLineSet.get(i).getB());
-                    if (kousa_point.distance(add_sen.getA()) > 0.00001) {
+                    if (kousa_point.distance(add_sen.getA()) > Epsilon.UNKNOWN_1EN5) {
                         if (kousa_point.distance(add_sen.getA()) < kousa_point_distance) {
                             double d_kakudo = OritaCalc.angle(add_sen.getA(), add_sen.getB(), add_sen.getA(), kousa_point);
                             if (d_kakudo < 1.0 || d_kakudo > 359.0) {

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerLineSegmentDelete.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerLineSegmentDelete.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
@@ -24,7 +25,7 @@ public class MouseHandlerLineSegmentDelete extends BaseMouseHandlerBoxSelect {
         d.lineStep.clear();
 
         //最寄の一つを削除
-        if (selectionStart.distance(p0) <= 0.000001) {//最寄の一つを削除
+        if (selectionStart.distance(p0) <= Epsilon.UNKNOWN_1EN6) {//最寄の一つを削除
             int i_removal_mode;//i_removal_mode is defined and declared here
             switch (d.i_foldLine_additional) {
                 case POLY_LINE_0:
@@ -127,7 +128,7 @@ public class MouseHandlerLineSegmentDelete extends BaseMouseHandlerBoxSelect {
 
 
         //四角枠内の削除 //p19_1はselectの最初のTen。この条件は最初のTenと最後の点が遠いので、四角を発生させるということ。
-        if (selectionStart.distance(p0) > 0.000001) {
+        if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {
             if ((d.i_foldLine_additional == FoldLineAdditionalInputMode.POLY_LINE_0) || (d.i_foldLine_additional == FoldLineAdditionalInputMode.BOTH_4)) { //折線の削除	//D_nisuru(selectionStart,p0)で折線だけが削除される。
                 if (d.deleteInside_foldingLine(selectionStart, p0)) {
                     d.organizeCircles();
@@ -160,18 +161,18 @@ public class MouseHandlerLineSegmentDelete extends BaseMouseHandlerBoxSelect {
         }
 
 //qqqqqqqqqqqqqqqqqqqqqqqqqqqqq//System.out.println("= ");qqqqq
-//check4(0.0001);//D_nisuru0をすると、foldLineSet.D_nisuru0内でresetが実行されるため、check4のやり直しが必要。
+//check4(Epsilon.UNKNOWN_00001);//D_nisuru0をすると、foldLineSet.D_nisuru0内でresetが実行されるため、check4のやり直しが必要。
         if (d.check1) {
-            d.check1(0.001, 0.5);
+            d.check1();
         }
         if (d.check2) {
-            d.check2(0.01, 0.5);
+            d.check2();
         }
         if (d.check3) {
-            d.check3(0.0001);
+            d.check3();
         }
         if (d.check4) {
-            d.check4(0.0001);
+            d.check4();
         }
 
     }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerLineSegmentDivision.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerLineSegmentDivision.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
@@ -54,7 +55,7 @@ public class MouseHandlerLineSegmentDivision extends BaseMouseHandlerInputRestri
         if (p.distance(closestPoint) <= d.selectionDistance) {
             d.lineStep.get(0).setA(closestPoint);
         }
-        if (d.lineStep.get(0).determineLength() > 0.00000001) {
+        if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
             for (int i = 0; i <= d.foldLineDividingNumber - 1; i++) {
                 double ax = ((double) (d.foldLineDividingNumber - i) * d.lineStep.get(0).determineAX() + (double) i * d.lineStep.get(0).determineBX()) / ((double) d.foldLineDividingNumber);
                 double ay = ((double) (d.foldLineDividingNumber - i) * d.lineStep.get(0).determineAY() + (double) i * d.lineStep.get(0).determineBY()) / ((double) d.foldLineDividingNumber);

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerLineSegmentRatioSet.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerLineSegmentRatioSet.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
@@ -60,7 +61,7 @@ public class MouseHandlerLineSegmentRatioSet extends BaseMouseHandlerInputRestri
         if (p.distance(closestPoint) <= d.selectionDistance) {
             d.lineStep.get(0).setA(closestPoint);
         }
-        if (d.lineStep.get(0).determineLength() > 0.00000001) {
+        if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
             if ((d.internalDivisionRatio_s == 0.0) && (d.internalDivisionRatio_t == 0.0)) {
             }
             if ((d.internalDivisionRatio_s == 0.0) && (d.internalDivisionRatio_t != 0.0)) {

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerModifyCalculatedShape.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerModifyCalculatedShape.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.FoldingException;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.App;
@@ -71,7 +72,7 @@ public class MouseHandlerModifyCalculatedShape implements MouseModeHandler {
             app.OZ.displayStyle = app.OZ.display_flg_backup;//20180216
 
             app.OZ.cp_worker2.mReleased_selectedPoint_move_with_camera(move_previous_selection_point, p_m_left_on, p, app.OZ.ip4);
-            if (p_m_left_on.distance(p) > 0.0000001) {
+            if (p_m_left_on.distance(p) > Epsilon.UNKNOWN_1EN7) {
                 app.OZ.record();
                 app.OZ.estimationStep = FoldedFigure.EstimationStep.STEP_2;
 
@@ -93,7 +94,7 @@ public class MouseHandlerModifyCalculatedShape implements MouseModeHandler {
             Point ps = new Point();
             ps.set(app.OZ.cp_worker2.getPoint(i_closestPointId));
             for (int i = 1; i <= app.OZ.cp_worker2.getPointsTotal(); i++) {
-                if (ps.distance(app.OZ.cp_worker2.getPoint(i)) < 0.0000001) {
+                if (ps.distance(app.OZ.cp_worker2.getPoint(i)) < Epsilon.UNKNOWN_1EN7) {
                     app.OZ.cp_worker1.setPointStateTrue(i);
                 }
             }
@@ -110,7 +111,7 @@ public class MouseHandlerModifyCalculatedShape implements MouseModeHandler {
 
         if (i_nanini_near == 2) {
             app.OZ.cp_worker2.mReleased_selectedPoint_move_with_camera(move_previous_selection_point, p_m_left_on, p, app.OZ.ip4);
-            if (p_m_left_on.distance(p) > 0.0000001) {
+            if (p_m_left_on.distance(p) > Epsilon.UNKNOWN_1EN7) {
                 app.OZ.record();
                 app.OZ.estimationStep = FoldedFigure.EstimationStep.STEP_2;
 
@@ -132,7 +133,7 @@ public class MouseHandlerModifyCalculatedShape implements MouseModeHandler {
             Point ps = new Point();
             ps.set(app.OZ.cp_worker2.getPoint(i_closestPointId));
             for (int i = 1; i <= app.OZ.cp_worker2.getPointsTotal(); i++) {
-                if (ps.distance(app.OZ.cp_worker2.getPoint(i)) < 0.0000001) {
+                if (ps.distance(app.OZ.cp_worker2.getPoint(i)) < Epsilon.UNKNOWN_1EN7) {
                     app.OZ.cp_worker1.setPointStateTrue(i);
                 }
             }
@@ -181,7 +182,7 @@ public class MouseHandlerModifyCalculatedShape implements MouseModeHandler {
                     Point ps = new Point();
                     ps.set(app.OZ.cp_worker2.getPoint(i_closestPointId));
                     for (int i = 1; i <= app.OZ.cp_worker2.getPointsTotal(); i++) {
-                        if (ps.distance(app.OZ.cp_worker2.getPoint(i)) < 0.0000001) {
+                        if (ps.distance(app.OZ.cp_worker2.getPoint(i)) < Epsilon.UNKNOWN_1EN7) {
                             app.OZ.cp_worker1.setPointStateTrue(i);
                         }
                     }
@@ -212,7 +213,7 @@ public class MouseHandlerModifyCalculatedShape implements MouseModeHandler {
                     Point ps = new Point();
                     ps.set(app.OZ.cp_worker2.getPoint(i_closestPointId));
                     for (int i = 1; i <= app.OZ.cp_worker2.getPointsTotal(); i++) {
-                        if (ps.distance(app.OZ.cp_worker2.getPoint(i)) < 0.0000001) {
+                        if (ps.distance(app.OZ.cp_worker2.getPoint(i)) < Epsilon.UNKNOWN_1EN7) {
                             app.OZ.cp_worker1.setPointStateTrue(i);
                         }
                     }
@@ -301,7 +302,7 @@ public class MouseHandlerModifyCalculatedShape implements MouseModeHandler {
                     Point ps = new Point();
                     ps.set(app.OZ.cp_worker2.getPoint(i_closestPointId));
                     for (int i = 1; i <= app.OZ.cp_worker2.getPointsTotal(); i++) {
-                        if (ps.distance(app.OZ.cp_worker2.getPoint(i)) < 0.0000001) {
+                        if (ps.distance(app.OZ.cp_worker2.getPoint(i)) < Epsilon.UNKNOWN_1EN7) {
                             app.OZ.cp_worker1.setPointStateTrue(i);
                         }
                     }
@@ -332,7 +333,7 @@ public class MouseHandlerModifyCalculatedShape implements MouseModeHandler {
                     Point ps = new Point();
                     ps.set(app.OZ.cp_worker2.getPoint(i_closestPointId));
                     for (int i = 1; i <= app.OZ.cp_worker2.getPointsTotal(); i++) {
-                        if (ps.distance(app.OZ.cp_worker2.getPoint(i)) < 0.0000001) {
+                        if (ps.distance(app.OZ.cp_worker2.getPoint(i)) < Epsilon.UNKNOWN_1EN7) {
                             app.OZ.cp_worker1.setPointStateTrue(i);
                         }
                     }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerParallelDraw.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerParallelDraw.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -80,24 +81,24 @@ public class MouseHandlerParallelDraw extends BaseMouseHandlerInputRestricted {
 
         Point cross_point = new Point();
 
-        if (OritaCalc.isLineSegmentParallel(s_o, s_k, 0.0000001) == OritaCalc.ParallelJudgement.PARALLEL_NOT_EQUAL) {//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
+        if (OritaCalc.isLineSegmentParallel(s_o, s_k, Epsilon.UNKNOWN_1EN7) == OritaCalc.ParallelJudgement.PARALLEL_NOT_EQUAL) {//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
             return -500;
         }
 
-        if (OritaCalc.isLineSegmentParallel(s_o, s_k, 0.0000001) == OritaCalc.ParallelJudgement.PARALLEL_EQUAL) {//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
+        if (OritaCalc.isLineSegmentParallel(s_o, s_k, Epsilon.UNKNOWN_1EN7) == OritaCalc.ParallelJudgement.PARALLEL_EQUAL) {//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
             cross_point.set(s_k.getA());
             if (OritaCalc.distance(s_o.getA(), s_k.getA()) > OritaCalc.distance(s_o.getA(), s_k.getB())) {
                 cross_point.set(s_k.getB());
             }
         }
 
-        if (OritaCalc.isLineSegmentParallel(s_o, s_k, 0.0000001) == OritaCalc.ParallelJudgement.NOT_PARALLEL) {//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
+        if (OritaCalc.isLineSegmentParallel(s_o, s_k, Epsilon.UNKNOWN_1EN7) == OritaCalc.ParallelJudgement.NOT_PARALLEL) {//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
             cross_point.set(OritaCalc.findIntersection(s_o, s_k));
         }
 
         LineSegment add_sen = new LineSegment(cross_point, s_o.getA(), icolo);
 
-        if (add_sen.determineLength() > 0.00000001) {
+        if (Epsilon.high.gt0(add_sen.determineLength())) {
             d.lineStep.get(i_e_d).set(add_sen);
             return 1;
         }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerParallelDrawWidth.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerParallelDrawWidth.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -90,7 +91,7 @@ public class MouseHandlerParallelDrawWidth extends BaseMouseHandler {
 
             d.lineStep.get(1).setA(closest_point);
 
-            if (d.lineStep.get(1).determineLength() < 0.00000001) {
+            if (Epsilon.high.le0(d.lineStep.get(1).determineLength())) {
                 d.lineStep.remove(3);
                 d.lineStep.remove(2);
                 d.lineStep.remove(1);

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerPerpendicularDraw.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerPerpendicularDraw.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -56,7 +57,7 @@ public class MouseHandlerPerpendicularDraw extends BaseMouseHandlerInputRestrict
             //直線t上の点pの影の位置（点pと最も近い直線t上の位置）を求める。public Ten oc.kage_motome(Tyokusen t,Ten p){
 
             LineSegment add_sen = new LineSegment(d.lineStep.get(0).getA(), OritaCalc.findProjection(OritaCalc.lineSegmentToStraightLine(d.lineStep.get(1)), d.lineStep.get(0).getA()), d.lineColor);
-            if (add_sen.determineLength() > 0.00000001) {
+            if (Epsilon.high.gt0(add_sen.determineLength())) {
                 d.addLineSegment(add_sen);
                 d.record();
             }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerPolygonSetNoCorners.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerPolygonSetNoCorners.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -52,7 +53,7 @@ public class MouseHandlerPolygonSetNoCorners extends BaseMouseHandler {
                 d.lineStepAdd(new LineSegment(closestPoint, closestPoint, LineColor.fromNumber(d.lineStep.size() + 1)));
                 d.lineStep.get(0).setB(d.lineStep.get(1).getB());
             }
-            if (d.lineStep.get(0).determineLength() < 0.00000001) {
+            if (Epsilon.high.le0(d.lineStep.get(0).determineLength())) {
                 d.lineStep.clear();
             }
         }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerSelectLineIntersecting.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerSelectLineIntersecting.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
 
@@ -20,7 +21,7 @@ public class MouseHandlerSelectLineIntersecting extends BaseMouseHandlerLineSele
         if (p.distance(closestPoint) <= d.selectionDistance) {
             d.lineStep.get(0).setA(closestPoint);
         }
-        if (d.lineStep.get(0).determineLength() > 0.00000001) {
+        if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
             //やりたい動作はここに書く
             d.foldLineSet.select_lX(d.lineStep.get(0), "select_lX");//lXは小文字のエルと大文字のエックス
         }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerSquareBisector.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerSquareBisector.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -59,7 +60,7 @@ public class MouseHandlerSquareBisector extends BaseMouseHandlerInputRestricted 
             cross_point.set(OritaCalc.findIntersection(add_sen2, d.lineStep.get(3)));
 
             LineSegment add_sen = new LineSegment(cross_point, d.lineStep.get(1).getA(), d.lineColor);
-            if (add_sen.determineLength() > 0.00000001) {
+            if (Epsilon.high.gt0(add_sen.determineLength())) {
                 d.addLineSegment(add_sen);
                 d.record();
             }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerSymmetricDraw.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerSymmetricDraw.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
@@ -42,7 +43,7 @@ public class MouseHandlerSymmetricDraw extends BaseMouseHandlerInputRestricted {
 
             add_sen.set(d.extendToIntersectionPoint(add_sen));
             add_sen.setColor(d.lineColor);
-            if (add_sen.determineLength() > 0.00000001) {
+            if (Epsilon.high.gt0(add_sen.determineLength())) {
                 d.addLineSegment(add_sen);
                 d.record();
             }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerUnselectLineIntersecting.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerUnselectLineIntersecting.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
 
@@ -19,7 +20,7 @@ public class MouseHandlerUnselectLineIntersecting extends BaseMouseHandlerLineSe
         if (p.distance(closestPoint) <= d.selectionDistance) {
             d.lineStep.get(0).setA(closestPoint);
         }
-        if (d.lineStep.get(0).determineLength() > 0.00000001) {
+        if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
             //やりたい動作はここに書く
             d.foldLineSet.select_lX(d.lineStep.get(0), "unselect_lX");//lXは小文字のエルと大文字のエックス
         }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerVertexDeleteOnCrease.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerVertexDeleteOnCrease.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.element.Point;
 import origami_editor.editor.MouseMode;
 
@@ -21,7 +22,7 @@ public class MouseHandlerVertexDeleteOnCrease extends BaseMouseHandler {
 
         //点pに最も近い線分の、点pに近い方の端点を、頂点とした場合、何本の線分が出ているか（頂点とr以内に端点がある線分の数）	public int tyouten_syuui_sennsuu(Ten p) {
 
-        d.foldLineSet.del_V_cc(p, d.selectionDistance, 0.000001);
+        d.foldLineSet.del_V_cc(p, d.selectionDistance, Epsilon.UNKNOWN_1EN6);
 
         d.record();
     }

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerVertexMakeAngularlyFlatFoldable.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerVertexMakeAngularlyFlatFoldable.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
@@ -73,7 +74,7 @@ public class MouseHandlerVertexMakeAngularlyFlatFoldable extends BaseMouseHandle
 
         switch (i_step_for_move_4p) {
             case STEP_0:
-                double hantei_kyori = 0.000001;
+                double decision_distance = Epsilon.UNKNOWN_1EN6;
 
                 Point t1 = new Point();
                 t1.set(d.foldLineSet.closestPointOfFoldLine(p));//点pに最も近い、「線分の端点」を返すori_s.mottomo_tikai_Tenは近い点がないと p_return.set(100000.0,100000.0)と返してくる
@@ -85,9 +86,9 @@ public class MouseHandlerVertexMakeAngularlyFlatFoldable extends BaseMouseHandle
                     for (int i = 1; i <= d.foldLineSet.getTotal(); i++) {
                         LineSegment s = d.foldLineSet.get(i);
                         if (s.getColor().isFoldingLine()) {
-                            if (t1.distance(s.getA()) < hantei_kyori) {
+                            if (t1.distance(s.getA()) < decision_distance) {
                                 nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getA(), s.getB())));
-                            } else if (t1.distance(s.getB()) < hantei_kyori) {
+                            } else if (t1.distance(s.getB()) < decision_distance) {
                                 nbox.container_i_smallest_first(new WeightedValue<>(s, OritaCalc.angle(s.getB(), s.getA())));
                             }
                         }
@@ -142,15 +143,15 @@ public class MouseHandlerVertexMakeAngularlyFlatFoldable extends BaseMouseHandle
                                 add_kakudo_1 = 360.0;
                             }
 
-                            if ((kakukagenti / 2.0 > 0.0 + 0.000001) && (kakukagenti / 2.0 < add_kakudo_1 - 0.000001)) {
-                                //if((kakukagenti/2.0>0.0-0.000001)&&(kakukagenti/2.0<add_kakudo_1+0.000001)){
+                            if ((kakukagenti / 2.0 > 0.0 + Epsilon.UNKNOWN_1EN6) && (kakukagenti / 2.0 < add_kakudo_1 - Epsilon.UNKNOWN_1EN6)) {
+                                //if((kakukagenti/2.0>0.0-Epsilon.UNKNOWN_0000001)&&(kakukagenti/2.0<add_kakudo_1+Epsilon.UNKNOWN_0000001)){
 
                                 //線分abをaを中心にd度回転した線分を返す関数（元の線分は変えずに新しい線分を返す）public oc.Senbun_kaiten(Senbun s0,double d)
                                 LineSegment s_kiso = new LineSegment();
                                 LineSegment nboxLineSegment = nbox.getValue(i);
-                                if (t1.distance(nboxLineSegment.getA()) < hantei_kyori) {
+                                if (t1.distance(nboxLineSegment.getA()) < decision_distance) {
                                     s_kiso.set(nboxLineSegment.getA(), nboxLineSegment.getB());
-                                } else if (t1.distance(nboxLineSegment.getB()) < hantei_kyori) {
+                                } else if (t1.distance(nboxLineSegment.getB()) < decision_distance) {
                                     s_kiso.set(nboxLineSegment.getB(), nboxLineSegment.getA());
                                 }
 
@@ -214,7 +215,7 @@ public class MouseHandlerVertexMakeAngularlyFlatFoldable extends BaseMouseHandle
                     Point kousa_point = new Point();
                     kousa_point.set(OritaCalc.findIntersection(d.lineStep.get(0), d.lineStep.get(1)));
                     LineSegment add_sen = new LineSegment(kousa_point, d.lineStep.get(0).getA(), icol_temp);//20180503変更
-                    if (add_sen.determineLength() > 0.00000001) {//最寄の既存折線が有効の場合
+                    if (Epsilon.high.gt0(add_sen.determineLength())) {//最寄の既存折線が有効の場合
                         d.addLineSegment(add_sen);
                         d.record();
                         d.lineStep.clear();

--- a/src/main/java/origami_editor/editor/canvas/MouseHandlerVoronoiCreate.java
+++ b/src/main/java/origami_editor/editor/canvas/MouseHandlerVoronoiCreate.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas;
 
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.*;
 import origami_editor.editor.MouseMode;
@@ -216,7 +217,7 @@ public class MouseHandlerVoronoiCreate extends BaseMouseHandler {
     List<LineSegment> s_step_no_1_top_continue_no_point_no_number() {//line_step [i] returns the number of Point (length 0) from the beginning. Returns 0 if there are no dots
         List<LineSegment> lineSegments = new ArrayList<>();
         for (LineSegment s : d.lineStep) {
-            if (s.determineLength() > 0.00000001) {
+            if (Epsilon.high.gt0(s.determineLength())) {
                 break;
             }
             lineSegments.add(s);
@@ -351,7 +352,7 @@ public class MouseHandlerVoronoiCreate extends BaseMouseHandler {
 
             //Fight the line segment to be added with the existing line segment
 
-            OritaCalc.ParallelJudgement parallel = OritaCalc.isLineSegmentParallel(add_straightLine, existing_straightLine, 0.0001);//0 = not parallel, 1 = parallel and 2 straight lines do not match, 2 = parallel and 2 straight lines match
+            OritaCalc.ParallelJudgement parallel = OritaCalc.isLineSegmentParallel(add_straightLine, existing_straightLine, Epsilon.UNKNOWN_1EN4);//0 = not parallel, 1 = parallel and 2 straight lines do not match, 2 = parallel and 2 straight lines match
 
             Point a = d.lineStep.get(center_point_count).getA();
             if (parallel == OritaCalc.ParallelJudgement.NOT_PARALLEL) {//When the line segment to be added and the existing line segment are non-parallel
@@ -364,7 +365,7 @@ public class MouseHandlerVoronoiCreate extends BaseMouseHandler {
                 } else if ((add_straightLine.sameSide(a, existing_lineSegment.getA()) == 1) &&
                         (add_straightLine.sameSide(a, existing_lineSegment.getB()) == -1)) {
                     existing_lineSegment.set(existing_lineSegment.getA(), intersection);
-                    if (existing_lineSegment.determineLength() < 0.0000001) {
+                    if (existing_lineSegment.determineLength() < Epsilon.UNKNOWN_1EN7) {
                         lineSegment_voronoi_onePoint.remove(i);
                     } else {
                         lineSegment_voronoi_onePoint.set(i, existing_lineSegment);
@@ -372,7 +373,7 @@ public class MouseHandlerVoronoiCreate extends BaseMouseHandler {
                 } else if ((add_straightLine.sameSide(a, existing_lineSegment.getA()) == -1) &&
                         (add_straightLine.sameSide(a, existing_lineSegment.getB()) == 1)) {
                     existing_lineSegment.set(intersection, existing_lineSegment.getB());
-                    if (existing_lineSegment.determineLength() < 0.0000001) {
+                    if (existing_lineSegment.determineLength() < Epsilon.UNKNOWN_1EN7) {
                         lineSegment_voronoi_onePoint.remove(i);
                     } else {
                         lineSegment_voronoi_onePoint.set(i, existing_lineSegment);
@@ -385,13 +386,13 @@ public class MouseHandlerVoronoiCreate extends BaseMouseHandler {
                 } else if ((existing_straightLine.sameSide(a, add_lineSegment.getA()) == 1) &&
                         (existing_straightLine.sameSide(a, add_lineSegment.getB()) == -1)) {
                     add_lineSegment.set(add_lineSegment.getA(), intersection);
-                    if (add_lineSegment.determineLength() < 0.0000001) {
+                    if (add_lineSegment.determineLength() < Epsilon.UNKNOWN_1EN7) {
                         return;
                     }
                 } else if ((existing_straightLine.sameSide(a, add_lineSegment.getA()) == -1) &&
                         (existing_straightLine.sameSide(a, add_lineSegment.getB()) == 1)) {
                     add_lineSegment.set(intersection, add_lineSegment.getB());
-                    if (add_lineSegment.determineLength() < 0.0000001) {
+                    if (add_lineSegment.determineLength() < Epsilon.UNKNOWN_1EN7) {
                         return;
                     }
                 }

--- a/src/main/java/origami_editor/editor/canvas/drawing_worker_toolbox/Drawing_Worker_Toolbox.java
+++ b/src/main/java/origami_editor/editor/canvas/drawing_worker_toolbox/Drawing_Worker_Toolbox.java
@@ -1,5 +1,6 @@
 package origami_editor.editor.canvas.drawing_worker_toolbox;
 
+import origami.Epsilon;
 import origami.crease_pattern.FoldLineSet;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineSegment;
@@ -38,7 +39,7 @@ public class Drawing_Worker_Toolbox {
 
                 cross_point.set(OritaCalc.findIntersection(straightLine, ori_s.get(i)));//A function that considers a line segment as a straight line and finds the intersection with another straight line. Even if it does not intersect as a line segment, it returns the intersection when it intersects as a straight line
 
-                if (cross_point.distance(addLine.getA()) > 0.00001) {
+                if (cross_point.distance(addLine.getA()) > Epsilon.UNKNOWN_1EN5) {
 
                     if (cross_point.distance(addLine.getA()) < crossPointDistance) {
                         double d_kakudo = OritaCalc.angle(addLine.getA(), addLine.getB(), addLine.getA(), cross_point);
@@ -86,7 +87,7 @@ public class Drawing_Worker_Toolbox {
 
                     kousa_point.set(OritaCalc.findIntersection(straightLine, ori_s.get(i)));//線分を直線とみなして他の直線との交点を求める関数。線分としては交差しなくても、直線として交差している場合の交点を返す
 
-                    if (kousa_point.distance(addLine.getA()) > 0.00001) {
+                    if (kousa_point.distance(addLine.getA()) > Epsilon.UNKNOWN_1EN5) {
 
                         if (kousa_point.distance(addLine.getA()) < kousa_point_distance) {
                             double d_kakudo = OritaCalc.angle(addLine.getA(), addLine.getB(), addLine.getA(), kousa_point);

--- a/src/main/java/origami_editor/editor/databinding/GridModel.java
+++ b/src/main/java/origami_editor/editor/databinding/GridModel.java
@@ -1,6 +1,7 @@
 package origami_editor.editor.databinding;
 
 import origami_editor.graphic2d.grid.Grid;
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 
 import java.awt.*;
@@ -269,13 +270,13 @@ public class GridModel implements Serializable {
     public void setGridAngle(final double gridAngle) {
         double oldAngle = this.gridAngle;
         double newAngle = gridAngle;
-        if (Math.abs(OritaCalc.angle_between_0_360(this.gridAngle)) < 0.1) {
+        if (Math.abs(OritaCalc.angle_between_0_360(this.gridAngle)) < Epsilon.UNKNOWN_01) {
             newAngle = 90.0;
         }
-        if (Math.abs(OritaCalc.angle_between_0_360(this.gridAngle - 180.0)) < 0.1) {
+        if (Math.abs(OritaCalc.angle_between_0_360(this.gridAngle - 180.0)) < Epsilon.UNKNOWN_01) {
             newAngle = 90.0;
         }
-        if (Math.abs(OritaCalc.angle_between_0_360(this.gridAngle - 360.0)) < 0.1) {
+        if (Math.abs(OritaCalc.angle_between_0_360(this.gridAngle - 360.0)) < Epsilon.UNKNOWN_01) {
             newAngle = 90.0;
         }
 
@@ -289,7 +290,7 @@ public class GridModel implements Serializable {
             return false;
         }
 
-        if (Math.abs(gridLength) < 0.0001) {
+        if (Math.abs(gridLength) < Epsilon.UNKNOWN_1EN4) {
             return false;
         }
 

--- a/src/main/java/origami_editor/editor/task/CheckCAMVTask.java
+++ b/src/main/java/origami_editor/editor/task/CheckCAMVTask.java
@@ -7,8 +7,6 @@ public class CheckCAMVTask implements Runnable{
     private final CreasePattern_Worker creasePattern_worker;
     private final Canvas canvas;
 
-    private final double CHECK4_R = 0.0001;
-
     public CheckCAMVTask(CreasePattern_Worker creasePattern_worker, Canvas canvas) {
         this.creasePattern_worker = creasePattern_worker;
         this.canvas = canvas;
@@ -19,7 +17,7 @@ public class CheckCAMVTask implements Runnable{
         long start = System.currentTimeMillis();
 
         try {
-            creasePattern_worker.ap_check4(CHECK4_R);
+            creasePattern_worker.ap_check4();
         } catch (InterruptedException e) {
             creasePattern_worker.foldLineSet.getCheck4LineSegments().clear();
         }

--- a/src/main/java/origami_editor/graphic2d/grid/Grid.java
+++ b/src/main/java/origami_editor/graphic2d/grid/Grid.java
@@ -2,6 +2,7 @@ package origami_editor.graphic2d.grid;
 
 import origami_editor.editor.databinding.GridModel;
 import origami.crease_pattern.element.LineSegment;
+import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.Point;
 import origami_editor.tools.Camera;
@@ -130,13 +131,13 @@ public class Grid {
 
     private void resetGrid() {
         if (baseState == State.WITHIN_PAPER) {
-            if (Math.abs(aGridLength - 1.0) > 0.000001) {
+            if (Math.abs(aGridLength - 1.0) > Epsilon.UNKNOWN_1EN6) {
                 setBaseState(State.FULL);
             }
-            if (Math.abs(bGridLength - 1.0) > 0.000001) {
+            if (Math.abs(bGridLength - 1.0) > Epsilon.UNKNOWN_1EN6) {
                 setBaseState(State.FULL);
             }
-            if (Math.abs(gridAngle - (-90.0)) > 0.000001) {
+            if (Math.abs(gridAngle - (-90.0)) > Epsilon.UNKNOWN_1EN6) {
                 setBaseState(State.FULL);
             }
         }
@@ -431,7 +432,7 @@ public class Grid {
     }
 
     private boolean isWithinPaper(Point t_tmp) {
-        return ((-200.000001 <= t_tmp.getX()) && (t_tmp.getX() <= 200.000001)) && ((-200.000001 <= t_tmp.getY()) && (t_tmp.getY() <= 200.000001));
+        return ((-200 - Epsilon.UNKNOWN_1EN6 <= t_tmp.getX()) && (t_tmp.getX() <= 200 + Epsilon.UNKNOWN_1EN6)) && ((-200 - Epsilon.UNKNOWN_1EN6 <= t_tmp.getY()) && (t_tmp.getY() <= 200 + Epsilon.UNKNOWN_1EN6));
     }
 
     public void setGridConfigurationData(GridModel gridModel) {


### PR DESCRIPTION
This PR gather all epsilon constants throughout the source code to one place, and setup a factor to increase their precision by 10x at once. This will solve the problem that the full Ryujin (without enlarging) cannot be folded. Essentially this fixes issue #36.