### PR TITLE
Selector system prototype

### DIFF
--- a/oriedita/src/main/java/oriedita/editor/Canvas.java
+++ b/oriedita/src/main/java/oriedita/editor/Canvas.java
@@ -184,7 +184,7 @@ public class Canvas extends JPanel implements MouseListener, MouseMotionListener
     public void addMouseModeHandler(MouseModeHandler handler) {
         mouseModeHandlers.put(handler.getMouseMode(), handler);
         if (handler instanceof BaseMouseHandler_WithSelector) {
-            ((BaseMouseHandler_WithSelector) handler).setupSelectors();
+            ((BaseMouseHandler_WithSelector) handler).setupAndCheckSelectors();
         }
     }
 

--- a/oriedita/src/main/java/oriedita/editor/Canvas.java
+++ b/oriedita/src/main/java/oriedita/editor/Canvas.java
@@ -1,9 +1,9 @@
 package oriedita.editor;
 
 import org.tinylog.Logger;
-import oriedita.editor.action.DrawingSettings;
 import oriedita.editor.action.MouseModeHandler;
 import oriedita.editor.action.selector.BaseMouseHandler_WithSelector;
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.canvas.CreasePattern_Worker;
 import oriedita.editor.canvas.LineStyle;
 import oriedita.editor.canvas.MouseMode;
@@ -273,7 +273,7 @@ public class Canvas extends JPanel implements MouseListener, MouseMotionListener
 
         //展開図表示
         mainCreasePatternWorker.drawWithCamera(bufferGraphics, displayComments, displayCpLines, displayAuxLines, displayLiveAuxLines, lineWidth, lineStyle, auxLineWidth, dim.width, dim.height, displayMarkings, hideOperationFrame);//渡す情報はカメラ設定、線幅、画面X幅、画面y高さ,展開図動かし中心の十字の目印の表示
-        DrawingSettings settings = new DrawingSettings(lineWidth, lineStyle, dim.height, dim.width);
+        DrawingSettings settings = new DrawingSettings(lineWidth, lineStyle, dim.height, dim.width, displayGridInputAssist);
         if (activeMouseHandler != null) {
             activeMouseHandler.drawPreview(g2, creasePatternCamera, settings);
         }

--- a/oriedita/src/main/java/oriedita/editor/Canvas.java
+++ b/oriedita/src/main/java/oriedita/editor/Canvas.java
@@ -3,6 +3,7 @@ package oriedita.editor;
 import org.tinylog.Logger;
 import oriedita.editor.action.DrawingSettings;
 import oriedita.editor.action.MouseModeHandler;
+import oriedita.editor.action.selector.BaseMouseHandler_WithSelector;
 import oriedita.editor.canvas.CreasePattern_Worker;
 import oriedita.editor.canvas.LineStyle;
 import oriedita.editor.canvas.MouseMode;
@@ -182,6 +183,9 @@ public class Canvas extends JPanel implements MouseListener, MouseMotionListener
 
     public void addMouseModeHandler(MouseModeHandler handler) {
         mouseModeHandlers.put(handler.getMouseMode(), handler);
+        if (handler instanceof BaseMouseHandler_WithSelector) {
+            ((BaseMouseHandler_WithSelector) handler).setupSelectors();
+        }
     }
 
     @Override

--- a/oriedita/src/main/java/oriedita/editor/action/BaseMouseHandlerBoxSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/action/BaseMouseHandlerBoxSelect.java
@@ -1,5 +1,6 @@
 package oriedita.editor.action;
 
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.drawing.tools.DrawingUtil;
 import origami.crease_pattern.element.LineColor;

--- a/oriedita/src/main/java/oriedita/editor/action/BaseMouseHandlerLineTransform.java
+++ b/oriedita/src/main/java/oriedita/editor/action/BaseMouseHandlerLineTransform.java
@@ -1,5 +1,6 @@
 package oriedita.editor.action;
 
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.databinding.CanvasModel;
 import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.drawing.tools.DrawingUtil;

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerAngleSystem.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerAngleSystem.java
@@ -1,42 +1,73 @@
 package oriedita.editor.action;
 
+import oriedita.editor.action.selector.*;
 import oriedita.editor.canvas.MouseMode;
-import oriedita.editor.drawing.tools.Camera;
-import oriedita.editor.drawing.tools.DrawingUtil;
 import origami.Epsilon;
-import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
-import origami.crease_pattern.element.LineSegment;
-import origami.crease_pattern.element.Point;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.awt.*;
-import java.util.List;
-import java.util.*;
+import java.util.EnumSet;
 
 @Singleton
-public class MouseHandlerAngleSystem extends BaseMouseHandlerInputRestricted {
-    Point pStart, pEnd;
-    List<LineSegment> candidates = new ArrayList<>();
-    LineSegment direction;
-    LineSegment previewLine;
-    Step currentStep = Step.SELECT_FIRST_POINT;
-    LineColor[] customAngleColors = new LineColor[] {
-            LineColor.ORANGE_4,
-            LineColor.GREEN_6,
-            LineColor.PURPLE_8
-    };
-
-    enum Step {
-        SELECT_FIRST_POINT,
-        SELECT_SECOND_POINT,
-        SELECT_DIRECTION,
-        SELECT_LENGTH
-    }
+public class MouseHandlerAngleSystem extends BaseMouseHandler_WithSelector {
+    CreasePatternPointSelector pStartSelector;
+    AngleSystemLineSetCalculator lineSetCalculator;
+    LineSelector candidateSelector;
+    LineExtender finalLineSelector;
 
     @Inject
     public MouseHandlerAngleSystem() {
+    }
+
+    @Override
+    public void setupSelectors() {
+        pStartSelector = registerStartingSelector(
+                new CreasePatternPointSelector(
+                        CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_ONLY,
+                        LineColor.RED_1
+                ),
+                () -> lineSetCalculator
+        );
+        lineSetCalculator = registerSelector(
+                new AngleSystemLineSetCalculator(
+                        pStartSelector::getSelection,
+                        new CreasePatternPointSelector(
+                                CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_OR_FREE,
+                                LineColor.BLUE_2
+                        )
+                ),
+                () -> candidateSelector
+        );
+        candidateSelector = registerSelector(
+                new LineSelector(
+                        lineSetCalculator::getSelection,
+                        LineColor.PURPLE_8,
+                        LineSelector.NoCloseLineValue.NONE
+                ),
+                () -> finalLineSelector);
+        candidateSelector.onFinish(lineSegment -> {
+            lineSetCalculator.setHidden(true);
+            candidateSelector.setHidden(true);
+        });
+
+        finalLineSelector = registerSelector(
+                new LineExtender(
+                        candidateSelector::getSelection,
+                        d::getLineColor,
+                        new LineSelector(
+                                d.foldLineSet::getLines,
+                                LineColor.GREEN_6,
+                                LineSelector.NoCloseLineValue.MOUSE_POS
+                        )
+                ), null
+        );
+        finalLineSelector.onFinish(lineSegment -> {
+            if (lineSegment != null && Epsilon.high.gt0(lineSegment.determineLength())) {
+                d.addLineSegment(lineSegment);
+                d.record();
+            }
+        });
     }
 
     @Override
@@ -47,198 +78,5 @@ public class MouseHandlerAngleSystem extends BaseMouseHandlerInputRestricted {
     @Override
     public EnumSet<Feature> getSubscribedFeatures() {
         return EnumSet.of(Feature.BUTTON_1);
-    }
-
-    public void mouseMoved(Point p0) {
-        super.mouseMoved(p0);
-        Point p = d.camera.TV2object(p0);
-        switch (currentStep) {
-            case SELECT_FIRST_POINT:
-                pStart = d.getClosestPoint(p);
-                break;
-            case SELECT_SECOND_POINT:
-                pEnd = determinePEnd(p);
-                candidates = makePreviewLines(pStart, pEnd);
-                break;
-            case SELECT_DIRECTION:
-                direction = determineSelectedCandidate(p);
-                break;
-            case SELECT_LENGTH:
-                previewLine = determineLineSegmentForPreview(p);
-                break;
-        }
-    }
-
-    private Point determinePEnd(Point p) {
-        Point previewPEnd = d.getClosestPoint(p);
-        if (previewPEnd.distance(p) >= d.selectionDistance) {
-            previewPEnd = p;
-        }
-        return previewPEnd;
-    }
-
-    //マウス操作(ボタンを押したとき)時の作業
-    public void mousePressed(Point p0) {
-        Point p = new Point();
-        p.set(d.camera.TV2object(p0));
-
-        // Apply values from mouseMoved
-        switch (currentStep) {
-            case SELECT_FIRST_POINT:
-                pStart = d.getClosestPoint(p);
-                currentStep = Step.SELECT_SECOND_POINT;
-                return;
-            case SELECT_SECOND_POINT:
-                pEnd = determinePEnd(p);
-                candidates = makePreviewLines(pStart, pEnd);
-                if (pEnd.distance(p) >= d.selectionDistance) {
-                    return;
-                }
-                currentStep = Step.SELECT_DIRECTION;
-                return;
-            case SELECT_DIRECTION:
-                direction = determineSelectedCandidate(p);
-                currentStep = Step.SELECT_LENGTH;
-                if (direction == null) {
-                    reset();
-                } else {
-                    candidates.clear();
-                }
-                return;
-            case SELECT_LENGTH:
-                LineSegment add_sen = determineLineSegmentToAdd(p);
-
-                if (add_sen != null && Epsilon.high.gt0(add_sen.determineLength())) {
-                    d.addLineSegment(add_sen);
-                    d.record();
-                }
-                reset();
-        }
-    }
-
-    private LineSegment determineLineSegmentForPreview(Point p) {
-        LineSegment ls = determineLineSegmentToAdd(p);
-        if (ls == null) {
-            Point newEndPoint = OritaCalc.findProjection(direction, p);
-            return new LineSegment(newEndPoint, pEnd, d.lineColor);
-        }
-        return ls;
-    }
-
-    private LineSegment determineLineSegmentToAdd(Point p) {
-        LineSegment closestLineSegment = d.getClosestLineSegment(p);
-        if (OritaCalc.determineLineSegmentDistance(p, closestLineSegment) < d.selectionDistance) {
-            LineSegment s = new LineSegment();
-            s.set(closestLineSegment);
-            s.setColor(LineColor.GREEN_6);
-            Point startingPoint = new Point();
-            startingPoint.set(OritaCalc.findIntersection(s, direction));
-            return new LineSegment(startingPoint, pEnd, d.lineColor);
-        }
-        return null;
-    }
-
-    private LineSegment determineSelectedCandidate(Point p) {
-        Optional<LineSegment> closestLineSegmentO = candidates.stream()
-                .min(Comparator.comparingDouble(cand -> OritaCalc.determineLineSegmentDistance(p, cand)));
-        if (closestLineSegmentO.isPresent()) {
-            LineSegment closestLineSegment = closestLineSegmentO.get();
-            if (OritaCalc.determineLineSegmentDistance(p, closestLineSegment) < d.selectionDistance) {
-                LineSegment s = new LineSegment();
-                s.set(closestLineSegment);
-                s.setColor(LineColor.BLUE_2);
-                return s;
-            }
-        }
-        return null;
-    }
-
-    private List<LineSegment> makePreviewLines(Point pStart, Point pEnd) {
-        List<LineSegment> candidates = new ArrayList<>();
-        int numPreviewLines;//1つの端点周りに描く線の本数
-        if (d.id_angle_system != 0) {
-            numPreviewLines = d.id_angle_system * 2 - 1;
-        } else {
-            numPreviewLines = 6;
-        }
-
-        //線分abをaを中心にd度回転した線分を返す関数（元の線分は変えずに新しい線分を返す）public oc.Senbun_kaiten(Senbun s0,double d)
-
-        LineSegment startingSegment = new LineSegment(pEnd, pStart);
-        startingSegment.setColor(LineColor.GREEN_6);
-        candidates.add(startingSegment);
-
-        if (d.id_angle_system != 0) {
-
-            double angle = 0.0;
-            double angleStep = 180.0 / d.id_angle_system;
-            for (int i = 0; i < numPreviewLines; i++) {
-                angle += angleStep;
-                LineSegment e = OritaCalc.lineSegment_rotate(startingSegment, angle, 1.0);
-                if (i % 2 == 0) {
-                    e.setColor(LineColor.ORANGE_4);
-                } else {
-                    e.setColor(LineColor.GREEN_6);
-                }
-                e.setActive(LineSegment.ActiveState.ACTIVE_BOTH_3);
-                candidates.add(e);
-            }
-        } else {
-            double[] angles = new double[] {
-                    d.d_restricted_angle_1,
-                    d.d_restricted_angle_2,
-                    d.d_restricted_angle_3,
-                    360 - d.d_restricted_angle_1,
-                    360 - d.d_restricted_angle_2,
-                    360 - d.d_restricted_angle_3
-            };
-
-            for (int i = 0; i < 6; i++) {
-                LineSegment s = new LineSegment();
-                s.set(OritaCalc.lineSegment_rotate(startingSegment, angles[i], 1.0));
-                s.setActive(LineSegment.ActiveState.ACTIVE_BOTH_3);
-                candidates.add(s);
-                s.setColor(customAngleColors[i%3]);
-            }
-        }
-        return candidates;
-    }
-
-    //マウス操作(ドラッグしたとき)を行う関数
-    public void mouseDragged(Point p0) {
-    }
-
-    //マウス操作(ボタンを離したとき)を行う関数
-    public void mouseReleased(Point p0) {
-    }
-
-    @Override
-    public void drawPreview(Graphics2D g2, Camera camera, DrawingSettings settings) {
-        super.drawPreview(g2, camera, settings);
-        for (LineSegment candidate : candidates) {
-            DrawingUtil.drawLineStep(g2, candidate, camera, settings.getLineWidth(), d.gridInputAssist);
-        }
-        if (direction != null && currentStep == Step.SELECT_DIRECTION) {
-            DrawingUtil.drawLineStep(g2, direction, camera, settings.getLineWidth(), d.gridInputAssist);
-        }
-        if (pStart != null) {
-            DrawingUtil.drawStepVertex(g2, pStart, LineColor.RED_1, camera, d.gridInputAssist);
-        }
-        if (pEnd != null) {
-            DrawingUtil.drawStepVertex(g2, pEnd, LineColor.BLUE_2, camera, d.gridInputAssist);
-        }
-        if (previewLine != null) {
-            DrawingUtil.drawCpLine(g2, previewLine, camera, settings.getLineStyle(), settings.getLineWidth(), d.pointSize, settings.getWidth(), settings.getHeight());
-        }
-    }
-
-    @Override
-    public void reset() {
-        candidates.clear();
-        currentStep = Step.SELECT_FIRST_POINT;
-        pStart = null;
-        pEnd = null;
-        direction = null;
-        previewLine = null;
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerAngleSystem.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerAngleSystem.java
@@ -50,7 +50,7 @@ public class MouseHandlerAngleSystem extends BaseMouseHandler_WithSelector {
             lineSetCalculator.setHidden(true);
             candidateSelector.setHidden(true);
         });
-        candidateSelector.onFailedFinish(this::reset);
+        candidateSelector.onFail(this::reset);
         finalLineSelector = registerSelector(
                 new LineExtender(
                         candidateSelector::getSelection,

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerAngleSystem.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerAngleSystem.java
@@ -13,7 +13,7 @@ import java.util.EnumSet;
 public class MouseHandlerAngleSystem extends BaseMouseHandler_WithSelector {
     CreasePatternPointSelector pStartSelector;
     AngleSystemLineSetCalculator lineSetCalculator;
-    LineSelector candidateSelector;
+    LineSelectorFromCollection candidateSelector;
     LineExtender finalLineSelector;
 
     @Inject
@@ -40,25 +40,25 @@ public class MouseHandlerAngleSystem extends BaseMouseHandler_WithSelector {
                 () -> candidateSelector
         );
         candidateSelector = registerSelector(
-                new LineSelector(
+                new LineSelectorFromCollection(
                         lineSetCalculator::getSelection,
                         LineColor.PURPLE_8,
-                        LineSelector.NoCloseLineValue.NONE
+                        LineSelectorFromCollection.NoCloseLineValue.NONE
                 ),
                 () -> finalLineSelector);
         candidateSelector.onFinish(lineSegment -> {
             lineSetCalculator.setHidden(true);
             candidateSelector.setHidden(true);
         });
-
+        candidateSelector.onFailedFinish(this::reset);
         finalLineSelector = registerSelector(
                 new LineExtender(
                         candidateSelector::getSelection,
                         d::getLineColor,
-                        new LineSelector(
+                        new LineSelectorFromCollection(
                                 d.foldLineSet::getLines,
                                 LineColor.GREEN_6,
-                                LineSelector.NoCloseLineValue.MOUSE_POS
+                                LineSelectorFromCollection.NoCloseLineValue.MOUSE_POS
                         )
                 ), null
         );

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDraw.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDraw.java
@@ -1,22 +1,18 @@
 package oriedita.editor.action;
 
+import oriedita.editor.action.selector.*;
 import oriedita.editor.canvas.MouseMode;
-import oriedita.editor.drawing.tools.Camera;
-import oriedita.editor.drawing.tools.DrawingUtil;
 import origami.Epsilon;
 import origami.crease_pattern.element.Circle;
 import origami.crease_pattern.element.LineColor;
-import origami.crease_pattern.element.LineSegment;
-import origami.crease_pattern.element.Point;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.awt.*;
 
 @Singleton
-public class MouseHandlerCircleDraw extends BaseMouseHandler {
-    private Circle previewCircle;
-    private LineSegment previewLine;
+public class MouseHandlerCircleDraw extends BaseMouseHandler_WithSelector {
+    private CreasePatternPointSelector center;
+    private ElementSelector<Circle> circleCalculator;
 
     @Inject
     public MouseHandlerCircleDraw() {
@@ -28,61 +24,34 @@ public class MouseHandlerCircleDraw extends BaseMouseHandler {
     }
 
     @Override
-    public void mouseMoved(Point p0) {
-
-    }
-
-    //マウス操作(mouseMode==42 円入力　でボタンを押したとき)時の作業----------------------------------------------------
-    public void mousePressed(Point p0) {
-        Point p = new Point();
-        p.set(d.camera.TV2object(p0));
-        Point closestPoint = d.getClosestPoint(p);
-        d.circleStep.clear();
-        d.lineStep.clear();
-        if (p.distance(closestPoint) <= d.selectionDistance) {
-            this.previewCircle = new Circle(closestPoint, 0, LineColor.CYAN_3);
-            this.previewLine = new LineSegment(p, closestPoint, LineColor.CYAN_3);
-        }
-    }
-
-    //マウス操作(mouseMode==42 円入力　でドラッグしたとき)を行う関数----------------------------------------------------
-    public void mouseDragged(Point p0) {
-        Point p = new Point();
-        p.set(d.camera.TV2object(p0));
-        if (previewLine != null) {
-            previewLine.setA(p);
-            if (previewCircle != null) {
-                previewCircle.setR(previewLine.determineLength());
+    public void setupSelectors() {
+        center = registerStartingSelector(
+                new CreasePatternPointSelector(
+                        CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_ONLY,
+                        LineColor.CYAN_3
+                ),
+                () -> circleCalculator
+        );
+        circleCalculator = registerSelector(
+                new CircleCalculator(
+                        center::getSelection,
+                        new LineCalculatorFrom2Points(
+                                center::getSelection,
+                                () -> LineColor.CYAN_3,
+                                new CreasePatternPointSelector(
+                                        CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_ONLY,
+                                        LineColor.CYAN_3
+                                )
+                        )
+                ),
+                FinishOn.RELEASE,
+                null
+        );
+        circleCalculator.onFinish(circle -> {
+            if (Epsilon.high.gt0(circle.getR())) {
+                d.addCircle(circle);
+                d.record();
             }
-        }
-    }
-
-    //マウス操作(mouseMode==42 円入力　でボタンを離したとき)を行う関数----------------------------------------------------
-    public void mouseReleased(Point p0) {
-        if (previewLine != null) {
-            Point p = new Point();
-            p.set(d.camera.TV2object(p0));
-            Point closestPoint = d.getClosestPoint(p);
-            previewLine.setA(closestPoint);
-            if (p.distance(closestPoint) <= d.selectionDistance) {
-                if (Epsilon.high.gt0(previewLine.determineLength())) {
-                    d.addCircle(previewLine.determineBX(), previewLine.determineBY(), previewLine.determineLength(), LineColor.CYAN_3);
-                    d.record();
-                }
-            }
-
-            previewLine = null;
-            previewCircle = null;
-        }
-    }
-
-    @Override
-    public void drawPreview(Graphics2D g2, Camera camera, DrawingSettings settings) {
-        if (previewCircle != null) {
-            DrawingUtil.drawCircleStep(g2, previewCircle,  camera);
-        }
-        if (previewLine != null) {
-            DrawingUtil.drawLineStep(g2, previewLine, camera, settings.getLineWidth(), d.gridInputAssist);
-        }
+        });
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawConcentric.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawConcentric.java
@@ -1,17 +1,19 @@
 package oriedita.editor.action;
 
+import oriedita.editor.action.selector.*;
+import oriedita.editor.canvas.MouseMode;
+import origami.crease_pattern.OritaCalc;
+import origami.crease_pattern.element.LineColor;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import origami.Epsilon;
-import origami.crease_pattern.OritaCalc;
-import origami.crease_pattern.element.Circle;
-import origami.crease_pattern.element.LineColor;
-import origami.crease_pattern.element.LineSegment;
-import origami.crease_pattern.element.Point;
-import oriedita.editor.canvas.MouseMode;
 
 @Singleton
-public class MouseHandlerCircleDrawConcentric extends BaseMouseHandler {
+public class MouseHandlerCircleDrawConcentric extends BaseMouseHandler_WithSelector {
+    private CircleSelectorFromIterable circleSelector;
+    private CreasePatternPointSelector firstPointSelector;
+    private CircleCalculator circleCalculator;
+
     @Inject
     public MouseHandlerCircleDrawConcentric() {
     }
@@ -22,71 +24,45 @@ public class MouseHandlerCircleDrawConcentric extends BaseMouseHandler {
     }
 
     @Override
-    public void mouseMoved(Point p0) {
-
-    }
-
-    //マウス操作(mouseMode==48 同心円　線分入力　でボタンを押したとき)時の作業----------------------------------------------------
-    public void mousePressed(Point p0) {
-        Point p = new Point();
-        p.set(d.camera.TV2object(p0));
-        Circle closest_circumference = new Circle(); //Circle with the circumference closest to the mouse
-        closest_circumference.set(d.getClosestCircleMidpoint(p));
-        Point closestPoint = d.getClosestPoint(p);
-
-        if ((d.lineStep.size() == 0) && (d.circleStep.size() == 0)) {
-            if (OritaCalc.distance_circumference(p, closest_circumference) > d.selectionDistance) {
-                return;
-            }
-
-            d.lineStep.clear();
-            d.circleStep.clear();
-            d.circleStep.add(new Circle(closest_circumference.determineCenter(), closest_circumference.getR(), LineColor.GREEN_6));
-            return;
-        }
-
-        if ((d.lineStep.size() == 0) && (d.circleStep.size() == 1)) {
-            if (p.distance(closestPoint) > d.selectionDistance) {
-                return;
-            }
-
-            d.lineStepAdd(new LineSegment(p, closestPoint, LineColor.CYAN_3));
-            d.circleStep.add(new Circle(d.circleStep.get(0).determineCenter(), d.circleStep.get(0).getR(), LineColor.GREEN_6));
-        }
-    }
-
-    //マウス操作(mouseMode==48 同心円　線分入力　でドラッグしたとき)を行う関数----------------------------------------------------
-    public void mouseDragged(Point p0) {
-        Point p = new Point();
-        p.set(d.camera.TV2object(p0));
-        if ((d.lineStep.size() == 1) && (d.circleStep.size() == 2)) {
-            d.lineStep.get(0).setA(p);
-            d.circleStep.get(1).setR(d.circleStep.get(0).getR() + d.lineStep.get(0).determineLength());
-        }
-    }
-
-    //マウス操作(mouseMode==48 同心円　線分入力　でボタンを離したとき)を行う関数----------------------------------------------------
-    public void mouseReleased(Point p0) {
-        if ((d.lineStep.size() == 1) && (d.circleStep.size() == 2)) {
-            Circle circle1 = d.circleStep.get(0);
-            Circle circle2 = d.circleStep.get(1);
-
-            d.circleStep.clear();
-
-            Point p = new Point();
-            p.set(d.camera.TV2object(p0));
-            Point closestPoint = d.getClosestPoint(p);
-            d.lineStep.get(0).setA(closestPoint);
-            if (p.distance(closestPoint) <= d.selectionDistance) {
-                if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
-                    d.addLineSegment(d.lineStep.get(0));
-                    circle2.setR(circle1.getR() + d.lineStep.get(0).determineLength());
-                    d.addCircle(circle2);
-                    d.record();
-                }
-            }
-
-            d.lineStep.clear();
-        }
+    public void setupSelectors() {
+        circleSelector = registerStartingSelector(
+                new CircleSelectorFromIterable(
+                        () -> d.foldLineSet.getCircles(),
+                        circle -> LineColor.GREEN_6
+                ),
+                () -> firstPointSelector
+        );
+        firstPointSelector = registerSelector(
+                new CreasePatternPointSelector(
+                        CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_OR_FREE,
+                        LineColor.MAGENTA_5
+                ),
+                () -> circleCalculator
+        );
+        circleCalculator = registerSelector(
+                new CircleCalculator(
+                        () -> circleSelector.getSelection().determineCenter(),
+                        new LineCalculatorFrom2Points(
+                                firstPointSelector::getSelection,
+                                () -> LineColor.MAGENTA_5,
+                                new CreasePatternPointSelector(
+                                        CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_OR_FREE,
+                                        LineColor.MAGENTA_5
+                                )
+                        ).then(line ->  // add radius of selected circle to the line
+                                OritaCalc.lineSegment_double(line,
+                                    (line.determineLength() + circleSelector.getSelection().getR())
+                                            /line.determineLength()
+                                ),
+                                true
+                        )
+                ),
+                FinishOn.RELEASE,
+                null
+        );
+        circleCalculator.onFinish(circle -> {
+            d.addCircle(circle);
+            d.record();
+        });
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawConcentricSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawConcentricSelect.java
@@ -61,6 +61,7 @@ public class MouseHandlerCircleDrawConcentricSelect extends BaseMouseHandler_Wit
             d.addCircle(circle);
             d.record();
         });
+        onAnyFail(this::reset, circleSelector1, circleSelector2, circleCalculator);
     }
 
     private Double calculateRadius(Circle circle1, Circle circle2, Circle circle3) {

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawConcentricSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawConcentricSelect.java
@@ -1,17 +1,23 @@
 package oriedita.editor.action;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import oriedita.editor.action.selector.BaseMouseHandler_WithSelector;
+import oriedita.editor.action.selector.CircleCalculatorFromRadius;
+import oriedita.editor.action.selector.CircleSelectorFromIterable;
+import oriedita.editor.canvas.MouseMode;
 import origami.Epsilon;
-import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.Circle;
 import origami.crease_pattern.element.LineColor;
-import origami.crease_pattern.element.Point;
-import oriedita.editor.canvas.MouseMode;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Singleton
-public class MouseHandlerCircleDrawConcentricSelect extends BaseMouseHandler {
+public class MouseHandlerCircleDrawConcentricSelect extends BaseMouseHandler_WithSelector {
     Circle closest_circumference = new Circle(100000.0, 100000.0, 10.0, LineColor.PURPLE_8); //Circle with the circumference closest to the mouse
+
+    CircleSelectorFromIterable circleSelector1;
+    CircleSelectorFromIterable circleSelector2;
+    CircleCalculatorFromRadius circleCalculator;
 
     @Inject
     public MouseHandlerCircleDrawConcentricSelect() {
@@ -23,61 +29,45 @@ public class MouseHandlerCircleDrawConcentricSelect extends BaseMouseHandler {
     }
 
     @Override
-    public void mouseMoved(Point p0) {
-
+    protected void setupSelectors() {
+        circleSelector1 = registerStartingSelector(
+                new CircleSelectorFromIterable(
+                        d.foldLineSet::getCircles,
+                        circle -> LineColor.GREEN_6
+                ),
+                () -> circleSelector2
+        );
+        circleSelector2 = registerSelector(
+                new CircleSelectorFromIterable(
+                        d.foldLineSet::getCircles,
+                        circle -> LineColor.PURPLE_8
+                ),
+                () -> circleCalculator
+        );
+        circleCalculator = registerSelector(
+                new CircleCalculatorFromRadius(
+                        () -> circleSelector1.getSelection().determineCenter(),
+                        new CircleSelectorFromIterable(
+                            d.foldLineSet::getCircles,
+                            circle -> LineColor.PURPLE_8
+                    ).thenGet(circle3 -> this.calculateRadius(
+                                circleSelector1.getSelection(),
+                                circleSelector2.getSelection(), circle3)
+                    )
+                ),
+                null
+        );
     }
 
-    //マウス操作(mouseMode==49 同心円　同心円入力　でボタンを押したとき)時の作業----------------------------------------------------
-    public void mousePressed(Point p0) {
-        Point p = new Point();
-        p.set(d.camera.TV2object(p0));
-        closest_circumference.set(d.getClosestCircleMidpoint(p));
-        // Point closest_point = d.getClosestPoint(p);
-
-        if ((d.lineStep.size() == 0) && (d.circleStep.size() == 0)) {
-            if (OritaCalc.distance_circumference(p, closest_circumference) > d.selectionDistance) {
-                return;
-            }
-
-            d.circleStep.add(new Circle(closest_circumference.determineCenter(), closest_circumference.getR(), LineColor.GREEN_6));
-        } else if ((d.lineStep.size() == 0) && (d.circleStep.size() == 1)) {
-            if (OritaCalc.distance_circumference(p, closest_circumference) > d.selectionDistance) {
-                return;
-            }
-
-            d.circleStep.add(new Circle(closest_circumference.determineCenter(), closest_circumference.getR(), LineColor.PURPLE_8));
-        } else if ((d.lineStep.size() == 0) && (d.circleStep.size() == 2)) {
-            if (OritaCalc.distance_circumference(p, closest_circumference) > d.selectionDistance) {
-                return;
-            }
-
-            d.circleStep.add(new Circle(closest_circumference.determineCenter(), closest_circumference.getR(), LineColor.PURPLE_8));
+    private Double calculateRadius(Circle circle1, Circle circle2, Circle circle3) {
+        double add_r = circle3.getR() - circle2.getR();
+        if (Epsilon.high.eq0(add_r)) {
+            return null;
         }
-    }
-
-    //マウス操作(mouseMode==49 同心円　同心円入力　でドラッグしたとき)を行う関数----------------------------------------------------
-    public void mouseDragged(Point p0) {
-
-    }
-
-    //マウス操作(mouseMode==49 同心円　同心円入力　でボタンを離したとき)を行う関数----------------------------------------------------
-    public void mouseReleased(Point p0) {
-        if ((d.lineStep.size() == 0) && (d.circleStep.size() == 3)) {
-            Circle circle1 = d.circleStep.get(0);
-            Circle circle2 = d.circleStep.get(1);
-            Circle circle3 = d.circleStep.get(2);
-            d.circleStep.clear();
-            double add_r = circle3.getR() - circle2.getR();
-            if (!Epsilon.high.eq0(add_r)) {
-                double new_r = add_r + circle1.getR();
-
-                if (Epsilon.high.gt0(new_r)) {
-                    circle1.setR(new_r);
-                    circle1.setColor(LineColor.CYAN_3);
-                    d.addCircle(circle1);
-                    d.record();
-                }
-            }
+        double new_r = circle1.getR() + add_r;
+        if (Epsilon.high.le0(new_r)) {
+            return null;
         }
+        return new_r;
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawConcentricSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawConcentricSelect.java
@@ -57,6 +57,10 @@ public class MouseHandlerCircleDrawConcentricSelect extends BaseMouseHandler_Wit
                 ),
                 null
         );
+        circleCalculator.onFinish(circle -> {
+            d.addCircle(circle);
+            d.record();
+        });
     }
 
     private Double calculateRadius(Circle circle1, Circle circle2, Circle circle3) {

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawFree.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawFree.java
@@ -1,17 +1,13 @@
 package oriedita.editor.action;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import origami.Epsilon;
-import origami.crease_pattern.OritaCalc;
-import origami.crease_pattern.element.Circle;
-import origami.crease_pattern.element.LineColor;
-import origami.crease_pattern.element.LineSegment;
-import origami.crease_pattern.element.Point;
+import oriedita.editor.action.selector.CreasePatternPointSelector;
 import oriedita.editor.canvas.MouseMode;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 @Singleton
-public class MouseHandlerCircleDrawFree extends BaseMouseHandler {
+public class MouseHandlerCircleDrawFree extends MouseHandlerCircleDraw {
     @Inject
     public MouseHandlerCircleDrawFree() {
     }
@@ -22,62 +18,7 @@ public class MouseHandlerCircleDrawFree extends BaseMouseHandler {
     }
 
     @Override
-    public void mouseMoved(Point p0) {
-
-    }
-
-    //マウス操作(mouseMode==47 円入力(フリー　)　でボタンを押したとき)時の作業----------------------------------------------------
-    public void mousePressed(Point p0) {
-        d.circleStep.clear();
-        d.lineStep.clear();
-
-        Point p = new Point();
-        p.set(d.camera.TV2object(p0));
-        Point closestPoint = d.getClosestPoint(p);
-        if (p.distance(closestPoint) > d.selectionDistance) {
-            d.lineStepAdd(new LineSegment(p, p, LineColor.CYAN_3));
-
-            Circle stepCircle = new Circle();
-            stepCircle.set(p, 0.0, LineColor.CYAN_3);
-            d.circleStep.add(stepCircle);
-        } else {
-            d.lineStepAdd(new LineSegment(p, closestPoint, LineColor.CYAN_3));
-
-            Circle stepCircle = new Circle();
-            stepCircle.set(closestPoint, 0.0, LineColor.CYAN_3);
-            d.circleStep.add(stepCircle);
-        }
-    }
-
-    //マウス操作(mouseMode==47 円入力　でドラッグしたとき)を行う関数----------------------------------------------------
-    public void mouseDragged(Point p0) {
-        Point p = new Point();
-        p.set(d.camera.TV2object(p0));
-        d.lineStep.get(0).setA(p);
-        d.circleStep.get(0).setR(OritaCalc.distance(d.lineStep.get(0).getA(), d.lineStep.get(0).getB()));
-    }
-
-    //マウス操作(mouseMode==47 円入力　でボタンを離したとき)を行う関数----------------------------------------------------
-    public void mouseReleased(Point p0) {
-        if (d.lineStep.size() == 1) {
-
-            Point p = new Point();
-            p.set(d.camera.TV2object(p0));
-            Point closestPoint = d.getClosestPoint(p);
-
-            if (p.distance(closestPoint) <= d.selectionDistance) {
-                d.lineStep.get(0).setA(closestPoint);
-            } else {
-                d.lineStep.get(0).setA(p);
-            }
-
-            if (Epsilon.high.gt0(d.lineStep.get(0).determineLength())) {
-                d.addCircle(d.lineStep.get(0).determineBX(), d.lineStep.get(0).determineBY(), d.lineStep.get(0).determineLength(), LineColor.CYAN_3);
-                d.record();
-            }
-
-            d.circleStep.clear();
-            d.lineStep.clear();
-        }
+    protected CreasePatternPointSelector.SelectionMode getSelectionMode() {
+        return CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_OR_FREE;
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawSeparate.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawSeparate.java
@@ -1,16 +1,24 @@
 package oriedita.editor.action;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import oriedita.editor.action.selector.BaseMouseHandler_WithSelector;
+import oriedita.editor.action.selector.CircleCalculatorFromRadius;
+import oriedita.editor.action.selector.CreasePatternPointSelector;
+import oriedita.editor.action.selector.LineCalculatorFrom2Points;
+import oriedita.editor.canvas.MouseMode;
 import origami.Epsilon;
-import origami.crease_pattern.element.Circle;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
-import origami.crease_pattern.element.Point;
-import oriedita.editor.canvas.MouseMode;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Singleton
-public class MouseHandlerCircleDrawSeparate extends BaseMouseHandler {
+public class MouseHandlerCircleDrawSeparate extends BaseMouseHandler_WithSelector {
+
+    private CreasePatternPointSelector center;
+    private CreasePatternPointSelector radiusFirstPoint;
+    private CircleCalculatorFromRadius circleCalculator;
+
     @Inject
     public MouseHandlerCircleDrawSeparate() {
     }
@@ -21,63 +29,42 @@ public class MouseHandlerCircleDrawSeparate extends BaseMouseHandler {
     }
 
     @Override
-    public void mouseMoved(Point p0) {
-
-    }
-
-    //マウス操作(mouseMode==44 円 分離入力　でボタンを押したとき)時の作業----------------------------------------------------
-    public void mousePressed(Point p0) {
-        Point p = new Point();
-        p.set(d.camera.TV2object(p0));
-        Point closest_point = d.getClosestPoint(p);
-
-        if (d.lineStep.size() == 0) {
-            d.circleStep.clear();
-            if (p.distance(closest_point) > d.selectionDistance) {
-                return;
+    public void setupSelectors() {
+        center = registerStartingSelector(
+                new CreasePatternPointSelector(
+                        CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_ONLY,
+                        LineColor.CYAN_3
+                ),
+                () -> radiusFirstPoint
+        );
+        radiusFirstPoint = registerSelector(
+                new CreasePatternPointSelector(
+                        CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_ONLY,
+                        LineColor.CYAN_3
+                ),
+                () -> circleCalculator
+        );
+        circleCalculator = registerSelector(
+                new CircleCalculatorFromRadius(
+                        center::getSelection,
+                        new LineCalculatorFrom2Points(
+                                radiusFirstPoint::getSelection,
+                                () -> LineColor.CYAN_3,
+                                new CreasePatternPointSelector(
+                                        CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_ONLY,
+                                        LineColor.CYAN_3
+                                )
+                        ).thenGet(LineSegment::determineLength)
+                ),
+                FinishOn.RELEASE,
+                () -> null
+        );
+        circleCalculator.onFail(() -> revertTo(radiusFirstPoint));
+        circleCalculator.onFinish(circle -> {
+            if (Epsilon.high.gt0(circle.getR())) {
+                d.addCircle(circle);
+                d.record();
             }
-
-            d.lineStepAdd(new LineSegment(closest_point, closest_point, LineColor.CYAN_3));
-        } else if (d.lineStep.size() == 1) {
-            if (p.distance(closest_point) > d.selectionDistance) {
-                return;
-            }
-
-            d.lineStepAdd(new LineSegment(p, closest_point, LineColor.CYAN_3));
-
-            d.circleStep.clear();
-            d.circleStep.add(new Circle(d.lineStep.get(0).getA(), 0.0, LineColor.CYAN_3));
-        }
-    }
-
-    //マウス操作(mouseMode==44 円 分離入力　でドラッグしたとき)を行う関数----------------------------------------------------
-    public void mouseDragged(Point p0) {
-        Point p = new Point();
-        p.set(d.camera.TV2object(p0));
-        if (d.lineStep.size() == 2) {
-            d.lineStep.get(1).setA(p);
-            d.circleStep.get(0).setR(d.lineStep.get(0).determineLength());
-        }
-    }
-
-    //マウス操作(mouseMode==44 円 分離入力　でボタンを離したとき)を行う関数----------------------------------------------------
-    public void mouseReleased(Point p0) {
-        if (d.lineStep.size() == 2) {
-            d.circleStep.clear();
-
-            Point p = new Point();
-            p.set(d.camera.TV2object(p0));
-            Point closest_point = d.getClosestPoint(p);
-            d.lineStep.get(1).setA(closest_point);
-            if (p.distance(closest_point) <= d.selectionDistance) {
-                if (Epsilon.high.gt0(d.lineStep.get(1).determineLength())) {
-                    d.addLineSegment(d.lineStep.get(1));
-                    d.addCircle(d.lineStep.get(0).getA(), d.lineStep.get(1).determineLength(), LineColor.CYAN_3);
-                    d.record();
-                }
-            }
-
-            d.lineStep.clear();
-        }
+        });
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawThreePoint.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerCircleDrawThreePoint.java
@@ -1,17 +1,22 @@
 package oriedita.editor.action;
 
+import oriedita.editor.action.drawing.CircleDrawer;
+import oriedita.editor.action.selector.BaseMouseHandler_WithSelector;
+import oriedita.editor.action.selector.CreasePatternPointSelector;
+import oriedita.editor.action.selector.ElementSelector;
+import oriedita.editor.canvas.MouseMode;
+import origami.crease_pattern.OritaCalc;
+import origami.crease_pattern.element.*;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import origami.Epsilon;
-import origami.crease_pattern.OritaCalc;
-import origami.crease_pattern.element.LineColor;
-import origami.crease_pattern.element.LineSegment;
-import origami.crease_pattern.element.Point;
-import origami.crease_pattern.element.StraightLine;
-import oriedita.editor.canvas.MouseMode;
 
 @Singleton
-public class MouseHandlerCircleDrawThreePoint extends BaseMouseHandler {
+public class MouseHandlerCircleDrawThreePoint extends BaseMouseHandler_WithSelector {
+    ElementSelector<Point> firstPoint;
+    ElementSelector<Point> secondPoint;
+    ElementSelector<Circle> finalCircle;
+
     @Inject
     public MouseHandlerCircleDrawThreePoint() {
     }
@@ -22,77 +27,44 @@ public class MouseHandlerCircleDrawThreePoint extends BaseMouseHandler {
     }
 
     @Override
-    public void mouseMoved(Point p0) {
-
-    }
-
-    public void mousePressed(Point p0) {
-        Point p = new Point();
-        p.set(d.camera.TV2object(p0));
-        Point closest_point = d.getClosestPoint(p);
-        if (p.distance(closest_point) < d.selectionDistance) {
-            d.lineStepAdd(new LineSegment(closest_point, closest_point, LineColor.fromNumber(d.lineStep.size() + 1)));
-        }
-    }
-
-    //マウス操作(ドラッグしたとき)を行う関数
-    public void mouseDragged(Point p0) {
-    }
-
-    //マウス操作(ボタンを離したとき)を行う関数
-    public void mouseReleased(Point p0) {
-        if (d.lineStep.size() == 3) {
-            LineSegment sen1 = new LineSegment(d.lineStep.get(0).getA(), d.lineStep.get(1).getA());
-            if (Epsilon.high.le0(sen1.determineLength())) {
-                return;
-            }
-            LineSegment sen2 = new LineSegment(d.lineStep.get(1).getA(), d.lineStep.get(2).getA());
-            if (Epsilon.high.le0(sen2.determineLength())) {
-                return;
-            }
-            LineSegment sen3 = new LineSegment(d.lineStep.get(2).getA(), d.lineStep.get(0).getA());
-            if (Epsilon.high.le0(sen3.determineLength())) {
-                return;
-            }
-
-            if (Math.abs(OritaCalc.angle(sen1, sen2) - 0.0) < Epsilon.UNKNOWN_1EN6) {
-                return;
-            }
-            if (Math.abs(OritaCalc.angle(sen1, sen2) - 180.0) < Epsilon.UNKNOWN_1EN6) {
-                return;
-            }
-            if (Math.abs(OritaCalc.angle(sen1, sen2) - 360.0) < Epsilon.UNKNOWN_1EN6) {
-                return;
-            }
-
-            if (Math.abs(OritaCalc.angle(sen2, sen3) - 0.0) < Epsilon.UNKNOWN_1EN6) {
-                return;
-            }
-            if (Math.abs(OritaCalc.angle(sen2, sen3) - 180.0) < Epsilon.UNKNOWN_1EN6) {
-                return;
-            }
-            if (Math.abs(OritaCalc.angle(sen2, sen3) - 360.0) < Epsilon.UNKNOWN_1EN6) {
-                return;
-            }
-
-            if (Math.abs(OritaCalc.angle(sen3, sen1) - 0.0) < Epsilon.UNKNOWN_1EN6) {
-                return;
-            }
-            if (Math.abs(OritaCalc.angle(sen3, sen1) - 180.0) < Epsilon.UNKNOWN_1EN6) {
-                return;
-            }
-            if (Math.abs(OritaCalc.angle(sen3, sen1) - 360.0) < Epsilon.UNKNOWN_1EN6) {
-                return;
-            }
-
-            StraightLine t1 = new StraightLine(sen1);
-            t1.orthogonalize(OritaCalc.internalDivisionRatio(sen1.getA(), sen1.getB(), 1.0, 1.0));
-            StraightLine t2 = new StraightLine(sen2);
-            t2.orthogonalize(OritaCalc.internalDivisionRatio(sen2.getA(), sen2.getB(), 1.0, 1.0));
-            d.addCircle(OritaCalc.findIntersection(t1, t2), OritaCalc.distance(d.lineStep.get(0).getA(), OritaCalc.findIntersection(t1, t2)), LineColor.CYAN_3);
+    protected void setupSelectors() {
+        firstPoint = registerStartingSelector(
+                new CreasePatternPointSelector(
+                        CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_ONLY,
+                        LineColor.CYAN_3
+                ),
+                () -> secondPoint
+        );
+        secondPoint = registerSelector(
+                new CreasePatternPointSelector(
+                        CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_ONLY,
+                        LineColor.CYAN_3
+                ),
+                () -> finalCircle
+        );
+        finalCircle = registerSelector(
+                new CreasePatternPointSelector(
+                        CreasePatternPointSelector.SelectionMode.CLOSEST_POINT_ONLY,
+                        LineColor.CYAN_3
+                ).thenGet(point -> {
+                    if (!OritaCalc.collinear(firstPoint.getSelection(), secondPoint.getSelection(), point)) {
+                        LineSegment sen1 = new LineSegment(firstPoint.getSelection(), secondPoint.getSelection());
+                        LineSegment sen2 = new LineSegment(secondPoint.getSelection(), point);
+                        StraightLine t1 = new StraightLine(sen1);
+                        t1.orthogonalize(OritaCalc.internalDivisionRatio(sen1.getA(), sen1.getB(), 1.0, 1.0));
+                        StraightLine t2 = new StraightLine(sen2);
+                        t2.orthogonalize(OritaCalc.internalDivisionRatio(sen2.getA(), sen2.getB(), 1.0, 1.0));
+                        return new Circle(
+                                OritaCalc.findIntersection(t1, t2),
+                                OritaCalc.distance(firstPoint.getSelection(), OritaCalc.findIntersection(t1, t2)), LineColor.CYAN_3);
+                    }
+                    return null;
+                }, new CircleDrawer()),
+                null
+        );
+        finalCircle.onFinish(circle -> {
+            d.addCircle(circle);
             d.record();
-
-            d.lineStep.clear();
-        }
+        });
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/MouseModeHandler.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseModeHandler.java
@@ -1,5 +1,6 @@
 package oriedita.editor.action;
 
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.canvas.MouseMode;
 import oriedita.editor.drawing.tools.Camera;
 import origami.crease_pattern.element.Point;

--- a/oriedita/src/main/java/oriedita/editor/action/drawing/CircleDrawer.java
+++ b/oriedita/src/main/java/oriedita/editor/action/drawing/CircleDrawer.java
@@ -1,0 +1,24 @@
+package oriedita.editor.action.drawing;
+
+import oriedita.editor.action.selector.drawing.Drawer;
+import oriedita.editor.action.selector.drawing.DrawingSettings;
+import oriedita.editor.drawing.tools.Camera;
+import oriedita.editor.drawing.tools.DrawingUtil;
+import origami.crease_pattern.element.Circle;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.awt.*;
+
+@Singleton
+public class CircleDrawer implements Drawer<Circle> {
+
+    @Inject
+    public CircleDrawer() {
+    }
+
+    @Override
+    public void draw(Circle element, Graphics2D g, Camera camera, DrawingSettings settings) {
+        DrawingUtil.drawCircleStep(g, element, camera);
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/AngleSystemLineSetCalculator.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/AngleSystemLineSetCalculator.java
@@ -1,0 +1,95 @@
+package oriedita.editor.action.selector;
+
+import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.drawing.tools.Camera;
+import oriedita.editor.drawing.tools.DrawingUtil;
+import origami.crease_pattern.OritaCalc;
+import origami.crease_pattern.element.LineColor;
+import origami.crease_pattern.element.LineSegment;
+import origami.crease_pattern.element.Point;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Calculates all outgoing lines from the point selected by the pointSelector, according to the currently
+ * active angle system in d, and rotated so that the line from first to the selected point is at 0 degrees
+ */
+public class AngleSystemLineSetCalculator extends CalculatedElementSelector<Point, List<LineSegment>> {
+    private final Supplier<Point> first;
+    private final LineColor[] customAngleColors = new LineColor[] {
+            LineColor.ORANGE_4,
+            LineColor.GREEN_6,
+            LineColor.PURPLE_8
+    };
+
+    public AngleSystemLineSetCalculator(Supplier<Point> firstPointSupplier, CreasePatternPointSelector base) {
+        super(base, true);
+        this.first = firstPointSupplier;
+    }
+
+    private List<LineSegment> makePreviewLines(Point pStart, Point pEnd) {
+        List<LineSegment> candidates = new ArrayList<>();
+        int numPreviewLines;//1つの端点周りに描く線の本数
+        if (d.id_angle_system != 0) {
+            numPreviewLines = d.id_angle_system * 2 - 1;
+        } else {
+            numPreviewLines = 6;
+        }
+
+        //線分abをaを中心にd度回転した線分を返す関数（元の線分は変えずに新しい線分を返す）public oc.Senbun_kaiten(Senbun s0,double d)
+
+        LineSegment startingSegment = new LineSegment(pEnd, pStart);
+        startingSegment.setColor(LineColor.GREEN_6);
+        candidates.add(startingSegment);
+
+        if (d.id_angle_system != 0) {
+
+            double angle = 0.0;
+            double angleStep = 180.0 / d.id_angle_system;
+            for (int i = 0; i < numPreviewLines; i++) {
+                angle += angleStep;
+                LineSegment e = OritaCalc.lineSegment_rotate(startingSegment, angle, 1.0);
+                if (i % 2 == 0) {
+                    e.setColor(LineColor.ORANGE_4);
+                } else {
+                    e.setColor(LineColor.GREEN_6);
+                }
+                e.setActive(LineSegment.ActiveState.ACTIVE_BOTH_3);
+                candidates.add(e);
+            }
+        } else {
+            double[] angles = new double[] {
+                    d.d_restricted_angle_1,
+                    d.d_restricted_angle_2,
+                    d.d_restricted_angle_3,
+                    360 - d.d_restricted_angle_1,
+                    360 - d.d_restricted_angle_2,
+                    360 - d.d_restricted_angle_3
+            };
+
+            for (int i = 0; i < 6; i++) {
+                LineSegment s = new LineSegment();
+                s.set(OritaCalc.lineSegment_rotate(startingSegment, angles[i], 1.0));
+                s.setActive(LineSegment.ActiveState.ACTIVE_BOTH_3);
+                candidates.add(s);
+                s.setColor(customAngleColors[i%3]);
+            }
+        }
+        return candidates;
+    }
+
+    @Override
+    protected List<LineSegment> calculate(Point baseSelected) {
+        return makePreviewLines(first.get(), baseSelected);
+    }
+
+    @Override
+    protected void draw(List<LineSegment> calculated, Graphics2D g2, Camera camera, DrawingSettings settings) {
+        for (LineSegment lineSegment : calculated) {
+            DrawingUtil.drawLineStep(g2, lineSegment, camera, settings.getLineWidth(), d.gridInputAssist);
+        }
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/AngleSystemLineSetCalculator.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/AngleSystemLineSetCalculator.java
@@ -1,6 +1,6 @@
 package oriedita.editor.action.selector;
 
-import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.drawing.tools.DrawingUtil;
 import origami.crease_pattern.OritaCalc;
@@ -87,9 +87,9 @@ public class AngleSystemLineSetCalculator extends CalculatedElementSelector<Poin
     }
 
     @Override
-    protected void draw(List<LineSegment> calculated, Graphics2D g2, Camera camera, DrawingSettings settings) {
+    public void draw(List<LineSegment> calculated, Graphics2D g2, Camera camera, DrawingSettings settings) {
         for (LineSegment lineSegment : calculated) {
-            DrawingUtil.drawLineStep(g2, lineSegment, camera, settings.getLineWidth(), d.gridInputAssist);
+            DrawingUtil.drawLineStep(g2, lineSegment, camera, settings);
         }
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/selector/BaseMouseHandler_WithSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/BaseMouseHandler_WithSelector.java
@@ -1,0 +1,132 @@
+package oriedita.editor.action.selector;
+
+import oriedita.editor.action.BaseMouseHandler;
+import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.drawing.tools.Camera;
+import origami.crease_pattern.element.Point;
+
+import java.awt.*;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public abstract class BaseMouseHandler_WithSelector extends BaseMouseHandler {
+    private final List<ElementSelector<?>> selectors = new ArrayList<>();
+    private ElementSelector<?> activeSelector;
+    // selectors will change their state, so they can't be used as map indices. We're using the index in the
+    // selectors list instead.
+    private final Map<Integer, Supplier<ElementSelector<?>>> nextSelectors = new HashMap<>();
+
+
+    public final <T, F extends ElementSelector<T>> F registerStartingSelector(
+            F startingSelector, Supplier<ElementSelector<?>> nextSelector
+    ) {
+        if (nextSelectors.containsKey(-1)) {
+            throw new IllegalStateException("Starting Selector already registered");
+        }
+        nextSelectors.put(-1, () -> startingSelector);
+        this.activeSelector = startingSelector;
+        return registerSelector(startingSelector, nextSelector);
+    }
+
+    public final <T,F extends ElementSelector<T>> F registerSelector(F selector, Supplier<ElementSelector<?>> nextSelector) {
+        selector.setCreasePattern_Worker(d);
+        this.nextSelectors.put(selectors.size(), nextSelector);
+        this.selectors.add(selector);
+        return selector;
+    }
+
+    @Override
+    public void drawPreview(Graphics2D g2, Camera camera, DrawingSettings settings) {
+        super.drawPreview(g2, camera, settings);
+        for (ElementSelector<?> selector : selectors) {
+            selector.draw(g2, camera, settings);
+        }
+    }
+
+    @Override
+    public void mouseMoved(Point p0, MouseEvent e) {
+        if (activeSelector != null) {
+            MouseEventInfo eventInfo = new MouseEventInfo(e);
+            this.activeSelector.update(p0, eventInfo);
+        }
+        super.mouseMoved(p0, e);
+    }
+
+    @Override
+    public void mousePressed(Point p0, MouseEvent e) {
+        MouseEventInfo eventInfo = new MouseEventInfo(e);
+        if (activeSelector != null) {
+            this.activeSelector.update(p0, eventInfo);
+            if (activeSelector.tryFinishSelection()) {
+                this.activeSelector = getNextSelector(activeSelector);
+            }
+        }
+        if (activeSelector == null) {
+            reset();
+        }
+        if (activeSelector != null) {
+            activeSelector.update(p0, eventInfo); // otherwise, preview would only start after moving the mouse
+        }
+        super.mousePressed(p0, e);
+    }
+
+    /**
+     * register all the selectors of the tools, as well as onFinish callbacks etc.
+     */
+    public abstract void setupSelectors();
+
+    /**
+     * which selector (if any) should come after the current selector. should only return selectors that were
+     * registered with registerSelector beforehand, or null if no selector should come afterwards.
+     */
+    protected ElementSelector<?> getNextSelector(ElementSelector<?> currentSelector) {
+        Supplier<ElementSelector<?>> nextSelector = nextSelectors.get(selectors.indexOf(currentSelector));
+        if (nextSelector != null) {
+            return nextSelector.get();
+        }
+        return null;
+    }
+
+    @Override
+    public void mouseDragged(Point p0, MouseEvent e) {
+        if (activeSelector != null) {
+            MouseEventInfo eventInfo = new MouseEventInfo(e);
+            this.activeSelector.update(p0, eventInfo);
+        }
+        super.mouseDragged(p0, e);
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        for (ElementSelector<?> selector : selectors) {
+            selector.reset();
+        }
+        if (!nextSelectors.containsKey(-1)) {
+            throw new IllegalStateException("No starting selector defined");
+        }
+        activeSelector = nextSelectors.get(-1).get();
+    }
+
+    // override all of these because they're usually not needed by the
+    // subclasses anymore
+    @Override
+    public void mouseMoved(Point p0) {
+    }
+
+    @Override
+    public void mousePressed(Point p0) {
+    }
+
+    @Override
+    public void mouseDragged(Point p0) {
+    }
+
+    @Override
+    public void mouseReleased(Point p0) {
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/BaseMouseHandler_WithSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/BaseMouseHandler_WithSelector.java
@@ -34,9 +34,8 @@ public abstract class BaseMouseHandler_WithSelector extends BaseMouseHandler {
     public final <T, F extends ElementSelector<T>> F registerStartingSelector(
             F startingSelector, FinishOn finishAction, Supplier<ElementSelector<?>> nextSelector
     ) {
-        if (nextSelectors.containsKey(-1)) {
-            throw new IllegalStateException("Starting Selector already registered");
-        }
+        assert !nextSelectors.containsKey(-1);
+
         nextSelectors.put(-1, () -> startingSelector);
         this.activeSelector = startingSelector;
         return registerSelector(startingSelector, finishAction, nextSelector);
@@ -50,6 +49,8 @@ public abstract class BaseMouseHandler_WithSelector extends BaseMouseHandler {
 
     public final <T,F extends ElementSelector<T>> F registerSelector(
             F selector, FinishOn finishAction, Supplier<ElementSelector<?>> nextSelector) {
+        assert !selectors.contains(selector);
+
         selector.setCreasePattern_Worker(d);
         this.nextSelectors.put(selectors.size(), nextSelector);
         this.finishActions.put(selectors.size(), finishAction);
@@ -139,9 +140,8 @@ public abstract class BaseMouseHandler_WithSelector extends BaseMouseHandler {
         for (ElementSelector<?> selector : selectors) {
             selector.reset();
         }
-        if (!nextSelectors.containsKey(-1)) {
-            throw new IllegalStateException("No starting selector defined");
-        }
+        assert nextSelectors.containsKey(-1);
+
         activeSelector = nextSelectors.get(-1).get();
     }
 

--- a/oriedita/src/main/java/oriedita/editor/action/selector/BaseMouseHandler_WithSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/BaseMouseHandler_WithSelector.java
@@ -21,7 +21,7 @@ public abstract class BaseMouseHandler_WithSelector extends BaseMouseHandler {
     private final Map<Integer, Supplier<ElementSelector<?>>> nextSelectors = new HashMap<>();
     private final Map<Integer, FinishOn> finishActions = new HashMap<>();
 
-    enum FinishOn {
+    public enum FinishOn {
         RELEASE, PRESS
     }
 
@@ -97,7 +97,8 @@ public abstract class BaseMouseHandler_WithSelector extends BaseMouseHandler {
                     activeSelector.update(mousePos, eventInfo); // otherwise, preview would only start after moving the mouse
                 }
             }
-        } else {
+        }
+        if (activeSelector == null) {
             reset();
         }
     }

--- a/oriedita/src/main/java/oriedita/editor/action/selector/BaseMouseHandler_WithSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/BaseMouseHandler_WithSelector.java
@@ -151,6 +151,12 @@ public abstract class BaseMouseHandler_WithSelector extends BaseMouseHandler {
         }
     }
 
+    protected void onAnyFail(Runnable callback, ElementSelector<?>... selectors) {
+        for (ElementSelector<?> selector : selectors) {
+            selector.onFail(callback);
+        }
+    }
+
     /**
      * register all the selectors of the tools, as well as onFinish callbacks etc.
      */

--- a/oriedita/src/main/java/oriedita/editor/action/selector/BaseMouseHandler_WithSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/BaseMouseHandler_WithSelector.java
@@ -2,7 +2,7 @@ package oriedita.editor.action.selector;
 
 import org.tinylog.Logger;
 import oriedita.editor.action.BaseMouseHandler;
-import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.drawing.tools.Camera;
 import origami.crease_pattern.element.Point;
 
@@ -62,7 +62,7 @@ public abstract class BaseMouseHandler_WithSelector extends BaseMouseHandler {
     public void drawPreview(Graphics2D g2, Camera camera, DrawingSettings settings) {
         super.drawPreview(g2, camera, settings);
         for (ElementSelector<?> selector : selectors) {
-            selector.draw(g2, camera, settings);
+            selector.drawPreview(g2, camera, settings);
         }
     }
 

--- a/oriedita/src/main/java/oriedita/editor/action/selector/CalculatedElementSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/CalculatedElementSelector.java
@@ -24,7 +24,10 @@ public abstract class CalculatedElementSelector<T, C> extends ElementSelector<C>
     @Override
     protected C determineSelected(Point mousePos, MouseEventInfo eventInfo) {
         T baseSelected = base.determineSelected(mousePos, eventInfo);
-        return calculate(baseSelected);
+        if (baseSelected != null) {
+            return calculate(baseSelected);
+        }
+        return null;
     }
 
     /**
@@ -34,13 +37,20 @@ public abstract class CalculatedElementSelector<T, C> extends ElementSelector<C>
     protected abstract C calculate(T baseSelected);
 
     @Override
+    protected boolean canFinishSelection() {
+        return super.canFinishSelection() && base.canFinishSelection();
+    }
+
+    @Override
     public boolean tryFinishSelection() {
-        if (base.canFinishSelection() && this.canFinishSelection()) {
+        if (canFinishSelection()) {
             base.finishSelection();
             super.finishSelection();
             return true;
 
         }
+        base.failSelection();
+        super.failSelection();
         return false;
     }
 

--- a/oriedita/src/main/java/oriedita/editor/action/selector/CalculatedElementSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/CalculatedElementSelector.java
@@ -1,0 +1,97 @@
+package oriedita.editor.action.selector;
+
+import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.canvas.CreasePattern_Worker;
+import oriedita.editor.drawing.tools.Camera;
+import origami.crease_pattern.element.Point;
+
+import java.awt.*;
+
+/**
+ * An element selector that calculates an element based on the selection from another selector.
+ * @param <T> Type of the base selector
+ * @param <C> Type of the calculated element
+ */
+public abstract class CalculatedElementSelector<T, C> extends ElementSelector<C> {
+    private final boolean drawBase;
+    private final ElementSelector<T> base;
+
+    public CalculatedElementSelector(ElementSelector<T> base, boolean drawBase) {
+        this.base = base;
+        this.drawBase = drawBase;
+    }
+
+    @Override
+    protected C determineSelected(Point mousePos, MouseEventInfo eventInfo) {
+        T baseSelected = base.determineSelected(mousePos, eventInfo);
+        return calculate(baseSelected);
+    }
+
+    /**
+     * Calculate the element
+     * @param baseSelected selection of the base selector
+     */
+    protected abstract C calculate(T baseSelected);
+
+    @Override
+    public boolean tryFinishSelection() {
+        if (base.canFinishSelection() && this.canFinishSelection()) {
+            base.finishSelection();
+            super.finishSelection();
+            return true;
+
+        }
+        return false;
+    }
+
+    @Override
+    public void update(Point mousePos, MouseEventInfo eventInfo) {
+        base.update(mousePos, eventInfo);
+        super.update(mousePos, eventInfo);
+    }
+
+    @Override
+    public void reset() {
+        base.reset();
+        super.reset();
+    }
+
+    @Override
+    protected final boolean validate(C element, MouseEventInfo eventInfo) {
+        return validate(base.getSelection(), element, eventInfo); // is only called if base is valid
+    }
+
+    protected boolean validate(T base, C calculated, MouseEventInfo eventInfo) {
+        return true;
+    }
+
+    @Override
+    public void draw(Graphics2D g2, Camera camera, DrawingSettings settings) {
+        if (drawBase) {
+            base.draw(g2, camera, settings);
+        }
+        super.draw(g2, camera, settings);
+    }
+
+    @Override
+    public boolean isSelectionFinished() {
+        return base.isSelectionFinished();
+    }
+
+    @Override
+    public boolean isHidden() {
+        return base.isHidden();
+    }
+
+    @Override
+    public void setHidden(boolean hidden) {
+        super.setHidden(hidden);
+        base.setHidden(hidden);
+    }
+
+    @Override
+    void setCreasePattern_Worker(CreasePattern_Worker d) {
+        super.setCreasePattern_Worker(d);
+        base.setCreasePattern_Worker(d);
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/CalculatedElementSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/CalculatedElementSelector.java
@@ -1,6 +1,6 @@
 package oriedita.editor.action.selector;
 
-import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.canvas.CreasePattern_Worker;
 import oriedita.editor.drawing.tools.Camera;
 import origami.crease_pattern.element.Point;
@@ -76,11 +76,11 @@ public abstract class CalculatedElementSelector<T, C> extends ElementSelector<C>
     }
 
     @Override
-    public void draw(Graphics2D g2, Camera camera, DrawingSettings settings) {
+    public void drawPreview(Graphics2D g2, Camera camera, DrawingSettings settings) {
         if (drawBase) {
-            base.draw(g2, camera, settings);
+            base.drawPreview(g2, camera, settings);
         }
-        super.draw(g2, camera, settings);
+        super.drawPreview(g2, camera, settings);
     }
 
     @Override

--- a/oriedita/src/main/java/oriedita/editor/action/selector/CircleCalculator.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/CircleCalculator.java
@@ -1,0 +1,31 @@
+package oriedita.editor.action.selector;
+
+import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.drawing.tools.Camera;
+import oriedita.editor.drawing.tools.DrawingUtil;
+import origami.crease_pattern.element.Circle;
+import origami.crease_pattern.element.LineColor;
+import origami.crease_pattern.element.LineSegment;
+import origami.crease_pattern.element.Point;
+
+import java.awt.*;
+import java.util.function.Supplier;
+
+public class CircleCalculator extends CalculatedElementSelector<LineSegment, Circle> {
+    private final Supplier<Point> center;
+
+    public CircleCalculator(Supplier<Point> center, ElementSelector<LineSegment> radius) {
+        super(radius, true);
+        this.center = center;
+    }
+
+    @Override
+    protected Circle calculate(LineSegment radius) {
+        return new Circle(center.get(), radius.determineLength(), LineColor.CYAN_3);
+    }
+
+    @Override
+    protected void draw(Circle element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+        DrawingUtil.drawCircleStep(g2, element, camera);
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/CircleCalculatorFromRadius.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/CircleCalculatorFromRadius.java
@@ -5,23 +5,22 @@ import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.drawing.tools.DrawingUtil;
 import origami.crease_pattern.element.Circle;
 import origami.crease_pattern.element.LineColor;
-import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 
 import java.awt.*;
 import java.util.function.Supplier;
 
-public class CircleCalculator extends CalculatedElementSelector<LineSegment, Circle> {
+public class CircleCalculatorFromRadius extends CalculatedElementSelector<Double, Circle> {
     private final Supplier<Point> center;
 
-    public CircleCalculator(Supplier<Point> center, ElementSelector<LineSegment> radius) {
+    public CircleCalculatorFromRadius(Supplier<Point> center, ElementSelector<Double> radius) {
         super(radius, true);
         this.center = center;
     }
 
     @Override
-    protected Circle calculate(LineSegment radius) {
-        return new Circle(center.get(), radius.determineLength(), LineColor.CYAN_3);
+    protected Circle calculate(Double radius) {
+        return new Circle(center.get(), radius, LineColor.CYAN_3);
     }
 
     @Override

--- a/oriedita/src/main/java/oriedita/editor/action/selector/CircleCalculatorFromRadius.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/CircleCalculatorFromRadius.java
@@ -1,6 +1,6 @@
 package oriedita.editor.action.selector;
 
-import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.drawing.tools.DrawingUtil;
 import origami.crease_pattern.element.Circle;
@@ -24,7 +24,7 @@ public class CircleCalculatorFromRadius extends CalculatedElementSelector<Double
     }
 
     @Override
-    protected void draw(Circle element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+    public void draw(Circle element, Graphics2D g2, Camera camera, DrawingSettings settings) {
         DrawingUtil.drawCircleStep(g2, element, camera);
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/selector/CircleSelectorFromIterable.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/CircleSelectorFromIterable.java
@@ -1,0 +1,66 @@
+package oriedita.editor.action.selector;
+
+import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.drawing.tools.Camera;
+import oriedita.editor.drawing.tools.DrawingUtil;
+import origami.crease_pattern.element.Circle;
+import origami.crease_pattern.element.LineColor;
+import origami.crease_pattern.element.Point;
+
+import java.awt.*;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class CircleSelectorFromIterable extends ElementSelector<Circle> {
+    private final Supplier<Iterable<Circle>> circleSet;
+    private final Function<Circle, LineColor> color;
+
+    public CircleSelectorFromIterable(Supplier<Iterable<Circle>> circleSet, Function<Circle, LineColor> color) {
+        this.circleSet = circleSet;
+        this.color = color;
+    }
+
+    @Override
+    protected Circle determineSelected(Point mousePos, MouseEventInfo eventInfo) {
+        Point p = d.camera.TV2object(mousePos);
+        double minBorderDist = 100000;
+        Circle minBorder = null;
+        double minCenterDist = 100000;
+        Circle minCenter = null;
+        for (Circle circle : circleSet.get()) {
+            double borderDist = Math.abs(circle.determineCenter().distance(p) - circle.getR());
+            double centerDist = circle.determineCenter().distance(p);
+            if (borderDist < minBorderDist) {
+                minBorder = circle;
+                minBorderDist = borderDist;
+            }
+            if (centerDist < minCenterDist) {
+                minCenter = circle;
+                minCenterDist = centerDist;
+            }
+        }
+        if (minBorderDist < d.selectionDistance) {
+            return copyWithColor(minBorder);
+        }
+        if (minCenterDist < d.selectionDistance) {
+            return copyWithColor(minCenter);
+        }
+        return null;
+    }
+
+    private Circle copyWithColor(Circle circle) {
+        Circle newCircle = new Circle(circle);
+        newCircle.setColor(color.apply(circle));
+        return newCircle;
+    }
+
+    @Override
+    protected boolean validate(Circle element, MouseEventInfo eventInfo) {
+        return element != null;
+    }
+
+    @Override
+    protected void draw(Circle element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+        DrawingUtil.drawCircleStep(g2, element, camera);
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/CircleSelectorFromIterable.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/CircleSelectorFromIterable.java
@@ -1,6 +1,6 @@
 package oriedita.editor.action.selector;
 
-import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.drawing.tools.DrawingUtil;
 import origami.crease_pattern.element.Circle;
@@ -60,7 +60,7 @@ public class CircleSelectorFromIterable extends ElementSelector<Circle> {
     }
 
     @Override
-    protected void draw(Circle element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+    public void draw(Circle element, Graphics2D g2, Camera camera, DrawingSettings settings) {
         DrawingUtil.drawCircleStep(g2, element, camera);
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/selector/ConditionalSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/ConditionalSelector.java
@@ -1,0 +1,95 @@
+package oriedita.editor.action.selector;
+
+import oriedita.editor.action.selector.drawing.DrawingSettings;
+import oriedita.editor.canvas.CreasePattern_Worker;
+import oriedita.editor.drawing.tools.Camera;
+import origami.crease_pattern.element.Point;
+
+import java.awt.*;
+
+public abstract class ConditionalSelector<T,U> extends ElementSelector<Object>{
+    private final ElementSelector<T> firstSelector;
+    private final ElementSelector<U> secondSelector;
+    private TypeChoice activeSelector;
+
+    public ConditionalSelector(ElementSelector<T> firstSelector,
+                               ElementSelector<U> secondSelector
+    ) {
+        this.firstSelector = firstSelector;
+        this.secondSelector = secondSelector;
+    }
+
+    @Override
+    protected Object determineSelected(Point mousePos, MouseEventInfo eventInfo) {
+        T first = firstSelector.determineSelected(mousePos, eventInfo);
+        U second = secondSelector.determineSelected(mousePos, eventInfo);
+        if (first == null) {
+            if (second != null) {
+                activeSelector = TypeChoice.SECOND;
+            } else {
+                activeSelector = null;
+            }
+            return second;
+        } else if (second == null) {
+            activeSelector = TypeChoice.FIRST;
+            return first;
+        }
+        TypeChoice c = choose(first, second, mousePos, eventInfo);
+        if (c == TypeChoice.FIRST) {
+            activeSelector = TypeChoice.FIRST;
+            return first;
+        } else if (c == TypeChoice.SECOND) {
+            activeSelector = TypeChoice.SECOND;
+            return second;
+        }
+        activeSelector = null;
+        return null;
+    }
+
+    @Override
+    protected boolean validate(Object element, MouseEventInfo eventInfo) {
+        if (activeSelector == TypeChoice.FIRST) {
+            return firstSelector.validate((T) element, eventInfo);
+        } else if (activeSelector == TypeChoice.SECOND) {
+            return secondSelector.validate((U) element, eventInfo);
+        }
+        return false;
+    }
+
+    @Override
+    public void draw(Object element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+        if (activeSelector == TypeChoice.FIRST) {
+            firstSelector.draw((T) element, g2, camera, settings);
+        } else if (activeSelector == TypeChoice.SECOND) {
+            secondSelector.draw((U) element, g2, camera, settings);
+        }
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        firstSelector.reset();
+        secondSelector.reset();
+        activeSelector = null;
+    }
+
+    @Override
+    public void update(Point mousePos, MouseEventInfo eventInfo) {
+        firstSelector.update(mousePos, eventInfo);
+        secondSelector.update(mousePos, eventInfo);
+        super.update(mousePos, eventInfo);
+    }
+
+    public enum TypeChoice {
+        FIRST, SECOND
+    }
+
+    @Override
+    void setCreasePattern_Worker(CreasePattern_Worker d) {
+        super.setCreasePattern_Worker(d);
+        firstSelector.setCreasePattern_Worker(d);
+        secondSelector.setCreasePattern_Worker(d);
+    }
+
+    protected abstract TypeChoice choose(T first, U second, Point mousePos, MouseEventInfo eventInfo);
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/CreasePatternPointSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/CreasePatternPointSelector.java
@@ -1,6 +1,6 @@
 package oriedita.editor.action.selector;
 
-import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.drawing.tools.DrawingUtil;
 import origami.crease_pattern.element.LineColor;
@@ -62,6 +62,6 @@ public class CreasePatternPointSelector extends ElementSelector<Point> {
 
     @Override
     public void draw(Point p, Graphics2D g2, Camera camera, DrawingSettings settings) {
-        DrawingUtil.drawStepVertex(g2, p, color.get(), camera, d.gridInputAssist);
+        DrawingUtil.drawStepVertex(g2, p, color.get(), camera, settings);
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/selector/CreasePatternPointSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/CreasePatternPointSelector.java
@@ -7,13 +7,14 @@ import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.Point;
 
 import java.awt.*;
+import java.util.function.Supplier;
 
 /**
  * Selects a Point out of the creasePattern in d
  */
 public class CreasePatternPointSelector extends ElementSelector<Point> {
     private final SelectionMode selectionMode;
-    private final LineColor color;
+    private final Supplier<LineColor> color;
 
     public enum SelectionMode {
         FREE(false), CLOSEST_POINT_ONLY(true), CLOSEST_POINT_OR_FREE(true);
@@ -29,6 +30,11 @@ public class CreasePatternPointSelector extends ElementSelector<Point> {
     }
 
     public CreasePatternPointSelector(SelectionMode selectionMode, LineColor color) {
+        this.selectionMode = selectionMode;
+        this.color = () -> color;
+    }
+
+    public CreasePatternPointSelector(SelectionMode selectionMode, Supplier<LineColor> color) {
         this.selectionMode = selectionMode;
         this.color = color;
     }
@@ -56,6 +62,6 @@ public class CreasePatternPointSelector extends ElementSelector<Point> {
 
     @Override
     public void draw(Point p, Graphics2D g2, Camera camera, DrawingSettings settings) {
-        DrawingUtil.drawStepVertex(g2, p, color, camera, d.gridInputAssist);
+        DrawingUtil.drawStepVertex(g2, p, color.get(), camera, d.gridInputAssist);
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/selector/CreasePatternPointSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/CreasePatternPointSelector.java
@@ -1,0 +1,61 @@
+package oriedita.editor.action.selector;
+
+import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.drawing.tools.Camera;
+import oriedita.editor.drawing.tools.DrawingUtil;
+import origami.crease_pattern.element.LineColor;
+import origami.crease_pattern.element.Point;
+
+import java.awt.*;
+
+/**
+ * Selects a Point out of the creasePattern in d
+ */
+public class CreasePatternPointSelector extends ElementSelector<Point> {
+    private final SelectionMode selectionMode;
+    private final LineColor color;
+
+    public enum SelectionMode {
+        FREE(false), CLOSEST_POINT_ONLY(true), CLOSEST_POINT_OR_FREE(true);
+        private final boolean snapToClosePoint;
+
+        SelectionMode(boolean snapToClosePoint) {
+            this.snapToClosePoint = snapToClosePoint;
+        }
+
+        public boolean shouldSnapToClosePoint() {
+            return snapToClosePoint;
+        }
+    }
+
+    public CreasePatternPointSelector(SelectionMode selectionMode, LineColor color) {
+        this.selectionMode = selectionMode;
+        this.color = color;
+    }
+
+    @Override
+    public Point determineSelected(Point mousePos, MouseEventInfo eventInfo) {
+        Point p = d.camera.TV2object(mousePos);
+        if (selectionMode.shouldSnapToClosePoint()) {
+            Point snapped = d.getClosestPoint(p);
+            if (snapped.distance(p) >= d.selectionDistance) {
+                snapped = p;
+            }
+            return snapped;
+        }
+        return p;
+    }
+
+    @Override
+    public boolean validate(Point p, MouseEventInfo eventInfo) {
+        if (selectionMode == SelectionMode.CLOSEST_POINT_ONLY) {
+            return p.equals(d.getClosestPoint(p));
+        }
+        return true;
+    }
+
+    @Override
+    public void draw(Point p, Graphics2D g2, Camera camera, DrawingSettings settings) {
+        DrawingUtil.drawStepVertex(g2, p, color, camera, d.gridInputAssist);
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/ElementSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/ElementSelector.java
@@ -156,14 +156,14 @@ public abstract class ElementSelector<T> implements Drawer<T> {
      * Creates a new ElementSelector that executes the operator on the selection of
      * this selector.
      * @param operator Operator to be applied on the selection of this selector
-     * @param drawOriginal whether to draw the original or the newly calculated Selection
+     * @param drawOriginal whether to draw the original
      */
-    public ElementSelector<T> then(UnaryOperator<T> operator, boolean drawOriginal) {
+    public ElementSelector<T> then(UnaryOperator<T> operator, boolean drawOriginal, boolean drawCalculated) {
         return new CalculatedElementSelector<>(this, drawOriginal) {
 
             @Override
             public void draw(T element, Graphics2D g2, Camera camera, DrawingSettings settings) {
-                if (!drawOriginal) {
+                if (drawCalculated) {
                     ElementSelector.this.draw(element, g2, camera, settings);
                 }
             }
@@ -175,12 +175,16 @@ public abstract class ElementSelector<T> implements Drawer<T> {
         };
     }
 
+    public <F> ElementSelector<F> thenGet(Function<T, F> getter) {
+        return thenGet(getter, (e, g, c, s) -> {});
+    }
+
     /**
      * Creates a new ElementSelector that executes the function on the selection of
      * this selector.
      * @param getter Function to be applied on the selection of this selector
      */
-    public <F> ElementSelector<F> thenGet(Function<T, F> getter) {
+    public <F> ElementSelector<F> thenGet(Function<T, F> getter, Drawer<F> drawer) {
         return new CalculatedElementSelector<>(this, true) {
             @Override
             protected F calculate(T baseSelected) {
@@ -189,6 +193,7 @@ public abstract class ElementSelector<T> implements Drawer<T> {
 
             @Override
             public void draw(F element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+                drawer.draw(element, g2, camera, settings);
             }
         };
     }

--- a/oriedita/src/main/java/oriedita/editor/action/selector/ElementSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/ElementSelector.java
@@ -1,0 +1,108 @@
+package oriedita.editor.action.selector;
+
+import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.canvas.CreasePattern_Worker;
+import oriedita.editor.drawing.tools.Camera;
+import origami.crease_pattern.element.Point;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * to simplify the drawing and implementation of tools where specific things have to be
+ * clicked on using the mouse, for example points, lines, circles, etc.
+ * @param <T> The kind of thing that is "selected" by clicking on it
+ */
+public abstract class ElementSelector<T> {
+    private T selected;
+    private boolean selectionFinished = false;
+    private MouseEventInfo eventInfo;
+    private boolean hidden = false;
+    private final List<Consumer<T>> observers = new ArrayList<>();
+    protected CreasePattern_Worker d;
+
+    /**
+     * returns the element that would get created if the mouse was clicked now,
+     * or just an element that is close to the mouse, gets called on mouseMove/Drag
+     * @param mousePos Position of the mouse on screen (usually, converting using Camera#TV2object is needed)
+     */
+    protected abstract T determineSelected(Point mousePos, MouseEventInfo eventInfo);
+
+    public void update(Point mousePos, MouseEventInfo eventInfo) {
+        if (selectionFinished) {
+            return;
+        }
+        this.selected = determineSelected(mousePos, eventInfo);
+        this.eventInfo = eventInfo;
+    }
+
+    /**
+     * tests whether the element is valid
+     */
+    protected abstract boolean validate(T element, MouseEventInfo eventInfo);
+
+    public boolean tryFinishSelection() {
+        if (canFinishSelection()) {
+            finishSelection();
+        }
+        return selectionFinished;
+    }
+
+    protected final boolean canFinishSelection() {
+        return eventInfo != null && validate(selected, eventInfo);
+    }
+
+    protected final void finishSelection() {
+        selectionFinished = true;
+        for (Consumer<T> observer : observers) {
+            observer.accept(selected);
+        }
+    }
+
+    public void onFinish(Consumer<T> callback) {
+        this.observers.add(callback);
+    }
+
+    /**
+     * @return the Element that is currently "selected". Return value does not always need to be valid
+     */
+    public T getSelection() {
+        return this.selected;
+    }
+
+    public void reset() {
+        eventInfo = null;
+        selected = null;
+        selectionFinished = false;
+        hidden = false;
+    }
+
+    public boolean isSelectionFinished() {
+        return selectionFinished;
+    }
+
+    /**
+     * draws a preview of the element that would be selected onto the graphics object.
+     */
+    protected abstract void draw(T element, Graphics2D g2, Camera camera, DrawingSettings settings);
+
+    public void draw(Graphics2D g2, Camera camera, DrawingSettings settings) {
+        if (selected != null && !hidden) {
+            draw(selected, g2, camera, settings);
+        }
+    }
+
+    public boolean isHidden() {
+        return hidden;
+    }
+
+    public void setHidden(boolean hidden) {
+        this.hidden = hidden;
+    }
+
+    void setCreasePattern_Worker(CreasePattern_Worker d) {
+        this.d = d;
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/ElementSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/ElementSelector.java
@@ -66,7 +66,7 @@ public abstract class ElementSelector<T> implements Drawer<T> {
     }
 
     protected boolean canFinishSelection() {
-        return eventInfo != null && validate(selected, eventInfo);
+        return eventInfo != null && selected != null && validate(selected, eventInfo);
     }
 
     protected final void finishSelection() {

--- a/oriedita/src/main/java/oriedita/editor/action/selector/ElementSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/ElementSelector.java
@@ -9,6 +9,7 @@ import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 /**
@@ -54,7 +55,7 @@ public abstract class ElementSelector<T> {
         return selectionFinished;
     }
 
-    protected final boolean canFinishSelection() {
+    protected boolean canFinishSelection() {
         return eventInfo != null && validate(selected, eventInfo);
     }
 
@@ -72,7 +73,7 @@ public abstract class ElementSelector<T> {
         this.finishObservers.add(callback);
     }
 
-    public void onFailedFinish(Runnable callback) {
+    public void onFail(Runnable callback) {
         this.failedFinishObservers.add(callback);
     }
 
@@ -132,5 +133,22 @@ public abstract class ElementSelector<T> {
                 return operator.apply(baseSelected);
             }
         };
+    }
+
+    public <F> ElementSelector<F> thenGet(Function<T, F> getter) {
+        return new CalculatedElementSelector<>(this, true) {
+            @Override
+            protected F calculate(T baseSelected) {
+                return getter.apply(baseSelected);
+            }
+
+            @Override
+            protected void draw(F element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+            }
+        };
+    }
+
+    public boolean hasFailedFinishCallback() {
+        return !failedFinishObservers.isEmpty();
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/selector/LineCalculatorFrom2Points.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/LineCalculatorFrom2Points.java
@@ -1,6 +1,6 @@
 package oriedita.editor.action.selector;
 
-import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.drawing.tools.DrawingUtil;
 import origami.crease_pattern.element.LineColor;
@@ -27,7 +27,7 @@ public class LineCalculatorFrom2Points extends CalculatedElementSelector<Point, 
     }
 
     @Override
-    protected void draw(LineSegment element, Graphics2D g2, Camera camera, DrawingSettings settings) {
-        DrawingUtil.drawLineStep(g2, element, camera, settings.getLineWidth(), d.gridInputAssist);
+    public void draw(LineSegment element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+        DrawingUtil.drawLineStep(g2, element, camera, settings);
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/selector/LineCalculatorFrom2Points.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/LineCalculatorFrom2Points.java
@@ -1,0 +1,33 @@
+package oriedita.editor.action.selector;
+
+import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.drawing.tools.Camera;
+import oriedita.editor.drawing.tools.DrawingUtil;
+import origami.crease_pattern.element.LineColor;
+import origami.crease_pattern.element.LineSegment;
+import origami.crease_pattern.element.Point;
+
+import java.awt.*;
+import java.util.function.Supplier;
+
+public class LineCalculatorFrom2Points extends CalculatedElementSelector<Point, LineSegment> {
+    private final Supplier<Point> firstPoint;
+    private final Supplier<LineColor> lineColor;
+
+    public LineCalculatorFrom2Points(
+            Supplier<Point> firstPoint, Supplier<LineColor> lineColor, ElementSelector<Point> secondPoint) {
+        super(secondPoint, true);
+        this.firstPoint = firstPoint;
+        this.lineColor = lineColor;
+    }
+
+    @Override
+    protected LineSegment calculate(Point baseSelected) {
+        return new LineSegment(firstPoint.get(), baseSelected, lineColor.get());
+    }
+
+    @Override
+    protected void draw(LineSegment element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+        DrawingUtil.drawLineStep(g2, element, camera, settings.getLineWidth(), d.gridInputAssist);
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/LineExtender.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/LineExtender.java
@@ -1,0 +1,52 @@
+package oriedita.editor.action.selector;
+
+import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.drawing.tools.Camera;
+import oriedita.editor.drawing.tools.DrawingUtil;
+import origami.Epsilon;
+import origami.crease_pattern.OritaCalc;
+import origami.crease_pattern.element.LineColor;
+import origami.crease_pattern.element.LineSegment;
+import origami.crease_pattern.element.Point;
+
+import java.awt.*;
+import java.util.function.Supplier;
+
+/**
+ * Extends the line segment supplied by segmentToExtend until it hits the (extension of the) line selected
+ * by lineSelector
+ */
+public class LineExtender extends CalculatedElementSelector<LineSegment, LineSegment> {
+    private final Supplier<LineSegment> segmentSupplier;
+    private final Supplier<LineColor> lineColorSupplier;
+
+    public LineExtender(Supplier<LineSegment> segmentToExtend,
+                        Supplier<LineColor> lineColor, ElementSelector<LineSegment> lineSelector) {
+        super(lineSelector, true);
+        segmentSupplier = segmentToExtend;
+        lineColorSupplier = lineColor;
+    }
+
+    @Override
+    protected LineSegment calculate(LineSegment closestSegment) {
+        LineSegment segment = this.segmentSupplier.get();
+        closestSegment.setColor(LineColor.GREEN_6);
+        Point startingPoint = new Point();
+        if (Epsilon.high.eq0(closestSegment.determineLength())) {
+            startingPoint.set(OritaCalc.findProjection(segment, closestSegment.getA()));
+        } else {
+            startingPoint.set(OritaCalc.findIntersection(closestSegment, segment));
+        }
+        return new LineSegment(segment.getA(), startingPoint, lineColorSupplier.get());
+    }
+
+    @Override
+    protected boolean validate(LineSegment selected, LineSegment calculated, MouseEventInfo eventInfo) {
+        return Epsilon.high.gt0(selected.determineLength());
+    }
+
+    @Override
+    protected void draw(LineSegment element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+        DrawingUtil.drawLineStep(g2, element, camera, settings.getLineWidth(), d.gridInputAssist);
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/LineExtender.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/LineExtender.java
@@ -1,6 +1,6 @@
 package oriedita.editor.action.selector;
 
-import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.drawing.tools.DrawingUtil;
 import origami.Epsilon;
@@ -46,7 +46,7 @@ public class LineExtender extends CalculatedElementSelector<LineSegment, LineSeg
     }
 
     @Override
-    protected void draw(LineSegment element, Graphics2D g2, Camera camera, DrawingSettings settings) {
-        DrawingUtil.drawLineStep(g2, element, camera, settings.getLineWidth(), d.gridInputAssist);
+    public void draw(LineSegment element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+        DrawingUtil.drawLineStep(g2, element, camera, settings);
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/selector/LineOrCircleSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/LineOrCircleSelector.java
@@ -1,0 +1,33 @@
+package oriedita.editor.action.selector;
+
+import origami.crease_pattern.OritaCalc;
+import origami.crease_pattern.element.Circle;
+import origami.crease_pattern.element.LineSegment;
+import origami.crease_pattern.element.Point;
+
+public class LineOrCircleSelector extends ConditionalSelector<LineSegment, Circle> {
+
+    public LineOrCircleSelector(ElementSelector<LineSegment> firstSelector, ElementSelector<Circle> secondSelector) {
+        super(firstSelector, secondSelector);
+    }
+
+    @Override
+    protected TypeChoice choose(LineSegment first, Circle second, Point mousePos, MouseEventInfo eventInfo) {
+        Point p = d.camera.TV2object(mousePos);
+        double lineDist = OritaCalc.determineLineSegmentDistance(p, first);
+        double circleCenterDist = second.determineCenter().distance(p);
+        double circleBorderDist = Math.abs(circleCenterDist - second.getR());
+        if (lineDist >= d.selectionDistance) {
+            if (circleBorderDist < d.selectionDistance || circleCenterDist < d.selectionDistance) {
+                return TypeChoice.SECOND;
+            }
+        } else if (circleBorderDist < d.selectionDistance) {
+            if (circleBorderDist < lineDist) {
+                return TypeChoice.SECOND;
+            } else {
+                return TypeChoice.FIRST;
+            }
+        }
+        return null;
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/LineSelector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/LineSelector.java
@@ -1,0 +1,67 @@
+package oriedita.editor.action.selector;
+
+import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.drawing.tools.Camera;
+import oriedita.editor.drawing.tools.DrawingUtil;
+import origami.crease_pattern.OritaCalc;
+import origami.crease_pattern.element.LineColor;
+import origami.crease_pattern.element.LineSegment;
+import origami.crease_pattern.element.Point;
+
+import java.awt.*;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Selects a line out of the line collection supplied by lineSegmentSetSupplier.
+ * noCloseLineValue determines what value is returned when there is no line in the selection radius
+ */
+public class LineSelector extends ElementSelector<LineSegment> {
+    private final LineColor color;
+    private final Supplier<Collection<LineSegment>> lineSegmentSetSupplier;
+    private final NoCloseLineValue noCloseLineValue;
+
+    public enum NoCloseLineValue {
+        NONE, MOUSE_POS
+    }
+
+    public LineSelector(
+            Supplier<Collection<LineSegment>> lineSegmentSetSupplier, LineColor color,
+            NoCloseLineValue noCloseLineValue) {
+        this.color = color;
+        this.lineSegmentSetSupplier = lineSegmentSetSupplier;
+        this.noCloseLineValue = noCloseLineValue;
+    }
+
+    @Override
+    protected LineSegment determineSelected(Point mousePos, MouseEventInfo eventInfo) {
+        Point p = d.camera.TV2object(mousePos);
+        Optional<LineSegment> closestLineSegmentO = lineSegmentSetSupplier.get().stream()
+                .min(Comparator.comparingDouble(cand -> OritaCalc.determineLineSegmentDistance(p, cand)));
+        if (closestLineSegmentO.isPresent()) {
+            LineSegment closestLineSegment = closestLineSegmentO.get();
+            if (OritaCalc.determineLineSegmentDistance(p, closestLineSegment) < d.selectionDistance) {
+                LineSegment s = new LineSegment();
+                s.set(closestLineSegment);
+                s.setColor(color);
+                return s;
+            }
+        }
+        if (noCloseLineValue == NoCloseLineValue.MOUSE_POS) {
+            return new LineSegment(p,p, color);
+        }
+        return null;
+    }
+
+    @Override
+    protected boolean validate(LineSegment element, MouseEventInfo eventInfo) {
+        return element != null;
+    }
+
+    @Override
+    protected void draw(LineSegment element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+        DrawingUtil.drawLineStep(g2, element, camera, settings.getLineWidth(), d.gridInputAssist);
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/LineSelectorFromCollection.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/LineSelectorFromCollection.java
@@ -18,7 +18,7 @@ import java.util.function.Supplier;
  * Selects a line out of the line collection supplied by lineSegmentSetSupplier.
  * noCloseLineValue determines what value is returned when there is no line in the selection radius
  */
-public class LineSelector extends ElementSelector<LineSegment> {
+public class LineSelectorFromCollection extends ElementSelector<LineSegment> {
     private final LineColor color;
     private final Supplier<Collection<LineSegment>> lineSegmentSetSupplier;
     private final NoCloseLineValue noCloseLineValue;
@@ -27,7 +27,7 @@ public class LineSelector extends ElementSelector<LineSegment> {
         NONE, MOUSE_POS
     }
 
-    public LineSelector(
+    public LineSelectorFromCollection(
             Supplier<Collection<LineSegment>> lineSegmentSetSupplier, LineColor color,
             NoCloseLineValue noCloseLineValue) {
         this.color = color;

--- a/oriedita/src/main/java/oriedita/editor/action/selector/LineSelectorFromCollection.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/LineSelectorFromCollection.java
@@ -1,6 +1,6 @@
 package oriedita.editor.action.selector;
 
-import oriedita.editor.action.DrawingSettings;
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.drawing.tools.DrawingUtil;
 import origami.crease_pattern.OritaCalc;
@@ -61,7 +61,7 @@ public class LineSelectorFromCollection extends ElementSelector<LineSegment> {
     }
 
     @Override
-    protected void draw(LineSegment element, Graphics2D g2, Camera camera, DrawingSettings settings) {
-        DrawingUtil.drawLineStep(g2, element, camera, settings.getLineWidth(), d.gridInputAssist);
+    public void draw(LineSegment element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+        DrawingUtil.drawLineStep(g2, element, camera, settings);
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/action/selector/MouseEventInfo.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/MouseEventInfo.java
@@ -1,0 +1,18 @@
+package oriedita.editor.action.selector;
+
+import java.awt.event.MouseEvent;
+
+/**
+ * To decouple selectors from AWT as much as possible
+ */
+public class MouseEventInfo {
+    private final boolean isCtrlDown;
+
+    public MouseEventInfo(MouseEvent e) {
+        this.isCtrlDown = e.isControlDown();
+    }
+
+    public boolean isCtrlDown() {
+        return isCtrlDown;
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/TouchingConcentricCirclesCalculator.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/TouchingConcentricCirclesCalculator.java
@@ -1,0 +1,50 @@
+package oriedita.editor.action.selector;
+
+import oriedita.editor.action.selector.drawing.DrawingSettings;
+import oriedita.editor.drawing.tools.Camera;
+import oriedita.editor.drawing.tools.DrawingUtil;
+import origami.Epsilon;
+import origami.crease_pattern.OritaCalc;
+import origami.crease_pattern.element.Circle;
+import origami.crease_pattern.element.LineColor;
+
+import java.awt.*;
+import java.util.Arrays;
+import java.util.function.Supplier;
+
+public class TouchingConcentricCirclesCalculator extends CalculatedElementSelector<Circle, Iterable<Circle>> {
+    private final Supplier<Circle> firstCircle;
+
+    public TouchingConcentricCirclesCalculator(Supplier<Circle> firstCircle, ElementSelector<Circle> base) {
+        super(base, true);
+        this.firstCircle = firstCircle;
+    }
+
+    @Override
+    protected Iterable<Circle> calculate(Circle baseSelected) {
+        Circle circle1 = new Circle(firstCircle.get());
+        Circle circle2 = new Circle(baseSelected);
+        double add_r = (OritaCalc.distance(circle1.determineCenter(), circle2.determineCenter()) - circle1.getR() - circle2.getR()) / 2;
+
+        if (!Epsilon.high.eq0(add_r)) {
+            double new_r1 = add_r + circle1.getR();
+            double new_r2 = add_r + circle2.getR();
+
+            if (Epsilon.high.gt0(new_r1) && Epsilon.high.gt0(new_r2)) {
+                circle1.setR(new_r1);
+                circle1.setColor(LineColor.CYAN_3);
+                circle2.setR(new_r2);
+                circle2.setColor(LineColor.CYAN_3);
+                return Arrays.asList(circle1, circle2);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void draw(Iterable<Circle> element, Graphics2D g2, Camera camera, DrawingSettings settings) {
+        for (Circle circle : element) {
+            DrawingUtil.drawCircleStep(g2, circle, camera);
+        }
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/drawing/Drawer.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/drawing/Drawer.java
@@ -1,0 +1,17 @@
+package oriedita.editor.action.selector.drawing;
+
+import oriedita.editor.drawing.tools.Camera;
+
+import java.awt.*;
+
+/**
+ * Can draw Elements of the type T to a Graphics2D object
+ * @param <T> Type of the element that can be drawn
+ */
+@FunctionalInterface
+public interface Drawer<T>  {
+    /**
+     * Draws an element to the graphics object
+     */
+    void draw(T element, Graphics2D g,  Camera camera, DrawingSettings settings);
+}

--- a/oriedita/src/main/java/oriedita/editor/action/selector/drawing/DrawingSettings.java
+++ b/oriedita/src/main/java/oriedita/editor/action/selector/drawing/DrawingSettings.java
@@ -1,12 +1,24 @@
-package oriedita.editor.action;
+package oriedita.editor.action.selector.drawing;
 
 import oriedita.editor.canvas.LineStyle;
 
+/**
+ * Data class to contain all settings related to rendering
+ */
 public class DrawingSettings {
     private float lineWidth;
     private LineStyle lineStyle;
     private int height;
     private int width;
+    private boolean gridInputAssist;
+
+    public boolean displayGridInputAssist() {
+        return gridInputAssist;
+    }
+
+    public void setGridInputAssist(boolean gridInputAssist) {
+        this.gridInputAssist = gridInputAssist;
+    }
 
     public int getHeight() {
         return height;
@@ -24,11 +36,12 @@ public class DrawingSettings {
         this.width = width;
     }
 
-    public DrawingSettings(float lineWidth, LineStyle lineStyle, int height, int width) {
+    public DrawingSettings(float lineWidth, LineStyle lineStyle, int height, int width, boolean gridInputAssist) {
         this.lineWidth = lineWidth;
         this.lineStyle = lineStyle;
         this.width = width;
         this.height = height;
+        this.gridInputAssist = gridInputAssist;
     }
 
     public LineStyle getLineStyle() {

--- a/oriedita/src/main/java/oriedita/editor/canvas/CreasePattern_Worker.java
+++ b/oriedita/src/main/java/oriedita/editor/canvas/CreasePattern_Worker.java
@@ -1007,6 +1007,10 @@ public class CreasePattern_Worker {
         this.foldLineSet.selectProbablyConnected(p);
     }
 
+    public LineColor getLineColor() {
+        return lineColor;
+    }
+
     //30 30 30 30 30 30 30 30 30 30 30 30 除け_線_変換
     public enum FourPointStep {
         STEP_0,

--- a/oriedita/src/main/java/oriedita/editor/drawing/tools/DrawingUtil.java
+++ b/oriedita/src/main/java/oriedita/editor/drawing/tools/DrawingUtil.java
@@ -1,6 +1,7 @@
 package oriedita.editor.drawing.tools;
 
 import oriedita.editor.Colors;
+import oriedita.editor.action.selector.drawing.DrawingSettings;
 import oriedita.editor.canvas.LineStyle;
 import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
@@ -288,6 +289,10 @@ public class DrawingUtil {
         }
     }
 
+    public static void drawLineStep(Graphics g, LineSegment s, Camera camera, DrawingSettings settings) {
+        drawLineStep(g, s, camera, settings.getLineWidth(), settings.displayGridInputAssist());
+    }
+
     public static void drawLineStep(Graphics g, LineSegment s, Camera camera, float lineWidth, boolean gridInputAssist) {
         Graphics2D g2 = (Graphics2D) g;
         setColor(g, s.getColor());
@@ -321,6 +326,10 @@ public class DrawingUtil {
             default:
                 break;
         }
+    }
+
+    public static void drawStepVertex(Graphics2D g, Point p, LineColor color, Camera camera, DrawingSettings s) {
+        drawStepVertex(g, p, color, camera, s.displayGridInputAssist());
     }
 
     public static void drawStepVertex(Graphics2D g, Point p, LineColor color, Camera camera, boolean gridInputAssist) {

--- a/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -3589,6 +3589,14 @@ public class FoldLineSet {
         }
     }
 
+    public Collection<LineSegment> getLines() {
+        List<LineSegment> lineSegments = new ArrayList<>();
+        for (int i = 1; i <= total; i++) {
+            lineSegments.add(get(i));
+        }
+        return lineSegments;
+    }
+
     /**
      * Internal class used for quickly copying the contents of a foldlineset.
      */

--- a/origami/src/main/java/origami/crease_pattern/OritaCalc.java
+++ b/origami/src/main/java/origami/crease_pattern/OritaCalc.java
@@ -1,9 +1,9 @@
 package origami.crease_pattern;
 
-import origami.crease_pattern.element.LineSegment;
-import origami.crease_pattern.element.Point;
 import origami.Epsilon;
 import origami.crease_pattern.element.Circle;
+import origami.crease_pattern.element.LineSegment;
+import origami.crease_pattern.element.Point;
 import origami.crease_pattern.element.StraightLine;
 
 /**
@@ -1069,6 +1069,52 @@ public class OritaCalc {
     //--------------------------------------------------------
     public static boolean lineSegment_X_kousa_decide(LineSegment s1, LineSegment s2) {//0はX交差しない。1は交差する。20201017追加
         return determineLineSegmentIntersection(s1, s2, Epsilon.UNKNOWN_1EN4) == LineSegment.Intersection.INTERSECTS_1;
+    }
+
+    public static boolean collinear(Point p1, Point p2, Point p3) {
+        LineSegment sen1 = new LineSegment(p1, p2);
+        if (Epsilon.high.le0(sen1.determineLength())) {
+            return true;
+        }
+        LineSegment sen2 = new LineSegment(p1, p3);
+        if (Epsilon.high.le0(sen2.determineLength())) {
+            return true;
+        }
+        LineSegment sen3 = new LineSegment(p2, p3);
+        if (Epsilon.high.le0(sen3.determineLength())) {
+            return true;
+        }
+
+        if (Math.abs(OritaCalc.angle(sen1, sen2) - 0.0) < Epsilon.UNKNOWN_1EN6) {
+            return true;
+        }
+        if (Math.abs(OritaCalc.angle(sen1, sen2) - 180.0) < Epsilon.UNKNOWN_1EN6) {
+            return true;
+        }
+        if (Math.abs(OritaCalc.angle(sen1, sen2) - 360.0) < Epsilon.UNKNOWN_1EN6) {
+            return true;
+        }
+
+        if (Math.abs(OritaCalc.angle(sen2, sen3) - 0.0) < Epsilon.UNKNOWN_1EN6) {
+            return true;
+        }
+        if (Math.abs(OritaCalc.angle(sen2, sen3) - 180.0) < Epsilon.UNKNOWN_1EN6) {
+            return true;
+        }
+        if (Math.abs(OritaCalc.angle(sen2, sen3) - 360.0) < Epsilon.UNKNOWN_1EN6) {
+            return true;
+        }
+
+        if (Math.abs(OritaCalc.angle(sen3, sen1) - 0.0) < Epsilon.UNKNOWN_1EN6) {
+            return true;
+        }
+        if (Math.abs(OritaCalc.angle(sen3, sen1) - 180.0) < Epsilon.UNKNOWN_1EN6) {
+            return true;
+        }
+        if (Math.abs(OritaCalc.angle(sen3, sen1) - 360.0) < Epsilon.UNKNOWN_1EN6) {
+            return true;
+        }
+        return false;
     }
 
     public enum ParallelJudgement {


### PR DESCRIPTION
I tried to make a system for the `MouseHandler`s that is more independent of the specific events (`mousePressed`/`Moved`/`Released`/`Dragged`), but still allows for nice previews without having to worry about state management in each Handler separately. In `MouseHandlerAngleSystem` (which can be used with the circled button) I implemented an example of how I imagine the system would be used.
![grafik](https://user-images.githubusercontent.com/20705949/145681625-a7131bf9-88c0-4489-bc4e-ea8416874475.png)


If anyone has any feedback on this, I'd be very happy to hear it, especially the parts you don't like about it (one thing I don't like is that most parameters have to be passed as `Supplier`s, but I haven't found a solution to that yet unfortunately), or cases/tools where the system might not be usable. Suggestions to improve the naming are also very welcome.

The basic idea is that each mouse handler usually "selects" some elements like points, lines or circles (meaning you click on them, and they become highlighted, not necessarily the kind of selection where the lines turn green), and then performs some calculations with them, before applying the result on the cp (usually by removing/adding elements).

Now, my approach was to extract different kinds of "Selectors" that are reused in different tools (e.g. `CreasePatternPointSelector` for selecting a Point on the cp, with different snapping options, or `LineSelector` for selecting a `LineSegment` out of an arbitrary set of them) and have the possibility to create "Calculators", which take the selection of a selector, along with some extra info, and calculate something based on that (e.g. `LineExtender`, which extends a given line until it hits the line selected by the `LineSelector`).

The selection is recalculated and rendered on `mouseMove`/`Drag`, so you always get a preview of what would happen if you clicked now. Additionally, Selectors/Calculators can select "invalid" elements, that are useful for previewing, but if you click while having an invalid element selected, nothing will happen. Determining whether a selected element is valid is done using the `validate` method. When clicking with a valid element selected, the next selector will automatically be activated if there is one, otherwise the handler will reset and start again with its starting selector.

The Selector/Calculator subclasses should ideally be implemented without side effects (except for drawing), changing the internal state is handled in the abstract superclasses.

(The `FoldLineSet.getLines()` method is temporary to get the tool working, I'm sure there are more performant ways to do that)