### PR TITLE
Fix rightclick eraser behaving weirdly

### DIFF
--- a/oriedita/src/main/java/oriedita/editor/Canvas.java
+++ b/oriedita/src/main/java/oriedita/editor/Canvas.java
@@ -4,6 +4,7 @@ import org.tinylog.Logger;
 import oriedita.editor.action.DrawingSettings;
 import oriedita.editor.action.MouseModeHandler;
 import oriedita.editor.canvas.CreasePattern_Worker;
+import oriedita.editor.canvas.FoldLineAdditionalInputMode;
 import oriedita.editor.canvas.LineStyle;
 import oriedita.editor.canvas.MouseMode;
 import oriedita.editor.databinding.*;
@@ -433,6 +434,9 @@ public class Canvas extends JPanel implements MouseListener, MouseMotionListener
             case MouseEvent.BUTTON3:
                 mainCreasePatternWorker.setCamera(creasePatternCamera);
                 activeMouseHandler.reset();
+                if (activeMouseHandler.getMouseMode() != MouseMode.LINE_SEGMENT_DELETE_3) {
+                    mainCreasePatternWorker.i_foldLine_additional = FoldLineAdditionalInputMode.BOTH_4;
+                }
                 mouseModeHandlers.get(MouseMode.LINE_SEGMENT_DELETE_3).mousePressed(p, e);
                 activeMouseHandler = mouseModeHandlers.get(MouseMode.LINE_SEGMENT_DELETE_3);
                 repaint();


### PR DESCRIPTION
using rightclick to erase would sometimes switch between only deleting aux and only deleting fold lines, now it deletes everything again (except if youre currently using an eraser tool, then right click does the same thing as left click)