### PR TITLE
Perpendicular tool's new feature

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -40,7 +40,7 @@
           <entry name="$MAVEN_REPOSITORY$/net/ltgt/gradle/incap/incap/0.2/incap-0.2.jar" />
           <entry name="$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-metadata-jvm/0.3.0/kotlinx-metadata-jvm-0.3.0.jar" />
         </processorPath>
-        <module name="oriedita (1)" />
+        <module name="oriedita" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -40,7 +40,7 @@
           <entry name="$MAVEN_REPOSITORY$/net/ltgt/gradle/incap/incap/0.2/incap-0.2.jar" />
           <entry name="$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-metadata-jvm/0.3.0/kotlinx-metadata-jvm-0.3.0.jar" />
         </processorPath>
-        <module name="oriedita" />
+        <module name="oriedita (1)" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerPerpendicularDraw.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerPerpendicularDraw.java
@@ -43,28 +43,29 @@ public class MouseHandlerPerpendicularDraw extends BaseMouseHandlerInputRestrict
             }
         }
 
-        //Step 2: Click a line
+        //Step 2: Click a destination line / base line
         if (d.lineStep.size() == 1) {
 
             LineSegment closestLineSegment = new LineSegment();
             closestLineSegment.set(d.getClosestLineSegment(p));
 
-            if (OritaCalc.determineLineSegmentDistance(p, closestLineSegment) < d.selectionDistance) {
-                closestLineSegment.setColor(LineColor.GREEN_6);
-                d.lineStepAdd(closestLineSegment);
+            if (!(OritaCalc.determineLineSegmentDistance(p, closestLineSegment) < d.selectionDistance)) {
+                return;
+            }
+            closestLineSegment.setColor(LineColor.GREEN_6);
+            d.lineStepAdd(closestLineSegment);
 
-                //Step 3 (situational): Show purple candidate line if the selected line goes through the selected point
-                if(OritaCalc.determineLineSegmentDistance(d.lineStep.get(0).getA(), d.lineStep.get(1)) < Epsilon.UNKNOWN_1EN4){
-                    d.lineStepAdd(new LineSegment(d.lineStep.get(0).getA(), OritaCalc.findProjection(OritaCalc.moveParallel(d.lineStep.get(1), 25.0), d.lineStep.get(0).getA())));
-                    d.lineStepAdd(new LineSegment(d.lineStep.get(0).getA(), OritaCalc.findProjection(OritaCalc.moveParallel(d.lineStep.get(1), -25.0), d.lineStep.get(0).getA())));
-                    d.lineStep.get(2).setColor(LineColor.PURPLE_8);
-                    d.lineStep.get(3).setColor(LineColor.PURPLE_8);
-                }
+            //Step 3 (situational if clicked base line): Show purple candidate line if the selected line goes through the selected point
+            if(OritaCalc.determineLineSegmentDistance(d.lineStep.get(0).getA(), d.lineStep.get(1)) < Epsilon.UNKNOWN_1EN4){
+                d.lineStepAdd(new LineSegment(d.lineStep.get(0).getA(), OritaCalc.findProjection(OritaCalc.moveParallel(d.lineStep.get(1), 25.0), d.lineStep.get(0).getA())));
+                d.lineStepAdd(new LineSegment(d.lineStep.get(0).getA(), OritaCalc.findProjection(OritaCalc.moveParallel(d.lineStep.get(1), -25.0), d.lineStep.get(0).getA())));
+                d.lineStep.get(2).setColor(LineColor.PURPLE_8);
+                d.lineStep.get(3).setColor(LineColor.PURPLE_8);
             }
             return;
         }
 
-        //Continuation from step 3
+        //Continuation from step 3: Click a final destination line
         if(d.lineStep.size() == 4){
 
             LineSegment closestLineSegment = new LineSegment();
@@ -97,7 +98,6 @@ public class MouseHandlerPerpendicularDraw extends BaseMouseHandlerInputRestrict
                     d.addLineSegment(d.lineStep.get(3));
                     d.record();
                 }
-                //d.lineStep.clear();
             } else{
                 //直線t上の点pの影の位置（点pと最も近い直線t上の位置）を求める。public Ten oc.kage_motome(Tyokusen t,Ten p){
 

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerPerpendicularDraw.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerPerpendicularDraw.java
@@ -88,7 +88,6 @@ public class MouseHandlerPerpendicularDraw extends BaseMouseHandlerInputRestrict
         if (d.lineStep.size() == 2) {
 
             //直線t上の点pの影の位置（点pと最も近い直線t上の位置）を求める。public Ten oc.kage_motome(Tyokusen t,Ten p){
-
             LineSegment add_sen = new LineSegment(d.lineStep.get(0).getA(), OritaCalc.findProjection(OritaCalc.lineSegmentToStraightLine(d.lineStep.get(1)), d.lineStep.get(0).getA()), d.lineColor);
 
             if (Epsilon.high.gt0(add_sen.determineLength())) {

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerPerpendicularDraw.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerPerpendicularDraw.java
@@ -87,28 +87,16 @@ public class MouseHandlerPerpendicularDraw extends BaseMouseHandlerInputRestrict
 
         if (d.lineStep.size() == 2) {
 
-            if(OritaCalc.determineLineSegmentDistance(d.lineStep.get(0).getA(), d.lineStep.get(1)) < Epsilon.UNKNOWN_1EN4){
+            //直線t上の点pの影の位置（点pと最も近い直線t上の位置）を求める。public Ten oc.kage_motome(Tyokusen t,Ten p){
 
-                if (Epsilon.high.gt0(d.lineStep.get(2).determineLength())) {
-                    d.addLineSegment(d.lineStep.get(2));
-                    d.record();
-                }
+            LineSegment add_sen = new LineSegment(d.lineStep.get(0).getA(), OritaCalc.findProjection(OritaCalc.lineSegmentToStraightLine(d.lineStep.get(1)), d.lineStep.get(0).getA()), d.lineColor);
 
-                if (Epsilon.high.gt0(d.lineStep.get(3).determineLength())) {
-                    d.addLineSegment(d.lineStep.get(3));
-                    d.record();
-                }
-            } else{
-                //直線t上の点pの影の位置（点pと最も近い直線t上の位置）を求める。public Ten oc.kage_motome(Tyokusen t,Ten p){
-
-                LineSegment add_sen = new LineSegment(d.lineStep.get(0).getA(), OritaCalc.findProjection(OritaCalc.lineSegmentToStraightLine(d.lineStep.get(1)), d.lineStep.get(0).getA()), d.lineColor);
-
-                if (Epsilon.high.gt0(add_sen.determineLength())) {
-                    d.addLineSegment(add_sen);
-                    d.record();
-                }
-                d.lineStep.clear();
+            if (Epsilon.high.gt0(add_sen.determineLength())) {
+                d.addLineSegment(add_sen);
+                d.record();
             }
+
+            d.lineStep.clear();
         } else if (d.lineStep.size() == 5) {
 
             LineSegment point = d.lineStep.get(0); //Point


### PR DESCRIPTION
Perpendicular in previous versions used to function in sequential order: select a point to begin drawing, and then a crease (**one that the point isn't lying on**) to draw properly. However, the issue (though somewhat minor) 
is that the tool doesn't do anything when selecting the crease containing the point. 

Therefore, inspired by OrigamiDraw, I decided to make a new feature that takes advantage of selecting its own crease. When the previous sequence is performed, it will **create an indicator of a new line** perpendicular to the selected crease. The user can then **select the destination crease for the new line to extend to**.


https://user-images.githubusercontent.com/94136126/170590719-42b76f9a-4d68-4711-90a7-b0f6e11015e3.mp4

