### PR TITLE
Bisector tool's new features

### DIFF
--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerSquareBisector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerSquareBisector.java
@@ -146,8 +146,8 @@ public class MouseHandlerSquareBisector extends BaseMouseHandlerInputRestricted 
 
                 /*
                  Draw purple indicators for bisector
-                 At this point, there should only be 2 lines in lineStep (first 2 initial line clicks)
-                 --> Next 2 should be at index 2 and 3
+                 At this point, there should be 3 lines in lineStep (first 2 initial line clicks and a line for midpoint)
+                 --> Next 2 should be at index 3 and 4
                 */
                 LineSegment tempPerpenLine = new LineSegment();
                 tempPerpenLine.set(d.lineStep.get(1).getA(), projectedPoint);
@@ -155,19 +155,6 @@ public class MouseHandlerSquareBisector extends BaseMouseHandlerInputRestricted 
                 d.lineStep.get(3).setColor(LineColor.PURPLE_8);
                 d.lineStepAdd(new LineSegment(midPoint, OritaCalc.findProjection(OritaCalc.moveParallel(tempPerpenLine, 25.0), midPoint)));
                 d.lineStep.get(4).setColor(LineColor.PURPLE_8);
-
-                // Make the purple bisector indicators parallel to one of the first 2 lines
-                LineSegment bisector1 = OritaCalc.s_step_additional_intersection(d.lineStep.get(2), d.lineStep.get(3), d.lineColor);
-                LineSegment bisector2 = OritaCalc.s_step_additional_intersection(d.lineStep.get(2), d.lineStep.get(4), d.lineColor);
-
-                if (bisector1 != null) {
-                    d.lineStepAdd(bisector1);
-                    d.record();
-                }
-                if (bisector2 != null) {
-                    d.lineStepAdd(bisector2);
-                    d.record();
-                }
             }
             // Step 2: Get the 2 destination lines and form the actual bisector
             if(d.lineStep.size() == 7){

--- a/oriedita/src/main/java/oriedita/editor/action/MouseHandlerSquareBisector.java
+++ b/oriedita/src/main/java/oriedita/editor/action/MouseHandlerSquareBisector.java
@@ -37,6 +37,7 @@ public class MouseHandlerSquareBisector extends BaseMouseHandlerInputRestricted 
         // If condition is for 2 lines bisect
         if((d.lineStep.isEmpty() || d.lineStep.get(0).determineLength() > 0)){
             // Click 2 lines to form bisect and then a destination line
+            // Only in first line click, no point is allowed within the selection radius
             if(d.lineStep.size() == 0 && d.getClosestPoint(p).distance(p) > d.selectionDistance) {
                 line.set(d.getClosestLineSegment(p));
                 if (OritaCalc.determineLineSegmentDistance(p, line) < d.selectionDistance) {
@@ -99,34 +100,94 @@ public class MouseHandlerSquareBisector extends BaseMouseHandlerInputRestricted 
             d.lineStep.clear();
         }
         // Calculation for 2 lines
-        else if (d.lineStep.size() == 3 && d.lineStep.get(0).determineLength() > 0){
-            // Find intersection of 2 lines
-            Point intersection = new Point();
-            intersection.set(OritaCalc.findIntersection(d.lineStep.get(0), d.lineStep.get(1)));
+        else if (d.lineStep.size() >= 2 && d.lineStep.get(0).determineLength() > 0){
+            // When there are 3 lines and the first 2 lines aren't parallel
+            if(OritaCalc.isLineSegmentParallel(d.lineStep.get(0), d.lineStep.get(1), Epsilon.UNKNOWN_1EN4) == OritaCalc.ParallelJudgement.NOT_PARALLEL && d.lineStep.size() == 3){
+                // Find intersection of 2 lines
+                Point intersection = new Point();
+                intersection.set(OritaCalc.findIntersection(d.lineStep.get(0), d.lineStep.get(1)));
 
-            // Find another point by taking the center point of 3 points
-            /* 2 points that are not the intersection have to be far away from said intersection
-             * to prevent them from being the intersection themselves, which can cause problems when
-             * finding the triangle center.
-             */
-            Point center = new Point();
-            center.set(OritaCalc.center(intersection, d.lineStep.get(0).determineFurthestEndpoint(intersection), d.lineStep.get(1).determineFurthestEndpoint(intersection)));
+                // Find another point by taking the center point of 3 points
+                /* 2 points that are not the intersection have to be far away from said intersection
+                 * to prevent them from being the intersection themselves, which can cause problems when
+                 * finding the triangle center.
+                 */
+                Point center = new Point();
+                center.set(OritaCalc.center(intersection, d.lineStep.get(0).determineFurthestEndpoint(intersection), d.lineStep.get(1).determineFurthestEndpoint(intersection)));
 
-            // Make a temporary line to connect intersection and center
-            LineSegment tempBisect = new LineSegment(intersection, center);
+                // Make a temporary line to connect intersection and center
+                LineSegment tempBisect = new LineSegment(intersection, center);
 
-            // Find intersection of temp line to the destination line
-            Point cross_point = new Point();
-            cross_point.set(OritaCalc.findIntersection(tempBisect, d.lineStep.get(2)));
+                // Find intersection of temp line to the destination line
+                Point cross_point = new Point();
+                cross_point.set(OritaCalc.findIntersection(tempBisect, d.lineStep.get(2)));
 
-            // Draw the bisector
-            LineSegment destinationLine = new LineSegment(cross_point, intersection, d.lineColor);
-            if (Epsilon.high.gt0(destinationLine.determineLength())) {
-                d.addLineSegment(destinationLine);
-                d.record();
+                // Draw the bisector
+                LineSegment destinationLine = new LineSegment(cross_point, intersection, d.lineColor);
+                if (Epsilon.high.gt0(destinationLine.determineLength())) {
+                    d.addLineSegment(destinationLine);
+                    d.record();
+                }
+
+                d.lineStep.clear();
             }
 
-            d.lineStep.clear();
+            // When the first 2 lines are parallel
+            // Step 1: draw the bisector indicator
+            else if(OritaCalc.isLineSegmentParallel(d.lineStep.get(0), d.lineStep.get(1), Epsilon.UNKNOWN_1EN4) == OritaCalc.ParallelJudgement.PARALLEL_NOT_EQUAL && d.lineStep.size() == 2){
+                // Get a point projected on the other line
+                Point projectedPoint = new Point();
+                projectedPoint.set(OritaCalc.findProjection(d.lineStep.get(0), d.lineStep.get(1).getA()));
+
+                // Get midpoint
+                Point midPoint = new Point();
+                midPoint.set(OritaCalc.midPoint(d.lineStep.get(1).getA(), projectedPoint));
+                d.lineStepAdd(new LineSegment(midPoint, midPoint, d.lineColor));
+
+                /*
+                 Draw purple indicators for bisector
+                 At this point, there should only be 2 lines in lineStep (first 2 initial line clicks)
+                 --> Next 2 should be at index 2 and 3
+                */
+                LineSegment tempPerpenLine = new LineSegment();
+                tempPerpenLine.set(d.lineStep.get(1).getA(), projectedPoint);
+                d.lineStepAdd(new LineSegment(midPoint, OritaCalc.findProjection(OritaCalc.moveParallel(tempPerpenLine, -25.0), midPoint)));
+                d.lineStep.get(3).setColor(LineColor.PURPLE_8);
+                d.lineStepAdd(new LineSegment(midPoint, OritaCalc.findProjection(OritaCalc.moveParallel(tempPerpenLine, 25.0), midPoint)));
+                d.lineStep.get(4).setColor(LineColor.PURPLE_8);
+
+                // Make the purple bisector indicators parallel to one of the first 2 lines
+                LineSegment bisector1 = OritaCalc.s_step_additional_intersection(d.lineStep.get(2), d.lineStep.get(3), d.lineColor);
+                LineSegment bisector2 = OritaCalc.s_step_additional_intersection(d.lineStep.get(2), d.lineStep.get(4), d.lineColor);
+
+                if (bisector1 != null) {
+                    d.lineStepAdd(bisector1);
+                    d.record();
+                }
+                if (bisector2 != null) {
+                    d.lineStepAdd(bisector2);
+                    d.record();
+                }
+            }
+            // Step 2: Get the 2 destination lines and form the actual bisector
+            if(d.lineStep.size() == 7){
+                // Find 2 intersection points
+                Point intersect1 = new Point();
+                intersect1.set(OritaCalc.findIntersection(d.lineStep.get(3), d.lineStep.get(5)));
+                Point intersect2 = new Point();
+                intersect2.set(OritaCalc.findIntersection(d.lineStep.get(3), d.lineStep.get(6)));
+
+                // Draw the bisector
+                LineSegment bisector = new LineSegment(intersect1, intersect2);
+                bisector.setColor(d.lineColor);
+
+                if (Epsilon.high.gt0(bisector.determineLength())) {
+                    d.addLineSegment(bisector);
+                    d.record();
+                }
+
+                d.lineStep.clear();
+            }
         }
     }
 }

--- a/origami/src/main/java/origami/crease_pattern/OritaCalc.java
+++ b/origami/src/main/java/origami/crease_pattern/OritaCalc.java
@@ -1,10 +1,7 @@
 package origami.crease_pattern;
 
 import origami.Epsilon;
-import origami.crease_pattern.element.Circle;
-import origami.crease_pattern.element.LineSegment;
-import origami.crease_pattern.element.Point;
-import origami.crease_pattern.element.StraightLine;
+import origami.crease_pattern.element.*;
 
 /**
  * Static utilities for calculations.
@@ -1083,5 +1080,33 @@ public class OritaCalc {
         NOT_PARALLEL,
         PARALLEL_NOT_EQUAL,
         PARALLEL_EQUAL,
+    }
+
+    public static LineSegment s_step_additional_intersection(LineSegment s_o, LineSegment s_k, LineColor icolo) {
+
+        Point cross_point = new Point();
+
+        if (OritaCalc.isLineSegmentParallel(s_o, s_k, Epsilon.UNKNOWN_1EN7) == OritaCalc.ParallelJudgement.PARALLEL_NOT_EQUAL) {//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
+            return null;
+        }
+
+        if (OritaCalc.isLineSegmentParallel(s_o, s_k, Epsilon.UNKNOWN_1EN7) == OritaCalc.ParallelJudgement.PARALLEL_EQUAL) {//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
+            cross_point.set(s_k.getA());
+            if (OritaCalc.distance(s_o.getA(), s_k.getA()) > OritaCalc.distance(s_o.getA(), s_k.getB())) {
+                cross_point.set(s_k.getB());
+            }
+        }
+
+        if (OritaCalc.isLineSegmentParallel(s_o, s_k, Epsilon.UNKNOWN_1EN7) == OritaCalc.ParallelJudgement.NOT_PARALLEL) {//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
+            cross_point.set(OritaCalc.findIntersection(s_o, s_k));
+        }
+
+        LineSegment add_sen = new LineSegment(cross_point, s_o.getA(), icolo);
+
+        if (Epsilon.high.gt0(add_sen.determineLength())) {
+            return add_sen;
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Users can either do the 3-points method like the usual or the new **2-lines method** by first selecting a point or a line respectively.

It is now also possible to s**elect 2 parallel lines and draw a "bisector" parallel to those 2 lines**, making sure to select 2 more lines to define its beginning point and end point.

There are issues in with this feature and I'm aware of some of them and I don't know how to fix them right now. But it should function as intended for the most part. I hope someone else smarter than me can do this if they encounter them.

**Demonstration:**
![c4b868894357fcbab1967042f6c6a042](https://user-images.githubusercontent.com/94136126/172480086-efa3dc3c-bfe8-45e0-8932-b842f520e625.gif)
![5e386813a13c3f95ecb1a4100edef1cf](https://user-images.githubusercontent.com/94136126/172480111-5c3a62a2-e3d4-4ded-9d3c-33216a3210a9.gif)
