### PR TITLE
Fix window size and keystrokes

### DIFF
--- a/oriedita/src/main/java/oriedita/editor/App.java
+++ b/oriedita/src/main/java/oriedita/editor/App.java
@@ -240,12 +240,13 @@ public class App {
         } else {
             frame.setLocationRelativeTo(null);
         }
-        if (applicationModel.getWindowSize() != null) {
-            frame.setSize(applicationModel.getWindowSize());
-        }
 
         frame.setExtendedState(applicationModel.getWindowState());
         frame.pack();
+
+        if (applicationModel.getWindowSize() != null) {
+            frame.setSize(applicationModel.getWindowSize());
+        }
 
         frame.setVisible(true);
 

--- a/oriedita/src/main/java/oriedita/editor/swing/dialog/SelectKeyStrokeDialog.java
+++ b/oriedita/src/main/java/oriedita/editor/swing/dialog/SelectKeyStrokeDialog.java
@@ -20,7 +20,7 @@ public class SelectKeyStrokeDialog extends JDialog {
 
     private KeyStroke keyStroke;
 
-    public SelectKeyStrokeDialog(Frame owner, AbstractButton button, Map<KeyStroke, AbstractButton> helpInputMap, KeyStroke keyStroke, Function<KeyStroke, Boolean> select) {
+    public SelectKeyStrokeDialog(JFrame owner, AbstractButton button, Map<KeyStroke, AbstractButton> helpInputMap, KeyStroke keyStroke, Function<KeyStroke, Boolean> select) {
         super(owner, "Set Key Stroke");
         this.select = select;
         setContentPane(contentPane);
@@ -47,8 +47,11 @@ public class SelectKeyStrokeDialog extends JDialog {
                 }
 
                 KeyStroke keyStrokeForEvent = KeyStroke.getKeyStrokeForEvent(e);
-                if (keyStrokeForEvent != null && helpInputMap.containsKey(keyStrokeForEvent) && helpInputMap.get(keyStrokeForEvent) != button) {
-                    String conflictingButton = (String) helpInputMap.get(keyStrokeForEvent).getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).get(keyStrokeForEvent);
+                if (keyStrokeForEvent != null && helpInputMap.containsKey(keyStrokeForEvent) && helpInputMap.get(
+                    keyStrokeForEvent) != button) {
+                    String conflictingButton = (String) owner.getRootPane()
+                                                             .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+                                                             .get(keyStrokeForEvent);
                     setConflict("Conflicting with " + conflictingButton);
                 } else {
                     setConflict(null);


### PR DESCRIPTION
this pr contains 2 small bugfixes:
- the window was sized weirdly when oriedita was started while the panels were hidden
- removing keybinds didnt work, and adding new ones needed a restart until they started working