### PR TITLE
Restricted input

### DIFF
--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
@@ -48,6 +48,7 @@ import javax.swing.border.LineBorder;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Insets;
+import java.awt.RenderingHints;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
@@ -383,7 +384,7 @@ public class LeftPanel {
         lineSegmentDivisionTextField.addKeyListener(new KeyAdapter() {
             @Override
             public void keyPressed(KeyEvent e) {
-                lineSegmentDivisionTextField.setEditable((e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE);
+                lineSegmentDivisionTextField.setEditable(onlyInt(e));
             }
         });
         senbun_b_nyuryokuButton.addActionListener(e -> {
@@ -588,7 +589,7 @@ public class LeftPanel {
         gridSizeTextField.addKeyListener(new KeyAdapter() {
             @Override
             public void keyPressed(KeyEvent e) {
-                gridSizeTextField.setEditable((e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE);
+                gridSizeTextField.setEditable(onlyInt(e));
             }
         });
         gridSizeIncreaseButton.addActionListener(e -> gridModel.setGridSize(gridModel.getGridSize() * 2));
@@ -609,7 +610,7 @@ public class LeftPanel {
         intervalGridSizeTextField.addKeyListener(new KeyAdapter() {
             @Override
             public void keyPressed(KeyEvent e) {
-                intervalGridSizeTextField.setEditable((e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE);
+                intervalGridSizeTextField.setEditable(onlyInt(e));
             }
         });
         moveIntervalGridHorizontal.addActionListener(e -> gridModel.changeVerticalScalePosition());
@@ -620,12 +621,54 @@ public class LeftPanel {
                 applicationModel.setGridScaleColor(color);
             }
         });
+        gridXATextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                gridXATextField.setEditable(onlyDouble(e, gridXATextField));
+            }
+        });
+        gridXBTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                gridXBTextField.setEditable(onlyDouble(e, gridXBTextField));
+            }
+        });
+        gridXCTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                gridXCTextField.setEditable(onlyDouble(e, gridXCTextField));
+            }
+        });
+        gridYATextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                gridYATextField.setEditable(onlyDouble(e, gridYATextField));
+            }
+        });
+        gridYBTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                gridYBTextField.setEditable(onlyDouble(e, gridYBTextField));
+            }
+        });
+        gridYCTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                gridYCTextField.setEditable(onlyDouble(e, gridYCTextField));
+            }
+        });
         setGridParametersButton.addActionListener(e -> {
             getData(gridModel);
             // Update the view if the grid angle got reset
             setData(gridModel);
         });
         gridAngleTextField.addActionListener(e -> setGridParametersButton.doClick());
+        gridAngleTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                gridAngleTextField.setEditable(onlyDouble(e, gridAngleTextField));
+            }
+        });
         resetGridButton.addActionListener(e -> gridModel.reset());
         drawDiagonalGridlinesCheckBox.addActionListener(e -> gridModel.setDrawDiagonalGridlines(drawDiagonalGridlinesCheckBox.isSelected()));
     }
@@ -660,6 +703,14 @@ public class LeftPanel {
         gridAngleTextField.setText(String.valueOf(data.getGridAngle()));
 
         gridSizeDecreaseButton.setEnabled(data.getGridSize() != 1);
+    }
+
+    public boolean onlyInt(KeyEvent e) {
+        return (e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE;
+    }
+
+    public boolean onlyDouble(KeyEvent e, JTextField tf) {
+        return (e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE || (e.getKeyChar() == '.' && !tf.getText().contains("."));
     }
 
     {

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
@@ -48,12 +48,15 @@ import javax.swing.border.LineBorder;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Insets;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.util.Arrays;
 
 @ApplicationScoped
 public class LeftPanel {
-    @Inject @ActionHandler(ActionType.lineWidthDecreaseAction)
+    @Inject
+    @ActionHandler(ActionType.lineWidthDecreaseAction)
     LineWidthDecreaseAction lineWidthDecreaseAction;
     private final FrameProvider frameProvider;
     private final HistoryState historyState;
@@ -377,6 +380,12 @@ public class LeftPanel {
             canvasModel.setMouseModeAfterColorSelection(MouseMode.LINE_SEGMENT_DIVISION_27);
         });
         lineSegmentDivisionTextField.addActionListener(e -> lineSegmentDivisionSetButton.doClick());
+        lineSegmentDivisionTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                lineSegmentDivisionTextField.setEditable((e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE);
+            }
+        });
         senbun_b_nyuryokuButton.addActionListener(e -> {
             getData(applicationModel);
 
@@ -576,6 +585,12 @@ public class LeftPanel {
         });
         gridSizeSetButton.addActionListener(e -> getData(gridModel));
         gridSizeTextField.addActionListener(e -> gridSizeSetButton.doClick());
+        gridSizeTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                gridSizeTextField.setEditable((e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE);
+            }
+        });
         gridSizeIncreaseButton.addActionListener(e -> gridModel.setGridSize(gridModel.getGridSize() * 2));
         gridColorButton.addActionListener(e -> {
             //以下にやりたいことを書く
@@ -591,6 +606,12 @@ public class LeftPanel {
         moveIntervalGridVerticalButton.addActionListener(e -> gridModel.changeHorizontalScalePosition());
         setIntervalGridSizeButton.addActionListener(e -> getData(gridModel));
         intervalGridSizeTextField.addActionListener(e -> setIntervalGridSizeButton.doClick());
+        intervalGridSizeTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                intervalGridSizeTextField.setEditable((e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE);
+            }
+        });
         moveIntervalGridHorizontal.addActionListener(e -> gridModel.changeVerticalScalePosition());
         intervalGridColorButton.addActionListener(e -> {
             //以下にやりたいことを書く

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
@@ -48,8 +48,6 @@ import javax.swing.border.LineBorder;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Insets;
-import java.awt.RenderingHints;
-import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.util.Arrays;
@@ -196,8 +194,6 @@ public class LeftPanel {
         this.drawCreaseFreeAction = drawCreaseFreeAction;
         this.foldingService = foldingService;
         this.foldedFiguresList = foldedFiguresList;
-
-
     }
 
     public void init() {
@@ -381,12 +377,7 @@ public class LeftPanel {
             canvasModel.setMouseModeAfterColorSelection(MouseMode.LINE_SEGMENT_DIVISION_27);
         });
         lineSegmentDivisionTextField.addActionListener(e -> lineSegmentDivisionSetButton.doClick());
-        lineSegmentDivisionTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                lineSegmentDivisionTextField.setEditable(onlyInt(e));
-            }
-        });
+        lineSegmentDivisionTextField.addKeyListener(new OnlyIntAdapter(lineSegmentDivisionTextField));
         senbun_b_nyuryokuButton.addActionListener(e -> {
             getData(applicationModel);
 
@@ -586,12 +577,7 @@ public class LeftPanel {
         });
         gridSizeSetButton.addActionListener(e -> getData(gridModel));
         gridSizeTextField.addActionListener(e -> gridSizeSetButton.doClick());
-        gridSizeTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                gridSizeTextField.setEditable(onlyInt(e));
-            }
-        });
+        gridSizeTextField.addKeyListener(new OnlyIntAdapter(gridSizeTextField));
         gridSizeIncreaseButton.addActionListener(e -> gridModel.setGridSize(gridModel.getGridSize() * 2));
         gridColorButton.addActionListener(e -> {
             //以下にやりたいことを書く
@@ -607,12 +593,7 @@ public class LeftPanel {
         moveIntervalGridVerticalButton.addActionListener(e -> gridModel.changeHorizontalScalePosition());
         setIntervalGridSizeButton.addActionListener(e -> getData(gridModel));
         intervalGridSizeTextField.addActionListener(e -> setIntervalGridSizeButton.doClick());
-        intervalGridSizeTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                intervalGridSizeTextField.setEditable(onlyInt(e));
-            }
-        });
+        intervalGridSizeTextField.addKeyListener(new OnlyIntAdapter(intervalGridSizeTextField));
         moveIntervalGridHorizontal.addActionListener(e -> gridModel.changeVerticalScalePosition());
         intervalGridColorButton.addActionListener(e -> {
             //以下にやりたいことを書く
@@ -621,54 +602,19 @@ public class LeftPanel {
                 applicationModel.setGridScaleColor(color);
             }
         });
-        gridXATextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                gridXATextField.setEditable(onlyDouble(e, gridXATextField));
-            }
-        });
-        gridXBTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                gridXBTextField.setEditable(onlyDouble(e, gridXBTextField));
-            }
-        });
-        gridXCTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                gridXCTextField.setEditable(onlyDouble(e, gridXCTextField));
-            }
-        });
-        gridYATextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                gridYATextField.setEditable(onlyDouble(e, gridYATextField));
-            }
-        });
-        gridYBTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                gridYBTextField.setEditable(onlyDouble(e, gridYBTextField));
-            }
-        });
-        gridYCTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                gridYCTextField.setEditable(onlyDouble(e, gridYCTextField));
-            }
-        });
+        gridXATextField.addKeyListener(new OnlyDoubleAdapter(gridXATextField));
+        gridXBTextField.addKeyListener(new OnlyDoubleAdapter(gridXBTextField));
+        gridXCTextField.addKeyListener(new OnlyDoubleAdapter(gridXCTextField));
+        gridYATextField.addKeyListener(new OnlyDoubleAdapter(gridYATextField));
+        gridYBTextField.addKeyListener(new OnlyDoubleAdapter(gridYBTextField));
+        gridYCTextField.addKeyListener(new OnlyDoubleAdapter(gridXCTextField));
         setGridParametersButton.addActionListener(e -> {
             getData(gridModel);
             // Update the view if the grid angle got reset
             setData(gridModel);
         });
         gridAngleTextField.addActionListener(e -> setGridParametersButton.doClick());
-        gridAngleTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                gridAngleTextField.setEditable(onlyDouble(e, gridAngleTextField));
-            }
-        });
+        gridAngleTextField.addKeyListener(new OnlyDoubleAdapter(gridAngleTextField));
         resetGridButton.addActionListener(e -> gridModel.reset());
         drawDiagonalGridlinesCheckBox.addActionListener(e -> gridModel.setDrawDiagonalGridlines(drawDiagonalGridlinesCheckBox.isSelected()));
     }
@@ -703,14 +649,6 @@ public class LeftPanel {
         gridAngleTextField.setText(String.valueOf(data.getGridAngle()));
 
         gridSizeDecreaseButton.setEnabled(data.getGridSize() != 1);
-    }
-
-    public boolean onlyInt(KeyEvent e) {
-        return (e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE;
-    }
-
-    public boolean onlyDouble(KeyEvent e, JTextField tf) {
-        return (e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE || (e.getKeyChar() == '.' && !tf.getText().contains("."));
     }
 
     {

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/OnlyDoubleAdapter.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/OnlyDoubleAdapter.java
@@ -1,0 +1,21 @@
+package oriedita.editor.swing;
+
+import javax.swing.JTextField;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+
+public class OnlyDoubleAdapter extends KeyAdapter {
+    private JTextField tf;
+
+    public OnlyDoubleAdapter(JTextField tf) {
+        this.tf = tf;
+    }
+
+    public void keyPressed(KeyEvent e) {
+        tf.setEditable(onlyDouble(e, tf));
+    }
+
+    public boolean onlyDouble(KeyEvent e, JTextField tf) {
+        return (e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE || (e.getKeyChar() == '.' && !tf.getText().contains("."));
+    }
+}

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/OnlyIntAdapter.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/OnlyIntAdapter.java
@@ -1,0 +1,21 @@
+package oriedita.editor.swing;
+
+import javax.swing.JTextField;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+
+public class OnlyIntAdapter extends KeyAdapter {
+    private JTextField tf;
+
+    public OnlyIntAdapter(JTextField tf) {
+        this.tf = tf;
+    }
+
+    public void keyPressed(KeyEvent e) {
+        tf.setEditable(onlyInt(e));
+    }
+
+    public boolean onlyInt(KeyEvent e) {
+        return (e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE;
+    }
+}

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/RightPanel.form
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/RightPanel.form
@@ -310,6 +310,7 @@
               <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
+              <editable value="false"/>
               <opaque value="true"/>
               <text value="0.0"/>
             </properties>
@@ -328,6 +329,7 @@
               <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
+              <editable value="false"/>
               <opaque value="true"/>
               <text value="0.0"/>
             </properties>
@@ -346,6 +348,7 @@
               <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
+              <editable value="false"/>
               <opaque value="true"/>
               <text value="0.0"/>
             </properties>
@@ -355,6 +358,7 @@
               <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
+              <editable value="false"/>
               <opaque value="true"/>
               <text value="0.0"/>
             </properties>
@@ -364,6 +368,7 @@
               <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
+              <editable value="false"/>
               <opaque value="true"/>
               <text value="0.0"/>
             </properties>

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/RightPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/RightPanel.java
@@ -392,68 +392,25 @@ public class RightPanel {
         });
         ActionListener listener = e -> restrictedAngleSetDEFButton.doClick();
         angleDTextField.addActionListener(listener);
-        angleDTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                angleDTextField.setEditable(onlyDouble(e, angleDTextField));
-            }
-        });
+        angleDTextField.addKeyListener(new OnlyDoubleAdapter(angleDTextField));
         angleETextField.addActionListener(listener);
-        angleETextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                angleETextField.setEditable(onlyDouble(e, angleETextField));
-            }
-        });
+        angleETextField.addKeyListener(new OnlyDoubleAdapter(angleETextField));
         angleFTextField.addActionListener(listener);
-        angleFTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                angleFTextField.setEditable(onlyDouble(e, angleFTextField));
-            }
-        });
+        angleFTextField.addKeyListener(new OnlyDoubleAdapter(angleFTextField));
         ActionListener listener1 = e -> restrictedAngleABCSetButton.doClick();
         angleATextField.addActionListener(listener1);
-        angleATextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                angleATextField.setEditable(onlyDouble(e, angleATextField));
-            }
-        });
+        angleATextField.addKeyListener(new OnlyDoubleAdapter(angleATextField));
         angleCTextField.addActionListener(listener1);
-        angleCTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                angleCTextField.setEditable(onlyDouble(e, angleCTextField));
-            }
-        });
+        angleCTextField.addKeyListener(new OnlyDoubleAdapter(angleCTextField));
         angleBTextField.addActionListener(listener1);
-        angleBTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                angleBTextField.setEditable(onlyDouble(e, angleBTextField));
-            }
-        });
+        angleBTextField.addKeyListener(new OnlyDoubleAdapter(angleBTextField));
         polygonSizeTextField.addActionListener(e -> polygonSizeSetButton.doClick());
-        polygonSizeTextField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                polygonSizeTextField.setEditable(onlyInt(e));
-            }
-        });
+        polygonSizeTextField.addKeyListener(new OnlyIntAdapter(polygonSizeTextField));
     }
 
     private void setData(HistoryState auxHistoryState) {
         h_undoButton.setEnabled(auxHistoryState.canUndo());
         h_redoButton.setEnabled(auxHistoryState.canRedo());
-    }
-
-    public boolean onlyInt(KeyEvent e) {
-        return (e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE;
-    }
-
-    public boolean onlyDouble(KeyEvent e, JTextField tf) {
-        return (e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE || (e.getKeyChar() == '.' && !tf.getText().contains("."));
     }
 
     /**

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/RightPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/RightPanel.java
@@ -33,6 +33,8 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Insets;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 
 @ApplicationScoped
@@ -397,6 +399,12 @@ public class RightPanel {
         angleCTextField.addActionListener(listener1);
         angleBTextField.addActionListener(listener1);
         polygonSizeTextField.addActionListener(e -> polygonSizeSetButton.doClick());
+        polygonSizeTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                polygonSizeTextField.setEditable((e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE);
+            }
+        });
     }
 
     private void setData(HistoryState auxHistoryState) {

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/RightPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/RightPanel.java
@@ -392,17 +392,53 @@ public class RightPanel {
         });
         ActionListener listener = e -> restrictedAngleSetDEFButton.doClick();
         angleDTextField.addActionListener(listener);
+        angleDTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                angleDTextField.setEditable(onlyDouble(e, angleDTextField));
+            }
+        });
         angleETextField.addActionListener(listener);
+        angleETextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                angleETextField.setEditable(onlyDouble(e, angleETextField));
+            }
+        });
         angleFTextField.addActionListener(listener);
+        angleFTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                angleFTextField.setEditable(onlyDouble(e, angleFTextField));
+            }
+        });
         ActionListener listener1 = e -> restrictedAngleABCSetButton.doClick();
         angleATextField.addActionListener(listener1);
+        angleATextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                angleATextField.setEditable(onlyDouble(e, angleATextField));
+            }
+        });
         angleCTextField.addActionListener(listener1);
+        angleCTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                angleCTextField.setEditable(onlyDouble(e, angleCTextField));
+            }
+        });
         angleBTextField.addActionListener(listener1);
+        angleBTextField.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                angleBTextField.setEditable(onlyDouble(e, angleBTextField));
+            }
+        });
         polygonSizeTextField.addActionListener(e -> polygonSizeSetButton.doClick());
         polygonSizeTextField.addKeyListener(new KeyAdapter() {
             @Override
             public void keyPressed(KeyEvent e) {
-                polygonSizeTextField.setEditable((e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE);
+                polygonSizeTextField.setEditable(onlyInt(e));
             }
         });
     }
@@ -410,6 +446,14 @@ public class RightPanel {
     private void setData(HistoryState auxHistoryState) {
         h_undoButton.setEnabled(auxHistoryState.canUndo());
         h_redoButton.setEnabled(auxHistoryState.canRedo());
+    }
+
+    public boolean onlyInt(KeyEvent e) {
+        return (e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE;
+    }
+
+    public boolean onlyDouble(KeyEvent e, JTextField tf) {
+        return (e.getKeyChar() >= '0' && e.getKeyChar() <= '9') || e.getKeyChar() == KeyEvent.VK_BACK_SPACE || (e.getKeyChar() == '.' && !tf.getText().contains("."));
     }
 
     /**
@@ -529,6 +573,7 @@ public class RightPanel {
         l1Button.setText("L1=");
         panel6.add(l1Button, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, 1, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         measuredLength1TextField = new JTextField();
+        measuredLength1TextField.setEditable(false);
         measuredLength1TextField.setOpaque(true);
         measuredLength1TextField.setText("0.0");
         panel6.add(measuredLength1TextField, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
@@ -537,6 +582,7 @@ public class RightPanel {
         l2Button.setText("L2=");
         panel6.add(l2Button, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, 1, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         measuredLength2TextField = new JTextField();
+        measuredLength2TextField.setEditable(false);
         measuredLength2TextField.setOpaque(true);
         measuredLength2TextField.setText("0.0");
         panel6.add(measuredLength2TextField, new GridConstraints(1, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
@@ -545,14 +591,17 @@ public class RightPanel {
         a3Button.setText("A3=");
         panel6.add(a3Button, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, 1, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         measuredAngle3TextField = new JTextField();
+        measuredAngle3TextField.setEditable(false);
         measuredAngle3TextField.setOpaque(true);
         measuredAngle3TextField.setText("0.0");
         panel6.add(measuredAngle3TextField, new GridConstraints(4, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         measuredAngle2TextField = new JTextField();
+        measuredAngle2TextField.setEditable(false);
         measuredAngle2TextField.setOpaque(true);
         measuredAngle2TextField.setText("0.0");
         panel6.add(measuredAngle2TextField, new GridConstraints(3, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         measuredAngle1TextField = new JTextField();
+        measuredAngle1TextField.setEditable(false);
         measuredAngle1TextField.setOpaque(true);
         measuredAngle1TextField.setText("0.0");
         panel6.add(measuredAngle1TextField, new GridConstraints(2, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));


### PR DESCRIPTION
- Hopefully solved issue #262 , now restricting inputs to integers/doubles.
![1818ab48d0014eebeaeba0194a4316dc](https://user-images.githubusercontent.com/94136126/219174708-26946eb2-2db6-44c8-9636-adb33c20e768.gif)

- Set measured lengths and angles text fields to be uneditable since they shouldn't be in the first place.

The most significant issue about this implementation is visual. The logic is if the key inputs are not numeric and backspace (and decimal if dealing with double values), the text field will be set to be uneditable (`setEditable(false)`) and vice versa. If you type something that doesn't fit the condition (say a letter), the field will be uneditable, and its visual changes. Users might see that and think it's not interactable although it still is, which can lead to confusion. But I couldn't really think of other ways that are not complicated to implement this, so this will have to do. I still want to fix this in the future so look forward to that.