### PR TITLE
Prevent many pref panel with a caveat / live grid color change

### DIFF
--- a/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
@@ -215,13 +215,16 @@ public class AppMenuBar {
             fileSaveService.exportFile();
         });
         prefButton.addActionListener(e -> {
-            preferenceDialog = new PreferenceDialog(applicationModel, lookAndFeelService, frameProvider, foldedFigureModel, "Preferences", frameProvider.get());
+            if(preferenceDialog == null){
+                preferenceDialog = new PreferenceDialog(applicationModel, lookAndFeelService, frameProvider, foldedFigureModel, "Preferences", frameProvider.get());
+            }
             preferenceDialog.setSize(475, 575);
             preferenceDialog.setMinimumSize(new Dimension(475, 575));
             preferenceDialog.setResizable(true);
             preferenceDialog.setData(applicationModel);
             preferenceDialog.setLocationRelativeTo(prefButton);
             preferenceDialog.setAlwaysOnTop(false);
+            preferenceDialog.updateTempModel(applicationModel);
             preferenceDialog.setVisible(true);
         });
         exitButton.addActionListener(e -> closing());

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
@@ -216,6 +216,8 @@ public class PreferenceDialog extends JDialog {
                         foldedFigureModel.setFrontColor(Colors.FIGURE_FRONT);
                         foldedFigureModel.setBackColor(Colors.FIGURE_BACK);
                     }
+                    gridColorButton.setIcon(new ColorIcon(applicationModel.getGridColor()));
+                    gridScaleColorButton.setIcon(new ColorIcon(applicationModel.getGridScaleColor()));
                 });
             } else { lookAndFeelService.toggleDarkMode(); }
         });
@@ -345,14 +347,14 @@ public class PreferenceDialog extends JDialog {
     }
 
     private void onOK() {
-        dispose();
+        setVisible(false);
     }
 
     private void onCancel() {
         setData(tempModel);
         applicationModel.set(tempModel);
         foldedFigureModel.set(tempfoldedModel);
-        dispose();
+        setVisible(false);
     }
 
     private void onReset() {
@@ -362,6 +364,10 @@ public class PreferenceDialog extends JDialog {
             foldedFigureModel.restorePrefDefaults();
             dispose();
         }
+    }
+
+    public void updateTempModel(ApplicationModel applicationModel) {
+        tempModel.set(applicationModel);
     }
 
     /**


### PR DESCRIPTION
- The Pref window should now only be viewed as one window and unable to make duplicate windows by abusing the switching to light and dark mode.
- Gird and grid-scale colors can change live when switching between light and dark modes.