### PR TITLE
UI Improvements to vertex drawing

### DIFF
--- a/oriedita-data/src/main/java/oriedita/editor/Colors.java
+++ b/oriedita-data/src/main/java/oriedita/editor/Colors.java
@@ -38,6 +38,7 @@ public class Colors {
         add(new Color(255, 0, 0, 75), new Color(255, 0, 0, 75), new Color(255, 0, 0, 75));
         add(new Color(230, 230, 230), new Color(230, 230, 230), new Color(54, 54, 54));
         add(new Color(162, 162, 162), new Color(162, 162, 162), new Color(120, 120, 120)); //placeholder
+        add(Color.gray, new Color(128,128,128,128), new Color(128,128,128,128));
     }
 
     private static Map<Color, Color> activeColorMap = colorMap;

--- a/oriedita-ui/src/main/java/oriedita/editor/drawing/tools/DrawingUtil.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/drawing/tools/DrawingUtil.java
@@ -84,8 +84,11 @@ public class DrawingUtil {
     }
 
     public static void drawVertex(Graphics2D g, Point a, int pointSize) {
-        g.setColor(Colors.get(Color.black));
+        g.setColor(Colors.get(Color.gray));
         g.fillRect((int) (a.getX() - pointSize), (int) (a.getY() - pointSize), (int) (pointSize * 2 + 0.5), (int) (pointSize * 2 + 0.5));
+
+        g.setColor(Colors.get(Color.black));
+        g.drawRect((int) (a.getX() - pointSize), (int) (a.getY() - pointSize), (int) (pointSize * 2 + 0.5), (int) (pointSize * 2 + 0.5));
     }
 
     //Draw a pointing diagram around the specified Point
@@ -180,9 +183,13 @@ public class DrawingUtil {
         g.drawLine((int) a.getX(), (int) a.getY(), (int) b.getX(), (int) b.getY()); //直線
 
         if (lineWidth < 2.0f) {//Draw a square at the vertex
-            g.setColor(Colors.get(Color.black));
+            g.setColor(Colors.get(Color.gray));
             g.fillRect((int) a.getX() - pointSize, (int) a.getY() - pointSize, 2 * pointSize + 1, 2 * pointSize + 1); //正方形を描く//g.fillRect(10, 10, 100, 50);長方形を描く
             g.fillRect((int) b.getX() - pointSize, (int) b.getY() - pointSize, 2 * pointSize + 1, 2 * pointSize + 1); //正方形を描く
+
+            g.setColor(Colors.get(Color.black));
+            g.drawRect((int) a.getX() - pointSize, (int) a.getY() - pointSize, 2 * pointSize + 1, 2 * pointSize + 1);
+            g.drawRect((int) b.getX() - pointSize, (int) b.getY() - pointSize, 2 * pointSize + 1, 2 * pointSize + 1);
         }
 
         if (lineWidth >= 2.0f) {//  Thick line
@@ -191,13 +198,13 @@ public class DrawingUtil {
             if (pointSize != 0) {
                 double d_width = (double) lineWidth / 2.0 + (double) pointSize;
 
-                g.setColor(Colors.get(Color.white));
+                g.setColor(Colors.get(Color.gray));
                 g2.fill(new Ellipse2D.Double(a.getX() - d_width, a.getY() - d_width, 2.0 * d_width, 2.0 * d_width));
 
                 g.setColor(Colors.get(Color.black));
                 g2.draw(new Ellipse2D.Double(a.getX() - d_width, a.getY() - d_width, 2.0 * d_width, 2.0 * d_width));
 
-                g.setColor(Colors.get(Color.white));
+                g.setColor(Colors.get(Color.gray));
                 g2.fill(new Ellipse2D.Double(b.getX() - d_width, b.getY() - d_width, 2.0 * d_width, 2.0 * d_width));
 
                 g.setColor(Colors.get(Color.black));
@@ -285,13 +292,13 @@ public class DrawingUtil {
                 g2.fill(new Ellipse2D.Double(a.getX() - d_width, a.getY() - d_width, 2.0 * d_width, 2.0 * d_width));
 
 
-                g.setColor(Colors.get(Color.black));
+                g.setColor(Colors.get(Color.gray));
                 g2.draw(new Ellipse2D.Double(a.getX() - d_width, a.getY() - d_width, 2.0 * d_width, 2.0 * d_width));
 
                 g.setColor(Colors.get(Color.white));
                 g2.fill(new Ellipse2D.Double(b.getX() - d_width, b.getY() - d_width, 2.0 * d_width, 2.0 * d_width));
 
-                g.setColor(Colors.get(Color.black));
+                g.setColor(Colors.get(Color.gray));
                 g2.draw(new Ellipse2D.Double(b.getX() - d_width, b.getY() - d_width, 2.0 * d_width, 2.0 * d_width));
             }
         }
@@ -483,13 +490,13 @@ public class DrawingUtil {
             if (pointSize != 0) {
                 double d_width = (double) lineWidth / 2.0 + (double) pointSize;
 
-                g.setColor(Colors.get(Color.white));
+                g.setColor(Colors.get(Color.gray));
                 g2.fill(new Ellipse2D.Double(a.getX() - d_width, a.getY() - d_width, 2.0 * d_width, 2.0 * d_width));
 
                 g.setColor(Colors.get(Color.black));
                 g2.draw(new Ellipse2D.Double(a.getX() - d_width, a.getY() - d_width, 2.0 * d_width, 2.0 * d_width));
 
-                g.setColor(Colors.get(Color.white));
+                g.setColor(Colors.get(Color.gray));
                 g2.fill(new Ellipse2D.Double(b.getX() - d_width, b.getY() - d_width, 2.0 * d_width, 2.0 * d_width));
 
                 g.setColor(Colors.get(Color.black));


### PR DESCRIPTION
1) Make the vertex fills grey and transparent for both circle & square shapes
   This makes it easier to see crease pattern error with large vertices
2) Vertex fill colours made consistent between circle and square shapes 
3) Add border to square shaped vertex, again for consistency

Fixes issue #324 

Screenshots to follow shortly...