### PR TITLE
Make warning text colours clearer for both Light and Dark mode

### DIFF
--- a/oriedita-data/src/main/java/oriedita/editor/Colors.java
+++ b/oriedita-data/src/main/java/oriedita/editor/Colors.java
@@ -39,6 +39,7 @@ public class Colors {
         add(new Color(230, 230, 230), new Color(230, 230, 230), new Color(54, 54, 54));
         add(new Color(162, 162, 162), new Color(162, 162, 162), new Color(120, 120, 120)); //placeholder
         add(Color.gray, new Color(128,128,128,128), new Color(128,128,128,128));
+        add(Color.yellow, Color.magenta, Color.yellow);
     }
 
     private static Map<Color, Color> activeColorMap = colorMap;


### PR DESCRIPTION
See below:

![Screenshot from 2023-07-20 12-50-01](https://github.com/oriedita/oriedita/assets/2546543/20a048a1-e50e-4924-aeed-7db0297a000f)


![Screenshot from 2023-07-20 12-49-51](https://github.com/oriedita/oriedita/assets/2546543/4f903ce9-85ac-43bc-a4e4-16043a2ec34b)


Decided to opt for magenta under Light mode, as its one of the colours considered to be the inversion of yellow. Orange still looks too unclear on light background.