### PR TITLE
Prevent line endings in test files from becoming inconsistent

### DIFF
--- a/oriedita-data/src/test/java/oriedita/editor/export/CpTest.java
+++ b/oriedita-data/src/test/java/oriedita/editor/export/CpTest.java
@@ -24,9 +24,9 @@ class CpTest {
         File saveFile = File.createTempFile("export", ".cp");
         Cp.exportFile(save, saveFile);
 
-        String expected = Files.readString(saveFile.toPath());
+        String expected = Files.readString(saveFile.toPath()).replace("\r","");
 
-        String actual = Files.readString(new File(birdbase.getFile()).toPath());
+        String actual = Files.readString(new File(birdbase.getFile()).toPath()).replace("\r","");
 
         Assertions.assertEquals(expected, actual);
     }


### PR DESCRIPTION
If the repository is cloned on Linux with a git client, we get "\n" line endings everywhere.
If the repository is cloned on Windows with a git client, we get "\r\n" line endings everywhere.

However, if the repository is downloaded on Windows with Github's download zip feature using the web interface, then the existing files have "\n" line endings, but newly created (temporary) files e.g via automated tests have "\r\n" line endings. This causes the maven build to fail.

Fixes issue #340