### PR TITLE
Categorize hotkey

### DIFF
--- a/oriedita-ui/pom.xml
+++ b/oriedita-ui/pom.xml
@@ -73,5 +73,10 @@
             <version>2.2.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>4.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
@@ -262,7 +262,7 @@ public class AppMenuBar {
             }
             preferenceDialog.setSize(preferenceDialog.getRootPane().getPreferredSize());
             preferenceDialog.setMinimumSize(preferenceDialog.getRootPane().getMinimumSize());
-            preferenceDialog.setResizable(false);
+            preferenceDialog.setResizable(true);
             preferenceDialog.setData(applicationModel);
             preferenceDialog.setLocationRelativeTo(prefButton);
             preferenceDialog.setAlwaysOnTop(false);

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
@@ -200,12 +200,7 @@ public class PreferenceDialog extends JDialog {
         setDefaultCloseOperation(HIDE_ON_CLOSE);
         getRootPane().setDefaultButton(buttonOK);
 
-        this.addComponentListener(new ComponentAdapter() {
-            @Override
-            public void componentShown(ComponentEvent e) {
-                setupHotKey(buttonService, frameProvider);
-            }
-        });
+        setupHotKey(buttonService, frameProvider);
 
         ck4Plus.setEnabled(applicationModel.getCheck4ColorTransparency() < 250);
         ck4Minus.setEnabled(applicationModel.getCheck4ColorTransparency() > 50);

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
@@ -481,6 +481,7 @@ public class PreferenceDialog extends JDialog {
     private void setupCategoryPanel(JPanel categoryPanel, JLabel clickLabel, JPanel listPanel, String categoryHeader) {
         // Category Panel
         categoryPanel.setLayout(new GridLayoutManager(2, 1, new Insets(0, 0, 5, 0), -1, -1));
+        categoryPanel.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, Color.BLACK));
         hotkeyPanel.add(categoryPanel, new GridConstraints(categoryHeaderList.indexOf(categoryHeader), 0, 1, 1, GridConstraints.ANCHOR_NORTHWEST, GridConstraints.FILL_HORIZONTAL, 1, 1, null, null, null, 0, false));
 
         //Category Label

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
@@ -480,12 +480,14 @@ public class PreferenceDialog extends JDialog {
         hotkeyPanel.add(categoryPanel, new GridConstraints(categoryHeaderList.indexOf(categoryHeader), 0, 1, 1, GridConstraints.ANCHOR_NORTHWEST, GridConstraints.FILL_HORIZONTAL, 1, 1, null, null, null, 0, false));
 
         //Category Label
-        clickLabel.setText(categoryHeader.toUpperCase().concat(" ▼"));
+        clickLabel.setText(categoryHeader.toUpperCase());
         clickLabel.setBorder(BorderFactory.createLineBorder(new Color(0, 0, 0, 0)));
         categoryPanel.add(clickLabel, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_NORTHWEST, GridConstraints.FILL_HORIZONTAL, 1, 1, null, null, null, 0, false));
 
         //List panel showing the hotkey list
         listPanel.setLayout(new GridLayoutManager(ActionType.values().length + 1, 4, new Insets(0, 15, 0, 0), -1, -1));
+        listPanel.setEnabled(false);
+        listPanel.setVisible(false);
         categoryPanel.add(listPanel, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_NORTH, GridConstraints.FILL_HORIZONTAL, 1, 1, null, null, null, 0, false));
     }
 
@@ -590,7 +592,6 @@ public class PreferenceDialog extends JDialog {
                     clickLabel.setBorder(BorderFactory.createLineBorder(new Color(0, 0, 0, 0)));
                 }
             });
-
         }
         final Spacer hotkeyPanelSpacer = new Spacer();
         hotkeyPanel.add(hotkeyPanelSpacer, new GridConstraints(hotkeyCategoryMap.size(), 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
@@ -490,7 +490,7 @@ public class PreferenceDialog extends JDialog {
         categoryPanel.add(clickLabel, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_NORTHWEST, GridConstraints.FILL_HORIZONTAL, 1, 1, null, null, null, 0, false));
 
         //List panel showing the hotkey list
-        listPanel.setLayout(new GridLayoutManager(ActionType.values().length + 1, 4, new Insets(0, 0, 0, 0), -1, -1));
+        listPanel.setLayout(new GridLayoutManager(ActionType.values().length + 1, 4, new Insets(0, 15, 0, 0), -1, -1));
         categoryPanel.add(listPanel, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_NORTH, GridConstraints.FILL_HORIZONTAL, 1, 1, null, null, null, 0, false));
     }
 

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
@@ -377,7 +377,6 @@ public class PreferenceDialog extends JDialog {
 
     private void onOK() {
         setVisible(false);
-//        clearHotKeyMap();
     }
 
     private void onCancel() {
@@ -385,7 +384,6 @@ public class PreferenceDialog extends JDialog {
         applicationModel.set(tempModel);
         foldedFigureModel.set(tempfoldedModel);
         setVisible(false);
-//        clearHotKeyMap();
     }
 
     private void onReset() {
@@ -395,13 +393,6 @@ public class PreferenceDialog extends JDialog {
             foldedFigureModel.restorePrefDefaults();
             dispose();
         }
-    }
-
-    private void clearHotKeyMap() {
-
-        hotkeyCategoryMap.clear();
-        categoryHeaderList.clear();
-
     }
 
     public void updateTempModel(ApplicationModel applicationModel) {
@@ -430,12 +421,12 @@ public class PreferenceDialog extends JDialog {
         return icon;
     }
 
-    private JLabel getTextLabel(int categoryIndex, int rowIndex) {
+    private JLabel getTextLabel(String key) {
         JLabel label = new JLabel();
         label.setEnabled(true);
         label.setFocusable(false);
         label.setIconTextGap(4);
-        String actionText = ResourceUtil.getBundleString("name", hotkeyCategoryMap.get(categoryHeaderList.get(categoryIndex)).get(rowIndex));
+        String actionText = ResourceUtil.getBundleString("name", key);
         if (actionText != null) {
             actionText = actionText.replaceAll("_", "");
         }
@@ -444,15 +435,15 @@ public class PreferenceDialog extends JDialog {
         return label;
     }
 
-    private JButton getKeyStrokeButton(ButtonService buttonService, FrameProvider frameProvider, int rowIndex, String key, int categoryIndex) {
+    private JButton getKeyStrokeButton(ButtonService buttonService, FrameProvider frameProvider, String key) {
         Map<KeyStroke, AbstractButton> helpInputMap = buttonService.getHelpInputMap();
-        KeyStroke currentKeyStroke = getKeyBind(frameProvider, hotkeyCategoryMap.get(categoryHeaderList.get(categoryIndex)).get(rowIndex));
+        KeyStroke currentKeyStroke = getKeyBind(frameProvider, key);
         AbstractButton button = buttonService.getPrefHotkeyMap().get(key);
 
         Action hotkeyAction = new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                KeyStroke tempKeyStroke = getKeyBind(frameProvider, ActionType.values()[rowIndex].action());
+                KeyStroke tempKeyStroke = getKeyBind(frameProvider, key);
                 new SelectKeyStrokeDialog(frameProvider.get(), button, helpInputMap, tempKeyStroke, newKeyStroke -> {
                     if (newKeyStroke != null && helpInputMap.containsKey(newKeyStroke) && helpInputMap.get(newKeyStroke) != button) {
                         String conflictingButton = (String) helpInputMap.get(newKeyStroke).getRootPane()
@@ -487,13 +478,13 @@ public class PreferenceDialog extends JDialog {
         return keyStrokeButton;
     }
 
-    private void setupCategoryPanel(JPanel categoryPanel, JLabel clickLabel, JPanel listPanel, int i) {
+    private void setupCategoryPanel(JPanel categoryPanel, JLabel clickLabel, JPanel listPanel, String categoryHeader) {
         // Category Panel
         categoryPanel.setLayout(new GridLayoutManager(2, 1, new Insets(0, 0, 5, 0), -1, -1));
-        hotkeyPanel.add(categoryPanel, new GridConstraints(i, 0, 1, 1, GridConstraints.ANCHOR_NORTHWEST, GridConstraints.FILL_HORIZONTAL, 1, 1, null, null, null, 0, false));
+        hotkeyPanel.add(categoryPanel, new GridConstraints(categoryHeaderList.indexOf(categoryHeader), 0, 1, 1, GridConstraints.ANCHOR_NORTHWEST, GridConstraints.FILL_HORIZONTAL, 1, 1, null, null, null, 0, false));
 
         //Category Label
-        clickLabel.setText(categoryHeaderList.get(i).toUpperCase().concat(" ▼"));
+        clickLabel.setText(categoryHeader.toUpperCase().concat(" ▼"));
         clickLabel.setBorder(BorderFactory.createLineBorder(new Color(0, 0, 0, 0)));
         categoryPanel.add(clickLabel, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_NORTHWEST, GridConstraints.FILL_HORIZONTAL, 1, 1, null, null, null, 0, false));
 
@@ -502,28 +493,27 @@ public class PreferenceDialog extends JDialog {
         categoryPanel.add(listPanel, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_NORTH, GridConstraints.FILL_HORIZONTAL, 1, 1, null, null, null, 0, false));
     }
 
-    private void addIconTextHotkey(ButtonService buttonService, FrameProvider frameProvider, JPanel listPanel, int i) {
-        int rowIndex;
+    private void addIconTextHotkey(ButtonService buttonService, FrameProvider frameProvider, JPanel listPanel, String categoryHeader) {
         final Spacer spacer1 = new Spacer();
         final Spacer spacer2 = new Spacer();
 
 
-        for (rowIndex = 0; rowIndex < hotkeyCategoryMap.get(categoryHeaderList.get(i)).size(); rowIndex++) {
-            String key = hotkeyCategoryMap.get(categoryHeaderList.get(i)).get(rowIndex);
+        for (String key : hotkeyCategoryMap.get(categoryHeader)) {
+            int index = hotkeyCategoryMap.get(categoryHeader).indexOf(key);
 
             JLabel iconLabel = getIconLabel(buttonService, key);
-            listPanel.add(iconLabel, new GridConstraints(rowIndex, 0, 1, 1, GridConstraints.ANCHOR_NORTH, GridConstraints.FILL_NONE, 1, 1, null, null, null, 0, false));
+            listPanel.add(iconLabel, new GridConstraints(index, 0, 1, 1, GridConstraints.ANCHOR_NORTH, GridConstraints.FILL_NONE, 1, 1, null, null, null, 0, false));
 
-            JLabel nameLabel = getTextLabel(i, rowIndex);
-            listPanel.add(nameLabel, new GridConstraints(rowIndex, 1, 1, 1, GridConstraints.ANCHOR_NORTH, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
+            JLabel nameLabel = getTextLabel(key);
+            listPanel.add(nameLabel, new GridConstraints(index, 1, 1, 1, GridConstraints.ANCHOR_NORTH, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
 
-            JButton keystrokeButton = getKeyStrokeButton(buttonService, frameProvider, rowIndex, key, i);
-            listPanel.add(keystrokeButton, new GridConstraints(rowIndex, 3, 1, 1, GridConstraints.ANCHOR_NORTH, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
+            JButton keystrokeButton = getKeyStrokeButton(buttonService, frameProvider, key);
+            listPanel.add(keystrokeButton, new GridConstraints(index, 3, 1, 1, GridConstraints.ANCHOR_NORTH, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
 
             //TODO: a restore default button for hotkeys specifically
         }
-        listPanel.add(spacer1, new GridConstraints(rowIndex, 0, 1, 3, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
-        listPanel.add(spacer2, new GridConstraints(0, 2, hotkeyCategoryMap.get(categoryHeaderList.get(i)).size(), 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
+        listPanel.add(spacer1, new GridConstraints(hotkeyCategoryMap.get(categoryHeader).size() - 1, 0, 1, 3, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
+        listPanel.add(spacer2, new GridConstraints(0, 2, hotkeyCategoryMap.get(categoryHeader).size(), 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
 
     }
 
@@ -577,22 +567,21 @@ public class PreferenceDialog extends JDialog {
 
     public void setupHotKey(ButtonService buttonService, FrameProvider frameProvider) {
         hotkeyPanel.removeAll();
-        for (int i = 0; i < categoryHeaderList.size(); i++) {
+        for (String categoryHeader : categoryHeaderList) {
             JPanel categoryPanel = new JPanel();
             JLabel clickLabel = new JLabel();
             JPanel listPanel = new JPanel();
 
-            setupCategoryPanel(categoryPanel, clickLabel, listPanel, i);
+            setupCategoryPanel(categoryPanel, clickLabel, listPanel, categoryHeader);
 
-            addIconTextHotkey(buttonService, frameProvider, listPanel, i);
+            addIconTextHotkey(buttonService, frameProvider, listPanel, categoryHeader);
 
-            int temp = i;
             clickLabel.addMouseListener(new MouseAdapter() {
                 @Override
                 public void mouseClicked(MouseEvent e) {
                     listPanel.setEnabled(!listPanel.isEnabled());
                     listPanel.setVisible(listPanel.isEnabled());
-                    clickLabel.setText(listPanel.isEnabled() ? categoryHeaderList.get(temp).toUpperCase().concat(" ▼") : categoryHeaderList.get(temp).toUpperCase());
+                    clickLabel.setText(listPanel.isEnabled() ? categoryHeader.toUpperCase().concat(" ▼") : categoryHeader.toUpperCase());
                 }
 
                 @Override
@@ -1211,7 +1200,6 @@ public class PreferenceDialog extends JDialog {
 
         hotkeyCategoryMap = new LinkedHashMap<>();
         categoryHeaderList = new ArrayList<>();
-        clearHotKeyMap();
         readCSV();
 
         hotkeyPanel = new JPanel();

--- a/oriedita/src/main/resources/name.properties
+++ b/oriedita/src/main/resources/name.properties
@@ -37,6 +37,7 @@ deleteSelectedLineSegmentAction=Delete selection
 lineSegmentDeleteAction=Delete fold lines (Legacy)
 edgeLineSegmentDeleteAction=Delete edge lines (Legacy)
 auxLiveLineSegmentDeleteAction=Delete auxiliary lines (Legacy)
+del_l_typeButton=Eraser
 trimBranchesAction=Trim branches
 toMountainAction=Convert to mountain (Legacy)
 toValleyAction=Convert to valley (Legacy)


### PR DESCRIPTION
Split the current long list of hotkeys into different category sections using the CSV file @JuhoKonkkola added in. Each category is collapsible and when clicked will show a list of actions related to such category.

Currently since all actions are included in the CSV, there is a lot of actions in there that doesn't have an icon, a name, or both. That's because not all of them actually have its key in their properties so it's an issue that can be fixed independently from the hotkey panel.

<img width="585" alt="image" src="https://github.com/oriedita/oriedita/assets/94136126/b7a220ed-501f-4116-8352-081e69bf1826">
<img width="595" alt="image" src="https://github.com/oriedita/oriedita/assets/94136126/b1565180-e1c9-47b2-b414-ea16c3e74b8b">
