### PR TITLE
Add .FOLD option into "Save as" and allow its visibility when using "Open"

### DIFF
--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/ExportDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/ExportDialog.java
@@ -91,7 +91,7 @@ public class ExportDialog extends JDialog {
         listModel.add(2, new ExportOption(".jpg", "JPEG (.jpg)"));
         listModel.add(3, new ExportOption(".orh", "Orihime save (.orh)"));
         listModel.add(4, new ExportOption(".cp", "Crease pattern (.cp)"));
-        listModel.add(4, new ExportOption(".fold", "FOLD (.fold)"));
+        listModel.add(5, new ExportOption(".fold", "FOLD (.fold)"));
 
         list1.setModel(listModel);
 

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/SaveTypeDialog.form
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/SaveTypeDialog.form
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="e3588" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e3588" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -21,8 +21,9 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <horizontalAlignment value="2"/>
-              <text value="&lt;html&gt;&lt;b&gt;Crease Pattern (.cp)&lt;/b&gt;&lt;br/&gt;&#10;Saves only crease pattern &lt;br/&gt;lines.&lt;br/&gt;&lt;br/&gt;&#10;&#10;&lt;i&gt;Use this format to share &lt;br/&gt;crease patterns with other &lt;br/&gt;people.&lt;/i&gt;"/>
+              <horizontalAlignment value="0"/>
+              <text value="&lt;html&gt;&lt;br/&gt;&lt;b&gt;.CP&lt;/b&gt;&lt;br/&gt;&lt;br/&gt; Save only M/V/A/E lines.&lt;br/&gt;&lt;br/&gt;&lt;i&gt;Robust and compatible file&lt;br/&gt;format that is widely used to&lt;br/&gt;share crease patterns.&lt;/i&gt;&lt;br/&gt;&lt;br/&gt;&lt;html/&gt;"/>
+              <verticalAlignment value="1"/>
             </properties>
           </component>
           <component id="d0911" class="javax.swing.JButton" binding="completeOriAlsoSavesButton" default-binding="true">
@@ -30,8 +31,18 @@
               <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <horizontalAlignment value="2"/>
-              <text value="&lt;html&gt;&lt;b&gt;Complete (.ori)&lt;/b&gt;&lt;br/&gt;&#10;Also saves circles, yellow &lt;br/&gt;aux lines and the grid.&lt;br/&gt;&#10;&lt;br/&gt;&#10;&lt;i&gt;Use this format when &lt;br/&gt;saving to your local &lt;br/&gt;computer.&lt;/i&gt;"/>
+              <horizontalAlignment value="0"/>
+              <text value="&lt;html&gt;&lt;br/&gt;&lt;b&gt;.ORI&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Save all lines, circles, text,&lt;br/&gt;and grid.&lt;br/&gt; &lt;br/&gt; &lt;i&gt;Oriedita exclusive file format.&lt;/i&gt;&lt;br/&gt;"/>
+              <verticalAlignment value="1"/>
+            </properties>
+          </component>
+          <component id="21e20" class="javax.swing.JButton" binding="completeFoldAlsoSavesButton" default-binding="true">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="&lt;html&gt;&lt;br/&gt;&lt;b&gt;.FOLD&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Save all lines, circles, text,&lt;br/&gt;and grid.&lt;br/&gt; &lt;br/&gt; &lt;i&gt;Compatible with other origami&lt;br/&gt;related software. &lt;/i&gt;&lt;br/&gt;"/>
+              <verticalAlignment value="1"/>
             </properties>
           </component>
         </children>

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/SaveTypeDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/SaveTypeDialog.java
@@ -16,6 +16,7 @@ public class SaveTypeDialog extends JDialog {
     private JPanel contentPane;
     private JButton creasePatternCpSavesButton;
     private JButton completeOriAlsoSavesButton;
+    private JButton completeFoldAlsoSavesButton;
 
     private String saveType = null;
 
@@ -29,6 +30,10 @@ public class SaveTypeDialog extends JDialog {
         });
         completeOriAlsoSavesButton.addActionListener(e -> {
             saveType = ".ori";
+            dispose();
+        });
+        completeFoldAlsoSavesButton.addActionListener(e -> {
+            saveType = ".fold";
             dispose();
         });
 
@@ -73,16 +78,22 @@ public class SaveTypeDialog extends JDialog {
         contentPane = new JPanel();
         contentPane.setLayout(new GridLayoutManager(1, 1, new Insets(10, 10, 10, 10), -1, -1));
         final JPanel panel1 = new JPanel();
-        panel1.setLayout(new GridLayoutManager(1, 2, new Insets(0, 0, 0, 0), -1, -1));
+        panel1.setLayout(new GridLayoutManager(1, 3, new Insets(0, 0, 0, 0), -1, -1));
         contentPane.add(panel1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         creasePatternCpSavesButton = new JButton();
-        creasePatternCpSavesButton.setHorizontalAlignment(2);
-        creasePatternCpSavesButton.setText("<html><b>Crease Pattern (.cp)</b><br/>\nSaves only crease pattern <br/>lines.<br/><br/>\n\n<i>Use this format to share <br/>crease patterns with other <br/>people.</i>");
+        creasePatternCpSavesButton.setHorizontalAlignment(0);
+        creasePatternCpSavesButton.setText("<html><br/><b>.CP</b><br/><br/> Save only M/V/A/E lines.<br/><br/><i>Robust and compatible file<br/>format that is widely used to<br/>share crease patterns.</i><br/><br/><html/>");
+        creasePatternCpSavesButton.setVerticalAlignment(1);
         panel1.add(creasePatternCpSavesButton, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         completeOriAlsoSavesButton = new JButton();
-        completeOriAlsoSavesButton.setHorizontalAlignment(2);
-        completeOriAlsoSavesButton.setText("<html><b>Complete (.ori)</b><br/>\nAlso saves circles, yellow <br/>aux lines and the grid.<br/>\n<br/>\n<i>Use this format when <br/>saving to your local <br/>computer.</i>");
+        completeOriAlsoSavesButton.setHorizontalAlignment(0);
+        completeOriAlsoSavesButton.setText("<html><br/><b>.ORI</b><br/><br/>Save all lines, circles, text,<br/>and grid.<br/> <br/> <i>Oriedita exclusive file format.</i><br/>");
+        completeOriAlsoSavesButton.setVerticalAlignment(1);
         panel1.add(completeOriAlsoSavesButton, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        completeFoldAlsoSavesButton = new JButton();
+        completeFoldAlsoSavesButton.setText("<html><br/><b>.FOLD</b><br/><br/>Save all lines, circles, text,<br/>and grid.<br/> <br/> <i>Compatible with other origami<br/>related software. </i><br/>");
+        completeFoldAlsoSavesButton.setVerticalAlignment(1);
+        panel1.add(completeFoldAlsoSavesButton, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
     }
 
     /**

--- a/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
+++ b/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
@@ -201,7 +201,7 @@ public class FileSaveServiceImpl implements FileSaveService {
     }
 
     public File selectOpenFile() {
-        String fileName = openFileDialog(frame.get(), "Open File", applicationModel.getDefaultDirectory(), new String[]{"*.ori", "*.cp"}, "Supported files (.ori, .cp)");
+        String fileName = openFileDialog(frame.get(), "Open File", applicationModel.getDefaultDirectory(), new String[]{"*.ori", "*.cp", "*.fold"}, "Supported files (.ori, .cp, .fold)");
 
         if (fileName == null) {
             return null;
@@ -415,7 +415,14 @@ public class FileSaveServiceImpl implements FileSaveService {
             }
 
             Cp.exportFile(save, fname);
-        } else {
+        } else if (fname.getName().endsWith((".fold"))){
+            try {
+                fold.exportFile(mainCreasePatternWorker.getSave_for_export(), fname);
+            } catch (InterruptedException | FileReadingException e) {
+                e.printStackTrace();
+            }
+        }
+        else {
             JOptionPane.showMessageDialog(frame.get(), "Unknown file type, cannot save", "Error", JOptionPane.ERROR_MESSAGE);
         }
     }


### PR DESCRIPTION
Regarding to issue #316 . Import is recommended by @undertrox to be untouched and instead focus on the .FOLD for Open and Save As. Save As now as .FOLD option to pick:

<img width="599" alt="image" src="https://github.com/oriedita/oriedita/assets/94136126/41b8270b-4e6a-474c-bda7-8d1fedfbe3bd">

And using "Open" will now show .fold files and allow users to pick them.
