### PR TITLE
DXF Export

### DIFF
--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/ExportDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/ExportDialog.java
@@ -92,6 +92,7 @@ public class ExportDialog extends JDialog {
         listModel.add(3, new ExportOption(".orh", "Orihime save (.orh)"));
         listModel.add(4, new ExportOption(".cp", "Crease pattern (.cp)"));
         listModel.add(5, new ExportOption(".fold", "FOLD (.fold)"));
+        listModel.add(6, new ExportOption(".dxf", "DXF (.dxf)"));
 
         list1.setModel(listModel);
 

--- a/oriedita/src/main/java/oriedita/editor/export/Dxf.java
+++ b/oriedita/src/main/java/oriedita/editor/export/Dxf.java
@@ -1,0 +1,100 @@
+package oriedita.editor.export;
+
+import org.tinylog.Logger;
+import oriedita.editor.save.Save;
+import origami.crease_pattern.element.LineColor;
+import origami.crease_pattern.element.LineSegment;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+
+public class Dxf {
+    public static void exportFile(Save cp, File file) {
+        double scale = 3.0;
+        double center = 4.0;
+        double x1, y1, x2, y2;
+        LineColor lineColor;
+
+        try(FileWriter fw = new FileWriter(file); BufferedWriter bw = new BufferedWriter(fw); PrintWriter pw = new PrintWriter(bw)){
+            pw.println("  0");
+            pw.println("SECTION");
+            pw.println("  2");
+            pw.println("HEADER");
+            pw.println("  9");
+            pw.println("$ACADVER");
+            pw.println("  1");
+            pw.println("AC1009");
+            pw.println("  0");
+            pw.println("ENDSEC");
+            pw.println("  0");
+            pw.println("SECTION");
+            pw.println("  2");
+            pw.println("ENTITIES");
+
+
+            for (LineSegment lineSegment : cp.getLineSegments()) {
+                    pw.println("  0");
+                    pw.println("LINE");
+                    pw.println("  8");
+
+                    lineColor = lineSegment.getColor();
+                    String layerName = "noname";
+                    int colorNumber = 0;
+
+                    switch (lineColor) {
+                        case BLACK_0:
+                            layerName = "CutLine";
+                            colorNumber = 250; // gray
+                            break;
+                        case RED_1:
+                            layerName = "MountainLine";
+                            colorNumber = 1; // red
+                            break;
+                        case BLUE_2:
+                            layerName = "ValleyLine";
+                            colorNumber = 5; // blue
+                            break;
+                        case CYAN_3:
+                            layerName = "AuxiliaryLine";
+                            colorNumber = 4; // cyan
+                    }
+                    x1 = lineSegment.determineAX();
+                    y1 = lineSegment.determineAY();
+                    x2 = lineSegment.determineBX();
+                    y2 = lineSegment.determineBY();
+
+                    pw.println(layerName);
+                    pw.println("  6");
+                    pw.println("CONTINUOUS");
+                    pw.println("  62");
+                    pw.println(colorNumber);
+
+                    pw.println("  10");
+                    pw.println(scale(x1, scale, center));
+                    pw.println("  20");
+                    pw.println(scale(y1, -scale, center));
+
+                    pw.println("  11");
+                    pw.println(scale(x2, scale, center));
+                    pw.println("  21");
+                    pw.println(scale(y2, -scale, center));
+
+            }
+
+            pw.println("  0\n");
+            pw.println("ENDSEC\n");
+            pw.println("  0\n");
+            pw.println("EOF\n");
+        } catch (IOException e) {
+            Logger.error(e, "Error during Dxf export");
+        }
+    }
+
+    private static double scale(double d, double scale, double center) {
+        return d * scale + center;
+    }
+}

--- a/oriedita/src/main/java/oriedita/editor/export/Dxf.java
+++ b/oriedita/src/main/java/oriedita/editor/export/Dxf.java
@@ -85,10 +85,10 @@ public class Dxf {
 
             }
 
-            pw.println("  0\n");
-            pw.println("ENDSEC\n");
-            pw.println("  0\n");
-            pw.println("EOF\n");
+            pw.println("  0");
+            pw.println("ENDSEC");
+            pw.println("  0");
+            pw.println("EOF");
         } catch (IOException e) {
             Logger.error(e, "Error during Dxf export");
         }

--- a/oriedita/src/main/java/oriedita/editor/export/Dxf.java
+++ b/oriedita/src/main/java/oriedita/editor/export/Dxf.java
@@ -62,10 +62,10 @@ public class Dxf {
                             layerName = "AuxiliaryLine";
                             colorNumber = 4; // cyan
                     }
-                    x1 = lineSegment.determineAX();
-                    y1 = lineSegment.determineAY();
-                    x2 = lineSegment.determineBX();
-                    y2 = lineSegment.determineBY();
+                    x1 = lineSegment.determineAX() + 200;
+                    y1 = lineSegment.determineAY() - 200;
+                    x2 = lineSegment.determineBX() + 200;
+                    y2 = lineSegment.determineBY() - 200;
 
                     pw.println(layerName);
                     pw.println("  6");

--- a/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
+++ b/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
@@ -16,6 +16,7 @@ import oriedita.editor.databinding.FoldedFiguresList;
 import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.exception.FileReadingException;
 import oriedita.editor.export.Cp;
+import oriedita.editor.export.Dxf;
 import oriedita.editor.export.Fold;
 import oriedita.editor.export.Obj;
 import oriedita.editor.export.Orh;
@@ -197,6 +198,8 @@ public class FileSaveServiceImpl implements FileSaveService {
             } catch (InterruptedException | FileReadingException e) {
                 e.printStackTrace();
             }
+        } else if (exportFile.getName().endsWith(".dxf")) {
+            Dxf.exportFile(mainCreasePatternWorker.getSave_for_export(), exportFile);
         }
     }
 


### PR DESCRIPTION
This branch focuses on implementing DXF exporting method (used in orihimeMod created by @undertrox) for AutoCAD users.

<img width="605" alt="image" src="https://github.com/oriedita/oriedita/assets/94136126/2901f333-4092-4ffc-9140-a94356555f3d">

Exported .DXF file opened in Inkscape
<img width="1046" alt="image" src="https://github.com/oriedita/oriedita/assets/94136126/a3d2f15d-a047-4957-807c-ae055377883c">

