### PR TITLE
Import/Export settings from Preference

### DIFF
--- a/oriedita-common/src/main/java/oriedita/editor/service/ApplicationModelPersistenceService.java
+++ b/oriedita-common/src/main/java/oriedita/editor/service/ApplicationModelPersistenceService.java
@@ -1,5 +1,9 @@
 package oriedita.editor.service;
 
+import java.io.File;
+
 public interface ApplicationModelPersistenceService {
     void init();
+
+    void importApplicationModel(File configFile);
 }

--- a/oriedita-common/src/main/java/oriedita/editor/service/ApplicationModelPersistenceService.java
+++ b/oriedita-common/src/main/java/oriedita/editor/service/ApplicationModelPersistenceService.java
@@ -1,9 +1,10 @@
 package oriedita.editor.service;
 
 import java.io.File;
+import java.util.zip.ZipInputStream;
 
 public interface ApplicationModelPersistenceService {
     void init();
 
-    void importApplicationModel(File configFile);
+    void importApplicationModel(ZipInputStream zis);
 }

--- a/oriedita-data/src/main/java/oriedita/editor/service/FileSaveService.java
+++ b/oriedita-data/src/main/java/oriedita/editor/service/FileSaveService.java
@@ -10,6 +10,10 @@ public interface FileSaveService {
 
     void openFile();
 
+    void importPref ();
+
+    void exportPref ();
+
     void importFile();
 
     void exportFile();

--- a/oriedita-data/src/main/java/oriedita/editor/service/FileSaveService.java
+++ b/oriedita-data/src/main/java/oriedita/editor/service/FileSaveService.java
@@ -1,5 +1,6 @@
 package oriedita.editor.service;
 
+import oriedita.editor.FrameProvider;
 import oriedita.editor.exception.FileReadingException;
 import oriedita.editor.save.Save;
 
@@ -11,7 +12,7 @@ public interface FileSaveService {
 
     void openFile();
 
-    void importPref (JPanel parent);
+    void importPref (JPanel parent, FrameProvider frameProvider, ButtonService buttonService);
 
     void exportPref ();
 

--- a/oriedita-data/src/main/java/oriedita/editor/service/FileSaveService.java
+++ b/oriedita-data/src/main/java/oriedita/editor/service/FileSaveService.java
@@ -3,6 +3,7 @@ package oriedita.editor.service;
 import oriedita.editor.exception.FileReadingException;
 import oriedita.editor.save.Save;
 
+import javax.swing.JPanel;
 import java.io.File;
 
 public interface FileSaveService {
@@ -10,7 +11,7 @@ public interface FileSaveService {
 
     void openFile();
 
-    void importPref ();
+    void importPref (JPanel parent);
 
     void exportPref ();
 

--- a/oriedita-data/src/main/java/oriedita/editor/service/impl/ApplicationModelPersistenceServiceImpl.java
+++ b/oriedita-data/src/main/java/oriedita/editor/service/impl/ApplicationModelPersistenceServiceImpl.java
@@ -1,5 +1,6 @@
 package oriedita.editor.service.impl;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -61,6 +62,22 @@ public class ApplicationModelPersistenceServiceImpl implements ApplicationModelP
             }
 
             applicationModel.reset();
+        }
+    }
+
+    public void importApplicationModel(File configFile){
+        try {
+            ApplicationModel loadedApplicationModel = new DefaultObjectMapper().readValue(configFile, ApplicationModel.class);
+            applicationModel.set(loadedApplicationModel);
+        } catch (JsonMappingException e) {
+            // Can't map imported application state
+            JOptionPane.showMessageDialog(frame.get(), "<html>Failed to map application state.", "State load failed", JOptionPane.ERROR_MESSAGE);
+        } catch (IOException e) {
+            // Imported application state isn't accessible
+            JOptionPane.showMessageDialog(frame.get(), "<html>Failed to import application state.", "State load failed", JOptionPane.ERROR_MESSAGE);
+            e.printStackTrace();
+        } catch (Exception e){
+            e.printStackTrace();
         }
     }
 

--- a/oriedita-data/src/main/java/oriedita/editor/service/impl/ApplicationModelPersistenceServiceImpl.java
+++ b/oriedita-data/src/main/java/oriedita/editor/service/impl/ApplicationModelPersistenceServiceImpl.java
@@ -15,6 +15,7 @@ import javax.swing.JOptionPane;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.zip.ZipInputStream;
 
 import static oriedita.editor.tools.ResourceUtil.getAppDir;
 
@@ -65,9 +66,18 @@ public class ApplicationModelPersistenceServiceImpl implements ApplicationModelP
         }
     }
 
-    public void importApplicationModel(File configFile){
+    public void importApplicationModel(ZipInputStream zis){
         try {
-            ApplicationModel loadedApplicationModel = new DefaultObjectMapper().readValue(configFile, ApplicationModel.class);
+            StringBuilder s = new StringBuilder();
+            byte[] buffer = new byte[1024];
+            int read = 0;
+            while ((read = zis.read(buffer, 0, 1024)) >= 0) {
+                s.append(new String(buffer, 0, read));
+            }
+
+            ObjectMapper objectMapper = new DefaultObjectMapper();
+            objectMapper.configure(SerializationFeature.CLOSE_CLOSEABLE, false);
+            ApplicationModel loadedApplicationModel = objectMapper.readValue(s.toString(), ApplicationModel.class);
             applicationModel.set(loadedApplicationModel);
         } catch (JsonMappingException e) {
             // Can't map imported application state

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
@@ -258,7 +258,7 @@ public class AppMenuBar {
         });
         prefButton.addActionListener(e -> {
             if(preferenceDialog == null){
-                preferenceDialog = new PreferenceDialog(applicationModel, lookAndFeelService, frameProvider, foldedFigureModel, "Preferences", frameProvider.get(), buttonService);
+                preferenceDialog = new PreferenceDialog(applicationModel, lookAndFeelService, frameProvider, foldedFigureModel, "Preferences", frameProvider.get(), buttonService, fileSaveService);
             }
             preferenceDialog.setSize(preferenceDialog.getRootPane().getPreferredSize());
             preferenceDialog.setMinimumSize(preferenceDialog.getRootPane().getMinimumSize());

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.form
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.form
@@ -20,7 +20,7 @@
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="9538f" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="9538f" layout-manager="GridLayoutManager" row-count="1" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="10"/>
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="6" fill="0" indent="0" use-parent-layout="false"/>
@@ -30,7 +30,7 @@
             <children>
               <component id="e7465" class="javax.swing.JButton" binding="buttonOK">
                 <constraints>
-                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="OK"/>
@@ -38,7 +38,7 @@
               </component>
               <component id="5723f" class="javax.swing.JButton" binding="buttonCancel">
                 <constraints>
-                  <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Cancel"/>
@@ -46,10 +46,26 @@
               </component>
               <component id="9e182" class="javax.swing.JButton" binding="restoreDefaultsButton" default-binding="true">
                 <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Restore defaults"/>
+                </properties>
+              </component>
+              <component id="30258" class="javax.swing.JButton" binding="importButton" default-binding="true">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Import"/>
+                </properties>
+              </component>
+              <component id="1be1a" class="javax.swing.JButton" binding="exportButton" default-binding="true">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Export"/>
                 </properties>
               </component>
             </children>

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
@@ -360,8 +360,9 @@ public class PreferenceDialog extends JDialog {
         buttonCancel.addActionListener(e -> onCancel());
         restoreDefaultsButton.addActionListener(e -> onReset());
         importButton.addActionListener(e -> {
-            fileSaveService.importPref(contentPane);
+            fileSaveService.importPref(contentPane, frameProvider, buttonService);
             setData(applicationModel);
+            setupHotKey(buttonService, frameProvider);
         });
         exportButton.addActionListener(e -> fileSaveService.exportPref());
 

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
@@ -359,6 +359,7 @@ public class PreferenceDialog extends JDialog {
         buttonOK.addActionListener(e -> onOK());
         buttonCancel.addActionListener(e -> onCancel());
         restoreDefaultsButton.addActionListener(e -> onReset());
+        importButton.addActionListener(e -> fileSaveService.importPref(contentPane));
         exportButton.addActionListener(e -> fileSaveService.exportPref());
 
         // call onCancel() when cross is clicked

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
@@ -16,6 +16,7 @@ import oriedita.editor.canvas.LineStyle;
 import oriedita.editor.databinding.ApplicationModel;
 import oriedita.editor.databinding.FoldedFigureModel;
 import oriedita.editor.service.ButtonService;
+import oriedita.editor.service.FileSaveService;
 import oriedita.editor.service.LookAndFeelService;
 import oriedita.editor.swing.component.ColorIcon;
 import oriedita.editor.tools.KeyStrokeUtil;
@@ -131,6 +132,8 @@ public class PreferenceDialog extends JDialog {
     private JPanel gridLinePanel;
     private JLabel CPLabel;
     private JPanel hotkeyPanel;
+    private JButton importButton;
+    private JButton exportButton;
     private int tempTransparency;
     private final ApplicationModel applicationModel;
     private final ApplicationModel tempModel;
@@ -184,7 +187,8 @@ public class PreferenceDialog extends JDialog {
             FoldedFigureModel foldedFigureModel,
             String name,
             Frame owner,
-            ButtonService buttonService
+            ButtonService buttonService,
+            FileSaveService fileSaveService
     ) {
         super(owner, name);
         this.applicationModel = appModel;
@@ -353,10 +357,9 @@ public class PreferenceDialog extends JDialog {
         mouseRangeSlider.addChangeListener(e -> applicationModel.setMouseRadius(mouseRangeSlider.getValue()));
 
         buttonOK.addActionListener(e -> onOK());
-
         buttonCancel.addActionListener(e -> onCancel());
-
         restoreDefaultsButton.addActionListener(e -> onReset());
+        exportButton.addActionListener(e -> fileSaveService.exportPref());
 
         // call onCancel() when cross is clicked
         addWindowListener(new WindowAdapter() {
@@ -613,17 +616,23 @@ public class PreferenceDialog extends JDialog {
         gbc.fill = GridBagConstraints.HORIZONTAL;
         contentPane.add(bottomPanel, gbc);
         final JPanel panel1 = new JPanel();
-        panel1.setLayout(new GridLayoutManager(1, 3, new Insets(0, 0, 0, 10), -1, -1));
+        panel1.setLayout(new GridLayoutManager(1, 5, new Insets(0, 0, 0, 10), -1, -1));
         bottomPanel.add(panel1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_SOUTHEAST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         buttonOK = new JButton();
         buttonOK.setText("OK");
-        panel1.add(buttonOK, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panel1.add(buttonOK, new GridConstraints(0, 3, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         buttonCancel = new JButton();
         buttonCancel.setText("Cancel");
-        panel1.add(buttonCancel, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panel1.add(buttonCancel, new GridConstraints(0, 4, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         restoreDefaultsButton = new JButton();
         restoreDefaultsButton.setText("Restore defaults");
-        panel1.add(restoreDefaultsButton, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panel1.add(restoreDefaultsButton, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        importButton = new JButton();
+        importButton.setText("Import");
+        panel1.add(importButton, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        exportButton = new JButton();
+        exportButton.setText("Export");
+        panel1.add(exportButton, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final Spacer spacer1 = new Spacer();
         bottomPanel.add(spacer1, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
         topPanel = new JPanel();

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
@@ -403,13 +403,7 @@ public class PreferenceDialog extends JDialog {
 
     public KeyStroke getKeyBind(FrameProvider owner, String key) {
         InputMap map = owner.get().getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        KeyStroke stroke = null;
-        for (KeyStroke keyStroke : map.keys()) {
-            if (map.get(keyStroke).equals(key)) {
-                stroke = keyStroke;
-            }
-        }
-        return stroke;
+        return Arrays.stream(map.keys()).filter(ks -> map.get(ks).equals(key)).findFirst().orElse(null);
     }
 
     private JLabel getIconLabel(ButtonService buttonService, String key) {

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
@@ -359,7 +359,10 @@ public class PreferenceDialog extends JDialog {
         buttonOK.addActionListener(e -> onOK());
         buttonCancel.addActionListener(e -> onCancel());
         restoreDefaultsButton.addActionListener(e -> onReset());
-        importButton.addActionListener(e -> fileSaveService.importPref(contentPane));
+        importButton.addActionListener(e -> {
+            fileSaveService.importPref(contentPane);
+            setData(applicationModel);
+        });
         exportButton.addActionListener(e -> fileSaveService.exportPref());
 
         // call onCancel() when cross is clicked

--- a/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
+++ b/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
@@ -35,16 +35,13 @@ import oriedita.editor.swing.dialog.FileDialogUtil;
 import oriedita.editor.swing.dialog.SaveTypeDialog;
 import oriedita.editor.tools.ResourceUtil;
 
-import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import java.awt.Image;
 import java.awt.Toolkit;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -53,10 +50,11 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
@@ -146,76 +144,32 @@ public class FileSaveServiceImpl implements FileSaveService {
 
     @Override
     public void importPref(JPanel parent) {
-        ZipFile zipFile = null;
-        JFileChooser fileChooser = new JFileChooser();
-        fileChooser.setMultiSelectionEnabled(false);
-
-        int option = fileChooser.showOpenDialog(parent);
-        if (option == JFileChooser.APPROVE_OPTION && fileChooser.getSelectedFile() != null){
-            try {
-                zipFile = new ZipFile(fileChooser.getSelectedFile());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        assert zipFile != null;
+        Path importPath = Path.of(FileDialogUtil.openFileDialog(frame.get(), "Import...", applicationModel.getDefaultDirectory(), new String[]{"*.zip"}, null));
 
         ZipEntry ze;
-        try(ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile.getName()))){
+        try(ZipInputStream zis = new ZipInputStream(new FileInputStream(importPath.toFile()))){
             while ((ze = zis.getNextEntry()) != null){
-                File file = new File(ze.getName());
 
-                try (FileOutputStream fos = new FileOutputStream(file)) {
-                    byte[] buffer = new byte[1024];
-                    int bytesRead;
-                    while ((bytesRead = zis.read(buffer)) != -1) {
-                        fos.write(buffer, 0, bytesRead);
+                if (ze.getName().equals("config.json")){
+                    applicationModelPersistenceService.importApplicationModel(zis);
+                } else if (ze.getName().endsWith(".properties")){
+                    Logger.info("ze.getName(): "+ze.getName());
+                    String bundleName = ze.getName().split("\\.")[0];
+                    ResourceBundle userBundle = null;
+
+                    try {
+                        userBundle = new PropertyResourceBundle(zis);
+                    } catch (IOException ignored) {
                     }
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
 
-                if (file.getName().equals("config.json")){
-                    applicationModelPersistenceService.importApplicationModel(file);
-                } else if (file.getName().endsWith(".properties")){
-                    try (BufferedReader br = new BufferedReader(new FileReader(file))) {
-                        String line;
-                        boolean skipFirstLine = true; // Flag to skip the first line
-
-                        while ((line = br.readLine()) != null) {
-                            if (skipFirstLine) {
-                                skipFirstLine = false;
-                                continue; // Skip the first line
-                            }
-                            if (!line.contains("=")) {
-                                Logger.info("Line does not contain '=' character: " + line);
-                                continue; // Skip lines without '='
-                            }
-
-                            String[] temp = line.split("=");
-
-                            if (temp.length < 2) {
-                                Logger.info("Invalid/Missing hotkey: " + line);
-                                continue; // Skip lines without both key and value
-                            }
-
-                            // Get bundleName, key, and value
-                            String bundleName = file.getName().split("\\.")[0];
-                            List<String> parts = new ArrayList<>();
-                            parts.add(temp[0]);
-                            parts.add(temp[1]);
-                            String key = parts.get(0);
-                            String value = parts.get(1);
-
-                            ResourceUtil.updateBundleKey(bundleName, key, value);
-                        }
-                    } catch (IOException e) {
-                        e.printStackTrace();
+                    assert userBundle != null;
+                    for( String key : userBundle.keySet()){
+                        ResourceUtil.updateBundleKey(bundleName, key, userBundle.getString(key));
                     }
                 }
             }
         } catch (IOException e) {
+            Logger.info("zis closed");
             throw new RuntimeException(e);
         }
     }

--- a/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
+++ b/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
@@ -149,10 +149,17 @@ public class FileSaveServiceImpl implements FileSaveService {
 
     @Override
     public void importPref(JPanel parent, FrameProvider frameProvider, ButtonService buttonService) {
-        Path importPath = Path.of(FileDialogUtil.openFileDialog(frame.get(), "Import...", applicationModel.getDefaultDirectory(), new String[]{"*.zip"}, null));
+        Path importPath = Path.of(FileDialogUtil.openFileDialog(frame.get(), "Import...", applicationModel.getDefaultDirectory(), new String[]{"*.oriconfig"}, null));
+        File zipFile = importPath.toFile();
+        String extension = ".oriconfig";
+
+        if(!zipFile.getName().endsWith(extension)){
+            JOptionPane.showMessageDialog(parent, String.format("The zip file must have %s as the extension", extension),"Wrong import file format", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
 
         ZipEntry ze;
-        try(ZipInputStream zis = new ZipInputStream(new FileInputStream(importPath.toFile()))){
+        try(ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile))){
             while ((ze = zis.getNextEntry()) != null){
                 if (ze.getName().equals("config.json")){
                     applicationModelPersistenceService.importApplicationModel(zis);
@@ -194,7 +201,7 @@ public class FileSaveServiceImpl implements FileSaveService {
             fileNames.add(file.getName());
         }
 
-        Path exportPath = Path.of(FileDialogUtil.saveFileDialog(frame.get(), "Export...", applicationModel.getDefaultDirectory(), new String[]{"*.zip"}, null));
+        Path exportPath = Path.of(FileDialogUtil.saveFileDialog(frame.get(), "Export...", applicationModel.getDefaultDirectory(), new String[]{"*.oriconfig"}, null));
 
         try (ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(exportPath.toFile()))) {
             fileNames.forEach(fileName -> {

--- a/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
+++ b/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
@@ -44,9 +44,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
@@ -141,7 +142,13 @@ public class FileSaveServiceImpl implements FileSaveService {
 
     @Override
     public void exportPref(){
-        List<String> fileNames = Arrays.asList("config.json", "hotkey.properties");
+        File configDir = new File(ResourceUtil.getAppDir().toUri());
+        List<String> fileNames = new ArrayList<>();
+
+        for (File file : Objects.requireNonNull(configDir.listFiles())){
+            fileNames.add(file.getName());
+        }
+
         Path exportPath = Path.of(FileDialogUtil.saveFileDialog(frame.get(), "Export...", applicationModel.getDefaultDirectory(), new String[]{"*.zip"}, null));
 
         try (ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(exportPath.toFile()))) {

--- a/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
+++ b/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
@@ -167,23 +167,19 @@ public class FileSaveServiceImpl implements FileSaveService {
     }
 
     private void readImportHotkey(ZipInputStream zis, ZipEntry ze, FrameProvider frameProvider, ButtonService buttonService){
-        String bundleName = ze.getName().split("\\.")[0];
-        ResourceBundle userBundle;
-
         try {
-            userBundle = new PropertyResourceBundle(zis);
+            ResourceBundle userBundle = new PropertyResourceBundle(zis);
+            InputMap map = frameProvider.get().getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
 
-            for( String action : userBundle.keySet()){
-                InputMap map = frameProvider.get().getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+            for(String action : userBundle.keySet()){
                 KeyStroke currentKeyStroke = Arrays.stream(map.keys()).filter(ks -> map.get(ks).equals(action)).findFirst().orElse(null);
-
-                String keyStroke = userBundle.getString(action);
-
+                String importKeyStroke = userBundle.getString(action);
+                String bundleName = ze.getName().split("\\.")[0];
 
                 buttonService.getHelpInputMap().remove(currentKeyStroke);
                 frameProvider.get().getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).remove(currentKeyStroke);
-                frameProvider.get().getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(keyStroke), action);
-                ResourceUtil.updateBundleKey(bundleName, action, keyStroke);
+                frameProvider.get().getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(importKeyStroke), action);
+                ResourceUtil.updateBundleKey(bundleName, action, importKeyStroke);
             }
         } catch (IOException ignored) {
         }

--- a/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
+++ b/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
@@ -51,6 +51,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -171,20 +172,18 @@ public class FileSaveServiceImpl implements FileSaveService {
 
         try {
             userBundle = new PropertyResourceBundle(zis);
-            for( String key : userBundle.keySet()){
+
+            for( String action : userBundle.keySet()){
                 InputMap map = frameProvider.get().getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-                KeyStroke stroke = null;
-                for (KeyStroke keyStroke : map.keys()) {
-                    if (map.get(keyStroke).equals(key)) {
-                        stroke = keyStroke;
-                    }
-                }
-                KeyStroke currentKeyStroke = stroke;
+                KeyStroke currentKeyStroke = Arrays.stream(map.keys()).filter(ks -> map.get(ks).equals(action)).findFirst().orElse(null);
+
+                String keyStroke = userBundle.getString(action);
+
 
                 buttonService.getHelpInputMap().remove(currentKeyStroke);
                 frameProvider.get().getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).remove(currentKeyStroke);
-                frameProvider.get().getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(userBundle.getString(key)), key);
-                ResourceUtil.updateBundleKey(bundleName, key, userBundle.getString(key));
+                frameProvider.get().getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(keyStroke), action);
+                ResourceUtil.updateBundleKey(bundleName, action, keyStroke);
             }
         } catch (IOException ignored) {
         }

--- a/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
+++ b/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
@@ -30,6 +30,7 @@ import oriedita.editor.save.SaveProvider;
 import oriedita.editor.service.FileSaveService;
 import oriedita.editor.service.ResetService;
 import oriedita.editor.swing.dialog.ExportDialog;
+import oriedita.editor.swing.dialog.FileDialogUtil;
 import oriedita.editor.swing.dialog.SaveTypeDialog;
 import oriedita.editor.tools.ResourceUtil;
 
@@ -37,12 +38,19 @@ import javax.swing.JOptionPane;
 import java.awt.Image;
 import java.awt.Toolkit;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static oriedita.editor.swing.dialog.FileDialogUtil.openFileDialog;
 import static oriedita.editor.swing.dialog.FileDialogUtil.saveFileDialog;
@@ -123,6 +131,32 @@ public class FileSaveServiceImpl implements FileSaveService {
         } catch (FileReadingException e) {
             Logger.error(e, "Error during file read");
             JOptionPane.showMessageDialog(frame.get(), "An error occurred when reading this file", "Read Error", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    @Override
+    public void importPref() {
+
+    }
+
+    @Override
+    public void exportPref(){
+        List<String> fileNames = Arrays.asList("config.json", "hotkey.properties");
+        Path exportPath = Path.of(FileDialogUtil.saveFileDialog(frame.get(), "Export...", applicationModel.getDefaultDirectory(), new String[]{"*.zip"}, null));
+
+        try (ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(exportPath.toFile()))) {
+            fileNames.forEach(fileName -> {
+                Path filePath = ResourceUtil.getAppDir().resolve(fileName);
+                try (InputStream fis = new FileInputStream(filePath.toFile())) {
+                    zout.putNextEntry(new ZipEntry(fileName));
+                    fis.transferTo(zout);
+                    zout.closeEntry();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Implemented export/import tools to export settings in the preference (currently only `config.json` and `hotkey.properties`).

Clicking on export will export an `.oriconfig` file (by manually including that extension after the name) that contains the two aforementioned files.
Clicking on import will let you pick a zip file with the mandatory `.oriconfig` extension and the two files inside it will be processed.
<img width="166" alt="image" src="https://github.com/oriedita/oriedita/assets/94136126/f82c8484-8306-4a3f-92d6-eb8cfa103e33">

NOTE: the two files has to have the exact name of `config.json` and `hotkey.properties` with the right content in order for it to work.