### PR TITLE
Rewrite eraser+replace logic / Letter-only dropdown items (mostly)

### DIFF
--- a/oriedita-data/src/main/java/oriedita/editor/canvas/CreasePattern_Worker.java
+++ b/oriedita-data/src/main/java/oriedita/editor/canvas/CreasePattern_Worker.java
@@ -6,6 +6,7 @@ import oriedita.editor.databinding.CanvasModel;
 import oriedita.editor.databinding.GridModel;
 import oriedita.editor.drawing.Grid;
 import oriedita.editor.drawing.tools.Camera;
+import origami.crease_pattern.CustomLineTypes;
 import oriedita.editor.save.Save;
 import origami.crease_pattern.FoldLineSet;
 import origami.crease_pattern.LineSegmentSet;
@@ -170,9 +171,9 @@ public interface CreasePattern_Worker {
 
     boolean insideToAux(Point p0a, Point p0b);
 
-    boolean insideToReplace(Point p0a, Point p0b, int from, int to);
+    boolean insideToReplace(Point p0a, Point p0b, CustomLineTypes from, CustomLineTypes to);
 
-    boolean insideToDelete(Point p0a, Point p0b, int del);
+    boolean insideToDelete(Point p0a, Point p0b, CustomLineTypes del);
 
     void setFoldLineDividingNumber(int i);
 

--- a/oriedita-data/src/main/java/oriedita/editor/databinding/ApplicationModel.java
+++ b/oriedita-data/src/main/java/oriedita/editor/databinding/ApplicationModel.java
@@ -4,7 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import oriedita.editor.Colors;
 import oriedita.editor.canvas.LineStyle;
-import oriedita.editor.handler.CustomLineTypes;
+import origami.crease_pattern.CustomLineTypes;
 
 import java.awt.Color;
 import java.awt.Dimension;

--- a/oriedita-ui/src/main/java/oriedita/editor/handler/PopupMenuAdapter.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/handler/PopupMenuAdapter.java
@@ -1,0 +1,22 @@
+package oriedita.editor.handler;
+
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+
+public abstract class PopupMenuAdapter implements PopupMenuListener {
+    @Override
+    public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+        // Empty default implementation
+    }
+
+    @Override
+    public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+        // Empty default implementation
+    }
+
+    @Override
+    public void popupMenuCanceled(PopupMenuEvent e) {
+        // Empty default implementation
+    }
+}
+

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.form
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.form
@@ -150,10 +150,11 @@
             <properties>
               <model>
                 <item value="Any"/>
-                <item value="Edge"/>
+                <item value="E"/>
+                <item value="M &amp; V"/>
                 <item value="M"/>
                 <item value="V"/>
-                <item value="Aux"/>
+                <item value="A"/>
               </model>
             </properties>
           </component>
@@ -171,10 +172,10 @@
             </constraints>
             <properties>
               <model>
-                <item value="Edge"/>
+                <item value="E"/>
                 <item value="M"/>
                 <item value="V"/>
-                <item value="Aux"/>
+                <item value="A"/>
               </model>
             </properties>
           </component>
@@ -877,10 +878,11 @@
             <properties>
               <model>
                 <item value="Any"/>
-                <item value="Edge"/>
-                <item value="Mountain"/>
-                <item value="Valley"/>
-                <item value="Aux"/>
+                <item value="E"/>
+                <item value="M &amp; V"/>
+                <item value="M"/>
+                <item value="V"/>
+                <item value="A"/>
               </model>
             </properties>
           </component>

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
@@ -25,6 +25,7 @@ import oriedita.editor.databinding.FoldedFiguresList;
 import oriedita.editor.databinding.GridModel;
 import oriedita.editor.databinding.MeasuresModel;
 import oriedita.editor.drawing.FoldedFigure_Drawer;
+import oriedita.editor.handler.PopupMenuAdapter;
 import origami.crease_pattern.CustomLineTypes;
 import oriedita.editor.service.ButtonService;
 import oriedita.editor.service.FoldingService;
@@ -49,6 +50,7 @@ import javax.swing.JTextField;
 import javax.swing.UIManager;
 import javax.swing.border.Border;
 import javax.swing.border.LineBorder;
+import javax.swing.event.PopupMenuEvent;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Insets;
@@ -438,6 +440,12 @@ public class LeftPanel {
             applicationModel.setDelLineType(CustomLineTypes.from(delTypeDropBox.getSelectedIndex() - 1));
             delTypeDropBox.setSelectedIndex(applicationModel.getDelLineType().getNumber() + 1);
         });
+        delTypeDropBox.addPopupMenuListener(new PopupMenuAdapter() {
+            @Override
+            public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+                del_l_typeButton.doClick();
+            }
+        });
         trimBranchesButton.addActionListener(e -> {
             mainCreasePatternWorker.point_removal();
             mainCreasePatternWorker.overlapping_line_removal();
@@ -454,6 +462,12 @@ public class LeftPanel {
             applicationModel.setCustomFromLineType(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1));
             fromLineDropBox.setSelectedIndex(applicationModel.getCustomFromLineType().getNumber() + 1);
         });
+        fromLineDropBox.addPopupMenuListener(new PopupMenuAdapter() {
+            @Override
+            public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+                replace_lineButton.doClick();
+            }
+        });
         toLineDropBox.addActionListener(e -> {
             if (toLineDropBox.getSelectedIndex() == CustomLineTypes.EGDE.getNumber()) {
                 applicationModel.setCustomToLineType(CustomLineTypes.from(toLineDropBox.getSelectedIndex()));
@@ -461,6 +475,12 @@ public class LeftPanel {
             } else {
                 applicationModel.setCustomToLineType(CustomLineTypes.from(toLineDropBox.getSelectedIndex() + 1));
                 toLineDropBox.setSelectedIndex(applicationModel.getCustomToLineType().getNumber() - 1);
+            }
+        });
+        toLineDropBox.addPopupMenuListener(new PopupMenuAdapter() {
+            @Override
+            public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+                replace_lineButton.doClick();
             }
         });
         zen_yama_tani_henkanButton.addActionListener(e -> {

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
@@ -438,7 +438,6 @@ public class LeftPanel {
         });
         delTypeDropBox.addActionListener(e -> {
             applicationModel.setDelLineType(CustomLineTypes.from(delTypeDropBox.getSelectedIndex() - 1));
-            delTypeDropBox.setSelectedIndex(applicationModel.getDelLineType().getNumber() + 1);
         });
         delTypeDropBox.addPopupMenuListener(new PopupMenuAdapter() {
             @Override
@@ -460,7 +459,6 @@ public class LeftPanel {
         });
         fromLineDropBox.addActionListener(e -> {
             applicationModel.setCustomFromLineType(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1));
-            fromLineDropBox.setSelectedIndex(applicationModel.getCustomFromLineType().getNumber() + 1);
         });
         fromLineDropBox.addPopupMenuListener(new PopupMenuAdapter() {
             @Override
@@ -471,10 +469,8 @@ public class LeftPanel {
         toLineDropBox.addActionListener(e -> {
             if (toLineDropBox.getSelectedIndex() == CustomLineTypes.EGDE.getNumber()) {
                 applicationModel.setCustomToLineType(CustomLineTypes.from(toLineDropBox.getSelectedIndex()));
-                toLineDropBox.setSelectedIndex(applicationModel.getCustomToLineType().getNumber());
             } else {
                 applicationModel.setCustomToLineType(CustomLineTypes.from(toLineDropBox.getSelectedIndex() + 1));
-                toLineDropBox.setSelectedIndex(applicationModel.getCustomToLineType().getNumber() - 1);
             }
         });
         toLineDropBox.addPopupMenuListener(new PopupMenuAdapter() {
@@ -1194,16 +1190,34 @@ public class LeftPanel {
 
         delTypeDropBox.setSelectedIndex(applicationModel.getDelLineType().getNumber() + 1);
         fromLineDropBox.setSelectedIndex(applicationModel.getCustomFromLineType().getNumber() + 1);
-        if (applicationModel.getCustomToLineType() == CustomLineTypes.EGDE) {
-            toLineDropBox.setSelectedIndex(applicationModel.getCustomToLineType().getNumber());
-        } else {
-            if (applicationModel.getCustomToLineType() != CustomLineTypes.ANY) {
+
+        // -------- CONTEXT FOR THE BELOW LOGIC --------
+        // - The Replace-to dropbox items are Edge, Mountain, Valley, Aux in that order
+        // - Dropbox starts at index 0 for first item
+        // - CustomLineType enum has Any, Edge, M&V, Mountain, Valley, Aux in that order, starting from -1
+        // -------- LOGIC --------
+        // - If Edge is selected, update the applicationModel using normal index
+        // - If Mountain, Valley, or Aux is selected, update the applicationModel with index - 1 (because those
+        // 3 options in CustomLineType are after M&V, therefore each has an extra value increment)
+        // - If somehow Any is selected (from manual edit in applicationModel), set its value in applicationModel
+        // to CustomLineType.EDGE, and set dropdown's selected index to 0, corresponding to Edge
+        switch (applicationModel.getCustomToLineType()) {
+            case EGDE:
+                toLineDropBox.setSelectedIndex(CustomLineTypes.EGDE.getNumber());
+                break;
+            case MOUNTAIN:
+            case VALLEY:
+            case AUX:
                 toLineDropBox.setSelectedIndex(applicationModel.getCustomToLineType().getNumber() - 1);
-            } else {
+                break;
+            case ANY:
                 applicationModel.setCustomToLineType(CustomLineTypes.EGDE);
                 toLineDropBox.setSelectedIndex(CustomLineTypes.EGDE.getNumber());
-            }
+                break;
+            default:
+                break;
         }
+        // ------ END LOGIC ------
 
         if (e.getPropertyName() == null || e.getPropertyName().equals("laf")) {
             // The look and feel is not set yet, so it must be read from the applicationModel

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
@@ -25,7 +25,7 @@ import oriedita.editor.databinding.FoldedFiguresList;
 import oriedita.editor.databinding.GridModel;
 import oriedita.editor.databinding.MeasuresModel;
 import oriedita.editor.drawing.FoldedFigure_Drawer;
-import oriedita.editor.handler.CustomLineTypes;
+import origami.crease_pattern.CustomLineTypes;
 import oriedita.editor.service.ButtonService;
 import oriedita.editor.service.FoldingService;
 import oriedita.editor.service.HistoryState;
@@ -35,7 +35,6 @@ import oriedita.editor.tools.LookAndFeelUtil;
 import oriedita.editor.tools.StringOp;
 import origami.crease_pattern.element.LineColor;
 import origami.folding.FoldedFigure;
-import origami.crease_pattern.element.LineSegment;
 
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.ImageIcon;
@@ -437,7 +436,7 @@ public class LeftPanel {
         });
         delTypeDropBox.addActionListener(e -> {
             applicationModel.setDelLineType(CustomLineTypes.from(delTypeDropBox.getSelectedIndex() - 1));
-            delTypeDropBox.setSelectedIndex(applicationModel.getDelLineType().getType() + 1);
+            delTypeDropBox.setSelectedIndex(applicationModel.getDelLineType().getNumber() + 1);
         });
         trimBranchesButton.addActionListener(e -> {
             mainCreasePatternWorker.point_removal();
@@ -453,11 +452,16 @@ public class LeftPanel {
         });
         fromLineDropBox.addActionListener(e -> {
             applicationModel.setCustomFromLineType(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1));
-            fromLineDropBox.setSelectedIndex(applicationModel.getCustomFromLineType().getType() + 1);
+            fromLineDropBox.setSelectedIndex(applicationModel.getCustomFromLineType().getNumber() + 1);
         });
         toLineDropBox.addActionListener(e -> {
-            applicationModel.setCustomToLineType(CustomLineTypes.from(toLineDropBox.getSelectedIndex()));
-            toLineDropBox.setSelectedIndex(applicationModel.getCustomToLineType().getType());
+            if (toLineDropBox.getSelectedIndex() == CustomLineTypes.EGDE.getNumber()) {
+                applicationModel.setCustomToLineType(CustomLineTypes.from(toLineDropBox.getSelectedIndex()));
+                toLineDropBox.setSelectedIndex(applicationModel.getCustomToLineType().getNumber());
+            } else {
+                applicationModel.setCustomToLineType(CustomLineTypes.from(toLineDropBox.getSelectedIndex() + 1));
+                toLineDropBox.setSelectedIndex(applicationModel.getCustomToLineType().getNumber() - 1);
+            }
         });
         zen_yama_tani_henkanButton.addActionListener(e -> {
             mainCreasePatternWorker.allMountainValleyChange();
@@ -761,10 +765,11 @@ public class LeftPanel {
         fromLineDropBox = new JComboBox();
         final DefaultComboBoxModel defaultComboBoxModel1 = new DefaultComboBoxModel();
         defaultComboBoxModel1.addElement("Any");
-        defaultComboBoxModel1.addElement("Edge");
+        defaultComboBoxModel1.addElement("E");
+        defaultComboBoxModel1.addElement("M & V");
         defaultComboBoxModel1.addElement("M");
         defaultComboBoxModel1.addElement("V");
-        defaultComboBoxModel1.addElement("Aux");
+        defaultComboBoxModel1.addElement("A");
         fromLineDropBox.setModel(defaultComboBoxModel1);
         panel3.add(fromLineDropBox, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         replaceLabel = new JLabel();
@@ -772,10 +777,10 @@ public class LeftPanel {
         panel3.add(replaceLabel, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         toLineDropBox = new JComboBox();
         final DefaultComboBoxModel defaultComboBoxModel2 = new DefaultComboBoxModel();
-        defaultComboBoxModel2.addElement("Edge");
+        defaultComboBoxModel2.addElement("E");
         defaultComboBoxModel2.addElement("M");
         defaultComboBoxModel2.addElement("V");
-        defaultComboBoxModel2.addElement("Aux");
+        defaultComboBoxModel2.addElement("A");
         toLineDropBox.setModel(defaultComboBoxModel2);
         panel3.add(toLineDropBox, new GridConstraints(0, 3, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JPanel panel4 = new JPanel();
@@ -1069,10 +1074,11 @@ public class LeftPanel {
         delTypeDropBox = new JComboBox();
         final DefaultComboBoxModel defaultComboBoxModel3 = new DefaultComboBoxModel();
         defaultComboBoxModel3.addElement("Any");
-        defaultComboBoxModel3.addElement("Edge");
-        defaultComboBoxModel3.addElement("Mountain");
-        defaultComboBoxModel3.addElement("Valley");
-        defaultComboBoxModel3.addElement("Aux");
+        defaultComboBoxModel3.addElement("E");
+        defaultComboBoxModel3.addElement("M & V");
+        defaultComboBoxModel3.addElement("M");
+        defaultComboBoxModel3.addElement("V");
+        defaultComboBoxModel3.addElement("A");
         delTypeDropBox.setModel(defaultComboBoxModel3);
         panel13.add(delTypeDropBox, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final Spacer spacer1 = new Spacer();
@@ -1166,9 +1172,18 @@ public class LeftPanel {
         gridColorButton.setIcon(new ColorIcon(data.getGridColor()));
         intervalGridColorButton.setIcon(new ColorIcon(data.getGridScaleColor()));
 
-        delTypeDropBox.setSelectedIndex(applicationModel.getDelLineType().getType() + 1);
-        fromLineDropBox.setSelectedIndex(applicationModel.getCustomFromLineType().getType() + 1);
-        toLineDropBox.setSelectedIndex(applicationModel.getCustomToLineType().getType());
+        delTypeDropBox.setSelectedIndex(applicationModel.getDelLineType().getNumber() + 1);
+        fromLineDropBox.setSelectedIndex(applicationModel.getCustomFromLineType().getNumber() + 1);
+        if (applicationModel.getCustomToLineType() == CustomLineTypes.EGDE) {
+            toLineDropBox.setSelectedIndex(applicationModel.getCustomToLineType().getNumber());
+        } else {
+            if (applicationModel.getCustomToLineType() != CustomLineTypes.ANY) {
+                toLineDropBox.setSelectedIndex(applicationModel.getCustomToLineType().getNumber() - 1);
+            } else {
+                applicationModel.setCustomToLineType(CustomLineTypes.EGDE);
+                toLineDropBox.setSelectedIndex(CustomLineTypes.EGDE.getNumber());
+            }
+        }
 
         if (e.getPropertyName() == null || e.getPropertyName().equals("laf")) {
             // The look and feel is not set yet, so it must be read from the applicationModel

--- a/oriedita/src/main/java/oriedita/editor/canvas/impl/CreasePattern_Worker_Impl.java
+++ b/oriedita/src/main/java/oriedita/editor/canvas/impl/CreasePattern_Worker_Impl.java
@@ -17,6 +17,7 @@ import oriedita.editor.databinding.SelectedTextModel;
 import oriedita.editor.drawing.Grid;
 import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.drawing.tools.DrawingUtil;
+import origami.crease_pattern.CustomLineTypes;
 import oriedita.editor.save.Save;
 import oriedita.editor.save.SaveProvider;
 import oriedita.editor.service.HistoryState;
@@ -831,7 +832,7 @@ public class CreasePattern_Worker_Impl implements CreasePattern_Worker {
     }
 
     @Override
-    public boolean insideToDelete(Point p0a, Point p0b, int del){
+    public boolean insideToDelete(Point p0a, Point p0b, CustomLineTypes del){
         return foldLineSet.insideToDelete(createBox(p0a, p0b), del);
     }
 
@@ -960,7 +961,7 @@ public class CreasePattern_Worker_Impl implements CreasePattern_Worker {
     }
 
     @Override
-    public boolean insideToReplace(Point p0a, Point p0b, int from, int to){
+    public boolean insideToReplace(Point p0a, Point p0b, CustomLineTypes from, CustomLineTypes to){
         return foldLineSet.insideToReplace(createBox(p0a, p0b), from, to);
     }
 

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerDeleteTypeSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerDeleteTypeSelect.java
@@ -5,6 +5,8 @@ import jakarta.inject.Inject;
 import oriedita.editor.canvas.MouseMode;
 import oriedita.editor.databinding.ApplicationModel;
 import origami.Epsilon;
+import origami.crease_pattern.CustomLineTypes;
+import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 
@@ -26,7 +28,7 @@ public class MouseHandlerDeleteTypeSelect extends BaseMouseHandlerBoxSelect {
         Point p = new Point();
         p.set(d.getCamera().TV2object(p0));
 
-        int del = applicationModel.getDelLineType().getType();
+        CustomLineTypes del = applicationModel.getDelLineType();
 
         if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218
             if (d.insideToDelete(selectionStart, p0, del)) {
@@ -36,18 +38,33 @@ public class MouseHandlerDeleteTypeSelect extends BaseMouseHandlerBoxSelect {
             if (d.getFoldLineSet().closestLineSegmentDistance(p) < d.getSelectionDistance()) {//点pに最も近い線分の番号での、その距離を返す	public double closestLineSegmentDistance(Ten p)
                 LineSegment s = d.getFoldLineSet().closestLineSegmentSearch(p);
 
-                // From "Any"
-                if (del == -1) {
-                    d.getFoldLineSet().deleteLine(s);
-                    d.record();
-
-                }
-                // From other line types
-                else {
-                    if (s.getColor().getNumber() == del) {
+                switch (del){
+                    case ANY:
                         d.getFoldLineSet().deleteLine(s);
                         d.record();
-                    }
+                        break;
+                    case EGDE:
+                        if (s.getColor() == LineColor.BLACK_0) {
+                            d.getFoldLineSet().deleteLine(s);
+                            d.record();
+                        }
+                        break;
+                    case MANDV:
+                        if (s.getColor() == LineColor.RED_1 || s.getColor() == LineColor.BLUE_2) {
+                            d.getFoldLineSet().deleteLine(s);
+                            d.record();
+                        }
+                        break;
+                    case MOUNTAIN:
+                    case VALLEY:
+                    case AUX:
+                        if (s.getColor() == LineColor.fromNumber(del.getNumber() - 1)) {
+                            d.getFoldLineSet().deleteLine(s);
+                            d.record();
+                        }
+                        break;
+                    default:
+                        break;
                 }
             }
         }

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceSelect.java
@@ -5,6 +5,7 @@ import jakarta.inject.Inject;
 import oriedita.editor.canvas.MouseMode;
 import oriedita.editor.databinding.ApplicationModel;
 import origami.Epsilon;
+import origami.crease_pattern.CustomLineTypes;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
@@ -27,8 +28,8 @@ public class MouseHandlerReplaceSelect extends BaseMouseHandlerBoxSelect {
         Point p = new Point();
         p.set(d.getCamera().TV2object(p0));
 
-        int from = applicationModel.getCustomFromLineType().getType();
-        int to = applicationModel.getCustomToLineType().getType();
+        CustomLineTypes from = applicationModel.getCustomFromLineType();
+        CustomLineTypes to = applicationModel.getCustomToLineType();
 
         if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218
             if (d.insideToReplace(selectionStart, p0, from, to)) {
@@ -39,19 +40,37 @@ public class MouseHandlerReplaceSelect extends BaseMouseHandlerBoxSelect {
             if (d.getFoldLineSet().closestLineSegmentDistance(p) < d.getSelectionDistance()) {//点pに最も近い線分の番号での、その距離を返す	public double closestLineSegmentDistance(Ten p)
                 LineSegment s = d.getFoldLineSet().closestLineSegmentSearch(p);
 
-                // From "Any"
-                if(from == -1){
-                    s.setColor(LineColor.fromNumber(to));
-                    d.fix2();
-                    d.record();
-                }
-                // From other line types
-                else {
-                    if( s.getColor().getNumber() == from){
-                        s.setColor(LineColor.fromNumber(to));
+                switch (from){
+                    case ANY:
+                        s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
                         d.fix2();
                         d.record();
-                    }
+                        break;
+                    case EGDE:
+                        if (s.getColor() == LineColor.BLACK_0) {
+                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            d.fix2();
+                            d.record();
+                        }
+                        break;
+                    case MANDV:
+                        if (s.getColor() == LineColor.RED_1 || s.getColor() == LineColor.BLUE_2) {
+                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            d.fix2();
+                            d.record();
+                        }
+                        break;
+                    case MOUNTAIN:
+                    case VALLEY:
+                    case AUX:
+                        if (s.getColor() == LineColor.fromNumber(from.getNumber() - 1)) {
+                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            d.fix2();
+                            d.record();
+                        }
+                        break;
+                    default:
+                        break;
                 }
             }
         }

--- a/origami/src/main/java/origami/crease_pattern/CustomLineTypes.java
+++ b/origami/src/main/java/origami/crease_pattern/CustomLineTypes.java
@@ -1,19 +1,24 @@
-package oriedita.editor.handler;
+package origami.crease_pattern;
 
 public enum CustomLineTypes {
     ANY(-1),
     EGDE(0),
-    MOUNTAIN(1),
-    VALLEY(2),
-    AUX(3);
+    MANDV(1),
+    MOUNTAIN(2),
+    VALLEY(3),
+    AUX(4);
     private final int customType;
 
     CustomLineTypes(int customType) {
         this.customType = customType;
     }
 
-    public int getType(){
+    public int getNumber(){
         return customType;
+    }
+
+    public int getReplaceToTypeNumber(){
+        return this == CustomLineTypes.EGDE ? this.getNumber() : this.getNumber() - 1;
     }
 
     public static CustomLineTypes from(int customType){

--- a/origami/src/main/java/origami/crease_pattern/CustomLineTypes.java
+++ b/origami/src/main/java/origami/crease_pattern/CustomLineTypes.java
@@ -18,6 +18,9 @@ public enum CustomLineTypes {
     }
 
     public int getReplaceToTypeNumber(){
+        if(this == CustomLineTypes.ANY){
+            return EGDE.customType;
+        }
         return this == CustomLineTypes.EGDE ? this.getNumber() : this.getNumber() - 1;
     }
 

--- a/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -435,31 +435,48 @@ public class FoldLineSet {
         return i_r;
     }
 
-    public boolean insideToReplace(Polygon b, int from, int to){
+    public boolean insideToReplace(Polygon b, CustomLineTypes from, CustomLineTypes to){
         boolean i_r = false;
 
         for (int i = 1; i <= total; i++){
             LineSegment s;
             s = lineSegments.get(i);
+
             if(b.totu_boundary_inside(s)){
-                // From "Any"
-                if(from == -1){
-                    s.setColor(LineColor.fromNumber(to));
-                    i_r = true;
-                }
-                // From other line types
-                else {
-                    if(s.getColor().getNumber() == from){
-                        s.setColor(LineColor.fromNumber(to));
+                switch (from){
+                    case ANY:
+                        s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
                         i_r = true;
-                    }
+                        break;
+                    case EGDE:
+                        if (s.getColor() == LineColor.BLACK_0) {
+                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            i_r = true;
+                        }
+                        break;
+                    case MANDV:
+                        if (s.getColor() == LineColor.RED_1 || s.getColor() == LineColor.BLUE_2) {
+                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            i_r = true;
+                        }
+                        break;
+                    case MOUNTAIN:
+                    case VALLEY:
+                    case AUX:
+                        if (s.getColor() == LineColor.fromNumber(from.getNumber() - 1)) {
+                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            i_r = true;
+                        }
+                        break;
+                    default:
+                        break;
                 }
             }
         }
         return i_r;
     }
 
-    public boolean insideToDelete(Polygon b, int del){
+    public boolean insideToDelete(Polygon b, CustomLineTypes del){
         boolean i_r = false;
 
         FoldLineSave save = new FoldLineSave();
@@ -468,22 +485,42 @@ public class FoldLineSet {
             LineSegment s;
             s = lineSegments.get(i);
 
-            // From "Any"
-            if(del == -1){
-                if(b.totu_boundary_inside(s)){
-                    i_r = true;
-                } else {
-                    save.addLineSegment(s.clone());
-                }
-            }
-            //From other line types
-            else {
-                if ((b.totu_boundary_inside(s)) && s.getColor().getNumber() == del) {
-                    i_r = true;
-                }//黒赤青線はmemo1に書かれない。つまり削除される。
-                else if ((!b.totu_boundary_inside(s)) || s.getColor().getNumber() != del) {
-                    save.addLineSegment(s.clone());
-                }
+            switch (del){
+                case ANY:
+                    if(b.totu_boundary_inside(s)){
+                        i_r = true;
+                    } else {
+                        save.addLineSegment(s.clone());
+                    }
+                    break;
+                case EGDE:
+                    if ((b.totu_boundary_inside(s)) && s.getColor() == LineColor.BLACK_0) {
+                        i_r = true;
+                    }//黒赤青線はmemo1に書かれない。つまり削除される。
+                    else if ((!b.totu_boundary_inside(s)) || s.getColor() != LineColor.BLACK_0) {
+                        save.addLineSegment(s.clone());
+                    }
+                    break;
+                case MANDV:
+                    if ((b.totu_boundary_inside(s)) && (s.getColor() == LineColor.RED_1 || s.getColor() == LineColor.BLUE_2)) {
+                        i_r = true;
+                    }//黒赤青線はmemo1に書かれない。つまり削除される。
+                    else if ((!b.totu_boundary_inside(s)) || !(s.getColor() == LineColor.RED_1 || s.getColor() == LineColor.BLUE_2)) {
+                        save.addLineSegment(s.clone());
+                    }
+                    break;
+                case MOUNTAIN:
+                case VALLEY:
+                case AUX:
+                    if ((b.totu_boundary_inside(s)) && s.getColor() == LineColor.fromNumber(del.getNumber() - 1)) {
+                        i_r = true;
+                    }//黒赤青線はmemo1に書かれない。つまり削除される。
+                    else if ((!b.totu_boundary_inside(s)) || s.getColor() != LineColor.fromNumber(del.getNumber() - 1)) {
+                        save.addLineSegment(s.clone());
+                    }
+                    break;
+                default:
+                    break;
             }
         }
         if(i_r){


### PR DESCRIPTION
Rewrite logic for eraser and replace tool, reduce item names to mostly letter-only, and add in "M & V" option to eraser and replace-from dropdowns.


https://github.com/oriedita/oriedita/assets/94136126/f598f065-8981-47f6-b73e-c327252b7255


https://github.com/oriedita/oriedita/assets/94136126/9501fb8c-b4ba-4acb-8d4e-e87364fde2ab



Currently one slight issue is with replace-to logic, which is being prone to being manually set to ANY in file during edita runtime.