### PR TITLE
Improve replace tool click select performance / clearer method names

### DIFF
--- a/oriedita-data/src/main/java/oriedita/editor/canvas/CreasePattern_Worker.java
+++ b/oriedita-data/src/main/java/oriedita/editor/canvas/CreasePattern_Worker.java
@@ -171,9 +171,9 @@ public interface CreasePattern_Worker {
 
     boolean insideToAux(Point p0a, Point p0b);
 
-    boolean insideToReplace(Point p0a, Point p0b, CustomLineTypes from, CustomLineTypes to);
+    boolean insideToReplaceType(Point p0a, Point p0b, CustomLineTypes from, CustomLineTypes to);
 
-    boolean insideToDelete(Point p0a, Point p0b, CustomLineTypes del);
+    boolean insideToDeleteType(Point p0a, Point p0b, CustomLineTypes del);
 
     void setFoldLineDividingNumber(int i);
 

--- a/oriedita/src/main/java/oriedita/editor/canvas/impl/CreasePattern_Worker_Impl.java
+++ b/oriedita/src/main/java/oriedita/editor/canvas/impl/CreasePattern_Worker_Impl.java
@@ -832,8 +832,8 @@ public class CreasePattern_Worker_Impl implements CreasePattern_Worker {
     }
 
     @Override
-    public boolean insideToDelete(Point p0a, Point p0b, CustomLineTypes del){
-        return foldLineSet.insideToDelete(createBox(p0a, p0b), del);
+    public boolean insideToDeleteType(Point p0a, Point p0b, CustomLineTypes del){
+        return foldLineSet.insideToDeleteType(createBox(p0a, p0b), del);
     }
 
     @Override
@@ -961,8 +961,8 @@ public class CreasePattern_Worker_Impl implements CreasePattern_Worker {
     }
 
     @Override
-    public boolean insideToReplace(Point p0a, Point p0b, CustomLineTypes from, CustomLineTypes to){
-        return foldLineSet.insideToReplace(createBox(p0a, p0b), from, to);
+    public boolean insideToReplaceType(Point p0a, Point p0b, CustomLineTypes from, CustomLineTypes to){
+        return foldLineSet.insideToReplaceType(createBox(p0a, p0b), from, to);
     }
 
     @Override

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerDeleteTypeSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerDeleteTypeSelect.java
@@ -31,7 +31,7 @@ public class MouseHandlerDeleteTypeSelect extends BaseMouseHandlerBoxSelect {
         CustomLineTypes del = applicationModel.getDelLineType();
 
         if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218
-            if (d.insideToDelete(selectionStart, p0, del)) {
+            if (d.insideToDeleteType(selectionStart, p0, del)) {
                 d.record();
             }
         } else {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceTypeSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceTypeSelect.java
@@ -33,6 +33,7 @@ public class MouseHandlerReplaceTypeSelect extends BaseMouseHandlerBoxSelect {
 
         if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218
             if (d.insideToReplaceType(selectionStart, p0, from, to)) {
+                d.fix2();
                 d.record();
             }
         } else {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceTypeSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceTypeSelect.java
@@ -33,7 +33,6 @@ public class MouseHandlerReplaceTypeSelect extends BaseMouseHandlerBoxSelect {
 
         if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218
             if (d.insideToReplaceType(selectionStart, p0, from, to)) {
-                d.fix2();
                 d.record();
             }
         } else {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceTypeSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceTypeSelect.java
@@ -39,16 +39,16 @@ public class MouseHandlerReplaceTypeSelect extends BaseMouseHandlerBoxSelect {
             if (d.getFoldLineSet().closestLineSegmentDistance(p) < d.getSelectionDistance()) {//点pに最も近い線分の番号での、その距離を返す	public double closestLineSegmentDistance(Ten p)
                 LineSegment s = d.getFoldLineSet().closestLineSegmentSearch(p);
 
-                d.getFoldLineSet().deleteLine(s);
-
                 switch (from){
                     case ANY:
+                        d.getFoldLineSet().deleteLine(s);
                         s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
                         d.addLineSegment(s);
                         d.record();
                         break;
                     case EGDE:
                         if (s.getColor() == LineColor.BLACK_0) {
+                            d.getFoldLineSet().deleteLine(s);
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
                             d.addLineSegment(s);
                             d.record();
@@ -56,6 +56,7 @@ public class MouseHandlerReplaceTypeSelect extends BaseMouseHandlerBoxSelect {
                         break;
                     case MANDV:
                         if (s.getColor() == LineColor.RED_1 || s.getColor() == LineColor.BLUE_2) {
+                            d.getFoldLineSet().deleteLine(s);
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
                             d.addLineSegment(s);
                             d.record();
@@ -65,6 +66,7 @@ public class MouseHandlerReplaceTypeSelect extends BaseMouseHandlerBoxSelect {
                     case VALLEY:
                     case AUX:
                         if (s.getColor() == LineColor.fromNumber(from.getNumber() - 1)) {
+                            d.getFoldLineSet().deleteLine(s);
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
                             d.addLineSegment(s);
                             d.record();

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceTypeSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceTypeSelect.java
@@ -12,12 +12,12 @@ import origami.crease_pattern.element.Point;
 
 @ApplicationScoped
 @Handles(MouseMode.REPLACE_LINE_TYPE_SELECT_72)
-public class MouseHandlerReplaceSelect extends BaseMouseHandlerBoxSelect {
+public class MouseHandlerReplaceTypeSelect extends BaseMouseHandlerBoxSelect {
 
     private ApplicationModel applicationModel;
 
     @Inject
-    public MouseHandlerReplaceSelect(ApplicationModel applicationModel) {
+    public MouseHandlerReplaceTypeSelect(ApplicationModel applicationModel) {
         this.applicationModel = applicationModel;
     }
 
@@ -32,32 +32,27 @@ public class MouseHandlerReplaceSelect extends BaseMouseHandlerBoxSelect {
         CustomLineTypes to = applicationModel.getCustomToLineType();
 
         if (selectionStart.distance(p0) > Epsilon.UNKNOWN_1EN6) {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218
-            if (d.insideToReplace(selectionStart, p0, from, to)) {
-                d.fix2();
+            if (d.insideToReplaceType(selectionStart, p0, from, to)) {
                 d.record();
             }
         } else {//現状では赤を赤に変えたときもUNDO用に記録されてしまう20161218
             if (d.getFoldLineSet().closestLineSegmentDistance(p) < d.getSelectionDistance()) {//点pに最も近い線分の番号での、その距離を返す	public double closestLineSegmentDistance(Ten p)
                 LineSegment s = d.getFoldLineSet().closestLineSegmentSearch(p);
 
+                d.getFoldLineSet().deleteLine(s);
+
                 switch (from){
                     case ANY:
                         s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
-                        d.fix2();
-                        d.record();
                         break;
                     case EGDE:
                         if (s.getColor() == LineColor.BLACK_0) {
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
-                            d.fix2();
-                            d.record();
                         }
                         break;
                     case MANDV:
                         if (s.getColor() == LineColor.RED_1 || s.getColor() == LineColor.BLUE_2) {
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
-                            d.fix2();
-                            d.record();
                         }
                         break;
                     case MOUNTAIN:
@@ -65,13 +60,13 @@ public class MouseHandlerReplaceSelect extends BaseMouseHandlerBoxSelect {
                     case AUX:
                         if (s.getColor() == LineColor.fromNumber(from.getNumber() - 1)) {
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
-                            d.fix2();
-                            d.record();
                         }
                         break;
                     default:
                         break;
                 }
+                d.addLineSegment(s);
+                d.record();
             }
         }
     }

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceTypeSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceTypeSelect.java
@@ -44,15 +44,21 @@ public class MouseHandlerReplaceTypeSelect extends BaseMouseHandlerBoxSelect {
                 switch (from){
                     case ANY:
                         s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                        d.addLineSegment(s);
+                        d.record();
                         break;
                     case EGDE:
                         if (s.getColor() == LineColor.BLACK_0) {
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            d.addLineSegment(s);
+                            d.record();
                         }
                         break;
                     case MANDV:
                         if (s.getColor() == LineColor.RED_1 || s.getColor() == LineColor.BLUE_2) {
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            d.addLineSegment(s);
+                            d.record();
                         }
                         break;
                     case MOUNTAIN:
@@ -60,13 +66,13 @@ public class MouseHandlerReplaceTypeSelect extends BaseMouseHandlerBoxSelect {
                     case AUX:
                         if (s.getColor() == LineColor.fromNumber(from.getNumber() - 1)) {
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            d.addLineSegment(s);
+                            d.record();
                         }
                         break;
                     default:
                         break;
                 }
-                d.addLineSegment(s);
-                d.record();
             }
         }
     }

--- a/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -435,12 +435,11 @@ public class FoldLineSet {
         return i_r;
     }
 
-    public boolean insideToReplace(Polygon b, CustomLineTypes from, CustomLineTypes to){
+    public boolean insideToReplaceType(Polygon b, CustomLineTypes from, CustomLineTypes to){
         boolean i_r = false;
 
         for (int i = 1; i <= total; i++){
-            LineSegment s;
-            s = lineSegments.get(i);
+            LineSegment s = lineSegments.get(i);
 
             if(b.totu_boundary_inside(s)){
                 switch (from){
@@ -476,14 +475,13 @@ public class FoldLineSet {
         return i_r;
     }
 
-    public boolean insideToDelete(Polygon b, CustomLineTypes del){
+    public boolean insideToDeleteType(Polygon b, CustomLineTypes del){
         boolean i_r = false;
 
         FoldLineSave save = new FoldLineSave();
 
         for (int i = 1; i <= total; i++){
-            LineSegment s;
-            s = lineSegments.get(i);
+            LineSegment s = lineSegments.get(i);
 
             switch (del){
                 case ANY:

--- a/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -36,7 +36,6 @@ public class FoldLineSet {
     private final Queue<LineSegment> Check3LineSegment = new ConcurrentLinkedQueue<>(); //Instantiation of line segments to store check information
     private final Queue<FlatFoldabilityViolation> cAMVViolations = new ConcurrentLinkedQueue<>();
     List<Circle> circles = new ArrayList<>(); //円のインスタンス化
-    List<LineSegment> reserveAux = new ArrayList<>();
 
     // Specify the point Q, delete the line segments AQ and QC, and add the line segment AC (however, only two line segments have Q as the end point) // When implemented, 1 when nothing is done Returns 0.
     // The procedure is (1) The point p is determined by clicking the mouse.
@@ -89,7 +88,7 @@ public class FoldLineSet {
         divideLineSegmentWithNewLines(total_old - 1, total_old);
     }
 
-    public void replaceAux(CustomLineTypes from, CustomLineTypes to){
+    public void replaceAux(CustomLineTypes from, CustomLineTypes to, List<LineSegment> reserveAux) {
         if(from == CustomLineTypes.AUX && to.getReplaceToTypeNumber() != LineColor.CYAN_3.getNumber()) {
             for (LineSegment s : reserveAux) {
                 LineSegment auxChange = s.clone();
@@ -456,6 +455,7 @@ public class FoldLineSet {
 
     public boolean insideToReplaceType(Polygon b, CustomLineTypes from, CustomLineTypes to){
         boolean i_r = false;
+        List<LineSegment> reserveAux = new ArrayList<>();
 
         for (int i = 1; i <= total; i++){
             LineSegment s = lineSegments.get(i);
@@ -499,7 +499,7 @@ public class FoldLineSet {
                 }
             }
         }
-        replaceAux(from, to);
+        replaceAux(from, to, reserveAux);
         return i_r;
     }
 

--- a/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -464,26 +464,31 @@ public class FoldLineSet {
                 switch (from){
                     case ANY:
                         s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                        i_r = true;
                         break;
                     case EGDE:
                         if (s.getColor() == LineColor.BLACK_0) {
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            i_r = true;
                         }
                         break;
                     case MANDV:
                         if (s.getColor() == LineColor.RED_1 || s.getColor() == LineColor.BLUE_2) {
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            i_r = true;
                         }
                         break;
                     case MOUNTAIN:
                     case VALLEY:
                         if (s.getColor() == LineColor.fromNumber(from.getNumber() - 1)) {
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            i_r = true;
                         }
                         break;
                     case AUX:
                         if(s.getColor() == LineColor.fromNumber(from.getNumber() - 1)) {
                             reserveAux.add(s);
+                            i_r = true;
                         }
                         break;
                     default:
@@ -492,7 +497,6 @@ public class FoldLineSet {
                 if(from != CustomLineTypes.AUX){
                     lineSegments.set(i, s);
                 }
-                i_r = true;
             }
         }
         replaceAux(from, to);

--- a/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -89,17 +89,13 @@ public class FoldLineSet {
     }
 
     public void replaceAux(CustomLineTypes from, CustomLineTypes to, List<LineSegment> reserveAux) {
-        if(from == CustomLineTypes.AUX || from == CustomLineTypes.ANY) {
-            if(to.getReplaceToTypeNumber() != LineColor.CYAN_3.getNumber()){
-                for (LineSegment s : reserveAux) {
-                    LineSegment auxChange = s.clone();
-                    auxChange.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
-                    deleteLine(s);
-                    addLineSegmentForReplace(auxChange);
-                }
-                reserveAux.clear();
-            }
+        for (LineSegment s : reserveAux) {
+            LineSegment auxChange = s.clone();
+            auxChange.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+            deleteLine(s);
+            addLineSegmentForReplace(auxChange);
         }
+        reserveAux.clear();
     }
 
     //Get the total number of line segments

--- a/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -464,31 +464,26 @@ public class FoldLineSet {
                 switch (from){
                     case ANY:
                         s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
-                        i_r = true;
                         break;
                     case EGDE:
                         if (s.getColor() == LineColor.BLACK_0) {
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
-                            i_r = true;
                         }
                         break;
                     case MANDV:
                         if (s.getColor() == LineColor.RED_1 || s.getColor() == LineColor.BLUE_2) {
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
-                            i_r = true;
                         }
                         break;
                     case MOUNTAIN:
                     case VALLEY:
                         if (s.getColor() == LineColor.fromNumber(from.getNumber() - 1)) {
                             s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
-                            i_r = true;
                         }
                         break;
                     case AUX:
                         if(s.getColor() == LineColor.fromNumber(from.getNumber() - 1)) {
                             reserveAux.add(s);
-                            i_r = true;
                         }
                         break;
                     default:
@@ -497,6 +492,7 @@ public class FoldLineSet {
                 if(from != CustomLineTypes.AUX){
                     lineSegments.set(i, s);
                 }
+                i_r = true;
             }
         }
         replaceAux(from, to);

--- a/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -89,14 +89,16 @@ public class FoldLineSet {
     }
 
     public void replaceAux(CustomLineTypes from, CustomLineTypes to, List<LineSegment> reserveAux) {
-        if(from == CustomLineTypes.AUX && to.getReplaceToTypeNumber() != LineColor.CYAN_3.getNumber()) {
-            for (LineSegment s : reserveAux) {
-                LineSegment auxChange = s.clone();
-                auxChange.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
-                deleteLine(s);
-                addLineSegmentForReplace(auxChange);
+        if(from == CustomLineTypes.AUX || from == CustomLineTypes.ANY) {
+            if(to.getReplaceToTypeNumber() != LineColor.CYAN_3.getNumber()){
+                for (LineSegment s : reserveAux) {
+                    LineSegment auxChange = s.clone();
+                    auxChange.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                    deleteLine(s);
+                    addLineSegmentForReplace(auxChange);
+                }
+                reserveAux.clear();
             }
-            reserveAux.clear();
         }
     }
 
@@ -459,11 +461,16 @@ public class FoldLineSet {
 
         for (int i = 1; i <= total; i++){
             LineSegment s = lineSegments.get(i);
+            LineSegment temp = s.clone();
 
             if(b.totu_boundary_inside(s) && (from.getNumber() != to.getReplaceToTypeNumber())){
                 switch (from){
                     case ANY:
-                        s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                        if(s.getColor() == LineColor.CYAN_3) {
+                            reserveAux.add(s);
+                        } else {
+                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                        }
                         i_r = true;
                         break;
                     case EGDE:
@@ -494,8 +501,14 @@ public class FoldLineSet {
                     default:
                         break;
                 }
-                if(from != CustomLineTypes.AUX){
-                    lineSegments.set(i, s);
+                if(from != CustomLineTypes.AUX){ // if replace from is not AUX
+                    if(from != CustomLineTypes.ANY){ // if replace from is not ANY
+                        lineSegments.set(i, s);
+                    } else { // if replace from is ANY & og linetype is not Aux
+                        if(temp.getColor() != LineColor.CYAN_3){
+                            lineSegments.set(i, s);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
When using replace tool to change one line type to another, the performance drops when there are significant amount of lines (usually at about L=10000 and above), both when using click select to select a individual line segment and box select to select multiple line segments. This PR at least got around with click select by simply deleting and adding the selected segment back in, removing the need the run fix2(). 

The box select performance drop still exists and I'm currently trying to figure out how to optimize it. Please let me know if there's anything I can try because I'm running out of ideas that doesn't involve writing some new specific methods (even I don't know what those would look like).

Note: The second commit I added back in just to show that that's what it looks like at the moment before the PR was made, I just forgot to put it back after testing.