### PR TITLE
OritaCalc method - check if a segment spans through a point

### DIFF
--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerAxiom5.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerAxiom5.java
@@ -119,12 +119,11 @@ public class MouseHandlerAxiom5 extends BaseMouseHandlerInputRestricted{
         // Make sure circle radius is not 0
         if(radius <= Epsilon.UNKNOWN_1EN7){ return; }
 
-        LineSegment secondTemp = new LineSegment(pivot, targetSegment.determineClosestEndpoint(pivot)); //  for checks alignment between pivot point and target segment
         double length_a = 0.0; //Distance between the center of the circle and target segment
         Point center = new Point(pivot);
 
         // If pivot point is not within the target segment span
-        if(OritaCalc.isLineSegmentParallel(secondTemp, targetSegment) != OritaCalc.ParallelJudgement.PARALLEL_EQUAL){
+        if(!OritaCalc.isPointWithinLineSpan(pivot, targetSegment)){
             length_a = OritaCalc.distance(center, OritaCalc.findProjection(targetSegment, center));
         }
 
@@ -157,8 +156,7 @@ public class MouseHandlerAxiom5 extends BaseMouseHandlerInputRestricted{
             LineSegment l2 = new LineSegment(projectPoint, OritaCalc.findProjection(OritaCalc.moveParallel(projectLine, -length_b), projectPoint));
             l2.set(new LineSegment(center, l2.getB()));
 
-            OritaCalc.ParallelJudgement pivotSegmentJudgement = OritaCalc.isLineSegmentParallel(secondTemp, targetSegment);
-            processPivotWithinSegmentSpan(pivotSegmentJudgement, l1, l2, center, targetSegment, pivot);
+            processPivotWithinSegmentSpan(l1, l2, center, targetSegment, pivot);
 
             // Center points for placeholders to draw bisecting indicators on
             Point center1 = new Point(OritaCalc.center(center, l1.determineFurthestEndpoint(center), l.determineFurthestEndpoint(center)));
@@ -178,9 +176,9 @@ public class MouseHandlerAxiom5 extends BaseMouseHandlerInputRestricted{
         }
     }
 
-    private void processPivotWithinSegmentSpan(OritaCalc.ParallelJudgement judgement, LineSegment l1, LineSegment l2, Point center, LineSegment targetSegment, Point pivot){
+    private void processPivotWithinSegmentSpan(LineSegment l1, LineSegment l2, Point center, LineSegment targetSegment, Point pivot){
         // If pivot point is within the target segment span
-        if(judgement == OritaCalc.ParallelJudgement.PARALLEL_EQUAL){
+        if(OritaCalc.isPointWithinLineSpan(pivot, targetSegment)){
             // pivot within span
             boolean isOutsideSegmentA = targetSegment.determineLength() > OritaCalc.distance(targetSegment.getA(), center) &&
                     OritaCalc.distance(targetSegment.getB(), center) > targetSegment.determineLength();
@@ -211,10 +209,8 @@ public class MouseHandlerAxiom5 extends BaseMouseHandlerInputRestricted{
     private void determineIndicators(LineSegment l, LineSegment l1, LineSegment l2, Point center, Point center1, Point center2, Point target, LineSegment targetSegment, Point pivot){
         if(OritaCalc.distance(center1, OritaCalc.findProjection(targetSegment, center1)) > Epsilon.UNKNOWN_1EN7 ||
                 OritaCalc.distance(center2, OritaCalc.findProjection(targetSegment, center2)) > Epsilon.UNKNOWN_1EN7){
-            LineSegment temp = new LineSegment(target, targetSegment.determineClosestEndpoint(target)); // for check alignment between target point and target segment
-
             // If target point is not within target segment span
-            if(OritaCalc.isLineSegmentParallel(temp, targetSegment) == OritaCalc.ParallelJudgement.NOT_PARALLEL){
+            if(!OritaCalc.isPointWithinLineSpan(target, targetSegment)){
                 //target not in span 1
                 LineSegment s1 = OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), new LineSegment(center, center1, LineColor.PURPLE_8));
                 LineSegment s2 = OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), new LineSegment(center, center2, LineColor.PURPLE_8));

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerAxiom7.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerAxiom7.java
@@ -43,9 +43,8 @@ public class MouseHandlerAxiom7 extends BaseMouseHandlerInputRestricted{
             LineSegment closestLineSegment = new LineSegment();
             closestLineSegment.set(d.getClosestLineSegment(p));
 
-            LineSegment temp = new LineSegment(d.getLineStep().get(0).getA(), closestLineSegment.determineClosestEndpoint(d.getLineStep().get(0).getA()));
             if (OritaCalc.determineLineSegmentDistance(p, closestLineSegment) < d.getSelectionDistance() &&
-                    OritaCalc.isLineSegmentParallel(temp, closestLineSegment) == OritaCalc.ParallelJudgement.NOT_PARALLEL) {
+                    !OritaCalc.isPointWithinLineSpan(d.getLineStep().get(0).getA(), closestLineSegment)) {
                 closestLineSegment.setColor(LineColor.GREEN_6);
                 d.lineStepAdd(closestLineSegment);
             }

--- a/origami/src/main/java/origami/crease_pattern/OritaCalc.java
+++ b/origami/src/main/java/origami/crease_pattern/OritaCalc.java
@@ -641,6 +641,7 @@ public class OritaCalc {
 
     }
 
+    //---------------------------
     public static LineSegment extendToIntersectionPoint_2(FoldLineSet foldLineSet, LineSegment s0) {//Extend s0 from point b in the opposite direction of a to the point where it intersects another polygonal line. Returns a new line // Returns the same line if it does not intersect another polygonal line
         LineSegment add_sen = new LineSegment();
         add_sen.set(s0);
@@ -699,6 +700,7 @@ public class OritaCalc {
         return add_sen;
     }
 
+    //---------------------------
     public static LineSegment fullExtendUntilHit(FoldLineSet foldLineSet, LineSegment s0){
         Point point = s0.getA();
         s0.set(extendToIntersectionPoint_2(foldLineSet, s0));
@@ -1150,37 +1152,22 @@ public class OritaCalc {
         return new LineSegment(s.getA(), new Point(s.getA().getX() + newDx, s.getA().getY() + nexDy));
     }
 
+    // Check if point p0 is within the span of segment s0
+    public static boolean isPointWithinLineSpan(Point p0, LineSegment s0){
+        LineSegment temp = new LineSegment(p0, s0.determineClosestEndpoint(p0));
+        return OritaCalc.isLineSegmentParallel(temp, s0) == ParallelJudgement.PARALLEL_EQUAL;
+    }
+
+    // Check if p0 is within the span of a segment, formed by p1 and p2
+    public static boolean isPointWithinLineSpan(Point p0, Point p1, Point p2){
+        return isPointWithinLineSpan(p0, new LineSegment(p1, p2));
+    }
+
+    //--------------------------------------------------------
+
     public enum ParallelJudgement {
         NOT_PARALLEL,
         PARALLEL_NOT_EQUAL,
         PARALLEL_EQUAL,
-    }
-
-    public static LineSegment s_step_additional_intersection(LineSegment s_o, LineSegment s_k, LineColor icolo) {
-
-        Point cross_point = new Point();
-
-        if (OritaCalc.isLineSegmentParallel(s_o, s_k, Epsilon.UNKNOWN_1EN7) == OritaCalc.ParallelJudgement.PARALLEL_NOT_EQUAL) {//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
-            return null;
-        }
-
-        if (OritaCalc.isLineSegmentParallel(s_o, s_k, Epsilon.UNKNOWN_1EN7) == OritaCalc.ParallelJudgement.PARALLEL_EQUAL) {//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
-            cross_point.set(s_k.getA());
-            if (OritaCalc.distance(s_o.getA(), s_k.getA()) > OritaCalc.distance(s_o.getA(), s_k.getB())) {
-                cross_point.set(s_k.getB());
-            }
-        }
-
-        if (OritaCalc.isLineSegmentParallel(s_o, s_k, Epsilon.UNKNOWN_1EN7) == OritaCalc.ParallelJudgement.NOT_PARALLEL) {//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
-            cross_point.set(OritaCalc.findIntersection(s_o, s_k));
-        }
-
-        LineSegment add_sen = new LineSegment(cross_point, s_o.getA(), icolo);
-
-        if (Epsilon.high.gt0(add_sen.determineLength())) {
-            return add_sen;
-        }
-
-        return null;
     }
 }


### PR DESCRIPTION
Added in a new method (2 variants of the same method)
```
// Check if point p0 is within the span of segment s0
public static boolean isPointWithinLineSpan(Point p0, LineSegment s0){
    LineSegment temp = new LineSegment(p0, s0.determineClosestEndpoint(p0));
    return OritaCalc.isLineSegmentParallel(temp, s0) == ParallelJudgement.PARALLEL_EQUAL;
}
```

```
  // Check if p0 is within the span of a segment, formed by p1 and p2
  public static boolean isPointWithinLineSpan(Point p0, Point p1, Point p2){
      return isPointWithinLineSpan(p0, new LineSegment(p1, p2));
  }
```