### PR TITLE
Replace line tool bug fix + Swap replace line types

### DIFF
--- a/oriedita-ui/src/main/java/oriedita/editor/action/ActionType.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/action/ActionType.java
@@ -193,7 +193,8 @@ public enum ActionType {
     restrictedAngleSetDEFAction("restrictedAngleSetDEFAction"),
     addColorConstraintAction("addColorConstraintAction"),
     axiom5Action("axiom5Action"),
-    axiom7Action("axiom7Action");
+    axiom7Action("axiom7Action"),
+    switchReplaceAction("switchReplaceAction");
 
 
     static final Map<String, ActionType> actionMap;

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.form
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.form
@@ -543,7 +543,7 @@
                   </component>
                 </children>
               </grid>
-              <grid id="7161c" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="1" vgap="1">
+              <grid id="7161c" layout-manager="GridLayoutManager" row-count="1" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="1" vgap="1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -593,6 +593,14 @@
                         <item value="V"/>
                         <item value="A"/>
                       </model>
+                    </properties>
+                  </component>
+                  <component id="cff19" class="javax.swing.JButton" binding="switchReplaceButton">
+                    <constraints>
+                      <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="⇆"/>
                     </properties>
                   </component>
                 </children>

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
@@ -173,6 +173,7 @@ public class LeftPanel {
     private JButton switchReplaceButton;
 
     private HashMap<MouseMode, JButton> selectionTransformationToolLookup;
+    private boolean isReplaceHold;
 
     public double convertAngle(double angle) {
         if (angle >= 0) return angle % 180;
@@ -214,6 +215,8 @@ public class LeftPanel {
         this.selectionTransformationToolLookup.put(MouseMode.CREASE_COPY_22, copyButton);
         this.selectionTransformationToolLookup.put(MouseMode.CREASE_MOVE_4P_31, move2p2pButton);
         this.selectionTransformationToolLookup.put(MouseMode.CREASE_COPY_4P_32, copy2p2pButton);
+
+        isReplaceHold = false;
     }
 
     public void init() {
@@ -1030,7 +1033,7 @@ public class LeftPanel {
             // The look and feel is not set yet, so it must be read from the applicationModel
             boolean isDark = LookAndFeelUtil.determineLafDark(data.getLaf());
 
-            for (JButton button : Arrays.asList(colBlackButton, colRedButton, colBlueButton, colCyanButton, senbun_henkan2Button)) {
+            for (JButton button : Arrays.asList(colBlackButton, colRedButton, colBlueButton, colCyanButton)) {
                 button.setForeground(Colors.restore(button.getForeground(), isDark));
                 button.setBackground(Colors.restore(button.getBackground(), isDark));
             }
@@ -1157,19 +1160,14 @@ public class LeftPanel {
             }
         }
 
-        if (e.getPropertyName() == null || e.getPropertyName().equals("mouseMode") || e.getPropertyName().equals("foldLineAdditionalInputMode")) {
-            Color buttonBg = UIManager.getColor("Button.background");
-            Color buttonFg = UIManager.getColor("Button.foreground");
-            senbun_henkan2Button.setBackground(buttonBg);
-            senbun_henkan2Button.setForeground(buttonFg);
+        if (canvasModel.getMouseMode() == MouseMode.REPLACE_LINE_TYPE_SELECT_72 && switchReplaceButton.isEnabled()) {
+            if (canvasModel.getToggleLineColor() && !isReplaceHold || !canvasModel.getToggleLineColor() && isReplaceHold) {
+                CustomLineTypes temp = applicationModel.getCustomFromLineType();
 
-            switch (data.getMouseMode()) {
-                case CREASE_TOGGLE_MV_58:
-                    senbun_henkan2Button.setBackground(Colors.get(new Color(138, 43, 226)));
-                    senbun_henkan2Button.setForeground(Colors.get(Color.white));
-                    break;
-                default:
-                    break;
+                applicationModel.setCustomFromLineType(applicationModel.getCustomToLineType());
+                applicationModel.setCustomToLineType(temp);
+
+                isReplaceHold = !isReplaceHold;
             }
         }
     }

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
@@ -319,8 +319,8 @@ public class LeftPanel {
         buttonService.setIcon(replaceLabel, "labelReplace");
 
         // Disable switchReplaceButton if "Any" or "M & V" is active
-        switchReplaceButton.setEnabled(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1) != CustomLineTypes.ANY &&
-                CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1) != CustomLineTypes.MANDV);
+        switchReplaceButton.setEnabled(applicationModel.getCustomFromLineType() != CustomLineTypes.ANY &&
+                applicationModel.getCustomFromLineType() != CustomLineTypes.MANDV);
 
         undoRedo.addUndoActionListener(e -> mainCreasePatternWorker.undo());
         undoRedo.addRedoActionListener(e -> mainCreasePatternWorker.redo());
@@ -352,8 +352,8 @@ public class LeftPanel {
             applicationModel.setCustomFromLineType(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1));
 
             // Disable switchReplaceButton if "Any" or "M & V" is active
-            switchReplaceButton.setEnabled(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1) != CustomLineTypes.ANY &&
-                    CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1) != CustomLineTypes.MANDV);
+        switchReplaceButton.setEnabled(applicationModel.getCustomFromLineType() != CustomLineTypes.ANY &&
+                applicationModel.getCustomFromLineType() != CustomLineTypes.MANDV);
         });
         fromLineDropBox.addPopupMenuListener(new PopupMenuAdapter() {
             @Override
@@ -372,23 +372,6 @@ public class LeftPanel {
             @Override
             public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
                 replace_lineButton.doClick();
-            }
-        });
-        switchReplaceButton.addActionListener(e -> {
-            CustomLineTypes tempFrom = applicationModel.getCustomFromLineType();
-            CustomLineTypes tempTo = applicationModel.getCustomToLineType();
-
-            // Set from line type
-            fromLineDropBox.setSelectedIndex(tempTo.getNumber() + 1);
-            applicationModel.setCustomFromLineType(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1));
-
-            // Set to line type
-            if (tempFrom == CustomLineTypes.EGDE) {
-                toLineDropBox.setSelectedIndex(tempFrom.getNumber());
-                applicationModel.setCustomToLineType(CustomLineTypes.from(toLineDropBox.getSelectedIndex()));
-            } else {
-                toLineDropBox.setSelectedIndex(tempFrom.getNumber() - 1);
-                applicationModel.setCustomToLineType(CustomLineTypes.from(toLineDropBox.getSelectedIndex() + 1));
             }
         });
         selectPersistentCheckBox.addActionListener(e -> applicationModel.setSelectPersistent(selectPersistentCheckBox.isSelected()));

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
@@ -170,6 +170,7 @@ public class LeftPanel {
     private JComboBox<String> toLineDropBox;
     private JLabel replaceLabel;
     private JScrollPane scrollPane1;
+    private JButton switchReplaceButton;
 
     private HashMap<MouseMode, JButton> selectionTransformationToolLookup;
 
@@ -255,6 +256,7 @@ public class LeftPanel {
         buttonService.registerButton(del_l_typeButton, "del_l_typeAction");
         buttonService.registerButton(trimBranchesButton, "trimBranchesAction");
         buttonService.registerButton(replace_lineButton, "replace_lineAction");
+        buttonService.registerButton(switchReplaceButton, "switchReplaceAction");
         buttonService.registerButton(zen_yama_tani_henkanButton, "zen_yama_tani_henkanAction");
         buttonService.registerButton(senbun_henkan2Button, "senbun_henkan2Action");
         buttonService.registerButton(senbun_henkanButton, "senbun_henkanAction");
@@ -314,6 +316,9 @@ public class LeftPanel {
         buttonService.setIcon(replaceLabel, "labelReplace");
 
 
+        switchReplaceButton.setEnabled(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1) != CustomLineTypes.ANY &&
+                CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1) != CustomLineTypes.MANDV);
+
         undoRedo.addUndoActionListener(e -> mainCreasePatternWorker.undo());
         undoRedo.addRedoActionListener(e -> mainCreasePatternWorker.redo());
 //        drawCreaseFreeButton.setAction(drawCreaseFreeAction);
@@ -332,12 +337,8 @@ public class LeftPanel {
                 getData(applicationModel);
             }
         });
-        senbun_b_nyuryokuButton.addActionListener(e -> {
-            getData(applicationModel);
-        });
-        delTypeDropBox.addActionListener(e -> {
-            applicationModel.setDelLineType(CustomLineTypes.from(delTypeDropBox.getSelectedIndex() - 1));
-        });
+        senbun_b_nyuryokuButton.addActionListener(e -> getData(applicationModel));
+        delTypeDropBox.addActionListener(e -> applicationModel.setDelLineType(CustomLineTypes.from(delTypeDropBox.getSelectedIndex() - 1)));
         delTypeDropBox.addPopupMenuListener(new PopupMenuAdapter() {
             @Override
             public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
@@ -346,6 +347,9 @@ public class LeftPanel {
         });
         fromLineDropBox.addActionListener(e -> {
             applicationModel.setCustomFromLineType(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1));
+
+            switchReplaceButton.setEnabled(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1) != CustomLineTypes.ANY &&
+                    CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1) != CustomLineTypes.MANDV);
         });
         fromLineDropBox.addPopupMenuListener(new PopupMenuAdapter() {
             @Override
@@ -364,6 +368,21 @@ public class LeftPanel {
             @Override
             public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
                 replace_lineButton.doClick();
+            }
+        });
+        switchReplaceButton.addActionListener(e -> {
+            CustomLineTypes tempFrom = applicationModel.getCustomFromLineType();
+            CustomLineTypes tempTo = applicationModel.getCustomToLineType();
+
+            fromLineDropBox.setSelectedIndex(tempTo.getNumber() + 1);
+            applicationModel.setCustomFromLineType(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1));
+
+            if (tempFrom == CustomLineTypes.EGDE) {
+                toLineDropBox.setSelectedIndex(tempFrom.getNumber());
+                applicationModel.setCustomToLineType(CustomLineTypes.from(toLineDropBox.getSelectedIndex()));
+            } else {
+                toLineDropBox.setSelectedIndex(tempFrom.getNumber() - 1);
+                applicationModel.setCustomToLineType(CustomLineTypes.from(toLineDropBox.getSelectedIndex() + 1));
             }
         });
         selectPersistentCheckBox.addActionListener(e -> applicationModel.setSelectPersistent(selectPersistentCheckBox.isSelected()));
@@ -729,7 +748,7 @@ public class LeftPanel {
         senbun_henkanButton.setIcon(new ImageIcon(getClass().getResource("/ppp/senbun_henkan.png")));
         panel7.add(senbun_henkanButton, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         final JPanel panel8 = new JPanel();
-        panel8.setLayout(new GridLayoutManager(1, 4, new Insets(0, 0, 0, 0), 1, 1));
+        panel8.setLayout(new GridLayoutManager(1, 5, new Insets(0, 0, 0, 0), 1, 1));
         panel1.add(panel8, new GridConstraints(10, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         replace_lineButton = new JButton();
         replace_lineButton.setText("Button");
@@ -755,6 +774,9 @@ public class LeftPanel {
         defaultComboBoxModel3.addElement("A");
         toLineDropBox.setModel(defaultComboBoxModel3);
         panel8.add(toLineDropBox, new GridConstraints(0, 3, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        switchReplaceButton = new JButton();
+        switchReplaceButton.setText("⇆");
+        panel8.add(switchReplaceButton, new GridConstraints(0, 4, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         in_L_col_changeButton = new JButton();
         in_L_col_changeButton.setActionCommand("in_L_col_changeAction");
         in_L_col_changeButton.setIcon(new ImageIcon(getClass().getResource("/ppp/in_L_col_change.png")));

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
@@ -315,7 +315,7 @@ public class LeftPanel {
         buttonService.setIcon(gridYSqrtLabel, "labelSqrt");
         buttonService.setIcon(replaceLabel, "labelReplace");
 
-
+        // Disable switchReplaceButton if "Any" or "M & V" is active
         switchReplaceButton.setEnabled(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1) != CustomLineTypes.ANY &&
                 CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1) != CustomLineTypes.MANDV);
 
@@ -348,6 +348,7 @@ public class LeftPanel {
         fromLineDropBox.addActionListener(e -> {
             applicationModel.setCustomFromLineType(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1));
 
+            // Disable switchReplaceButton if "Any" or "M & V" is active
             switchReplaceButton.setEnabled(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1) != CustomLineTypes.ANY &&
                     CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1) != CustomLineTypes.MANDV);
         });
@@ -374,9 +375,11 @@ public class LeftPanel {
             CustomLineTypes tempFrom = applicationModel.getCustomFromLineType();
             CustomLineTypes tempTo = applicationModel.getCustomToLineType();
 
+            // Set from line type
             fromLineDropBox.setSelectedIndex(tempTo.getNumber() + 1);
             applicationModel.setCustomFromLineType(CustomLineTypes.from(fromLineDropBox.getSelectedIndex() - 1));
 
+            // Set to line type
             if (tempFrom == CustomLineTypes.EGDE) {
                 toLineDropBox.setSelectedIndex(tempFrom.getNumber());
                 applicationModel.setCustomToLineType(CustomLineTypes.from(toLineDropBox.getSelectedIndex()));

--- a/oriedita/src/main/java/oriedita/editor/App.java
+++ b/oriedita/src/main/java/oriedita/editor/App.java
@@ -491,12 +491,6 @@ public class App {
             mainCreasePatternWorker.del_selected_senbun();
             mainCreasePatternWorker.record();
         }));
-        actionService.registerAction(new LambdaAction(ActionType.switchReplaceAction, () -> {
-            CustomLineTypes temp = applicationModel.getCustomFromLineType();
-
-            applicationModel.setCustomFromLineType(applicationModel.getCustomToLineType());
-            applicationModel.setCustomToLineType(temp);
-        }));
 
         // - line edit actions
         actionService.registerAction(new LambdaAction(ActionType.v_del_allAction, mainCreasePatternWorker::v_del_all));
@@ -535,6 +529,12 @@ public class App {
             mainCreasePatternWorker.organizeCircles();
             mainCreasePatternWorker.record();
             mainCreasePatternWorker.unselect_all(false);
+        }));
+        actionService.registerAction(new LambdaAction(ActionType.switchReplaceAction, () -> {
+            CustomLineTypes temp = applicationModel.getCustomFromLineType();
+
+            applicationModel.setCustomFromLineType(applicationModel.getCustomToLineType());
+            applicationModel.setCustomToLineType(temp);
         }));
 
         // - grid actions

--- a/oriedita/src/main/java/oriedita/editor/App.java
+++ b/oriedita/src/main/java/oriedita/editor/App.java
@@ -37,6 +37,7 @@ import oriedita.editor.swing.AppMenuBar;
 import oriedita.editor.swing.Editor;
 import oriedita.editor.swing.dialog.HelpDialog;
 import oriedita.editor.tools.ResourceUtil;
+import origami.crease_pattern.CustomLineTypes;
 import origami.crease_pattern.OritaCalc;
 import origami.crease_pattern.element.LineColor;
 import origami.folding.FoldedFigure;
@@ -489,6 +490,12 @@ public class App {
         actionService.registerAction(new LambdaAction(ActionType.deleteSelectedLineSegmentAction, () -> {
             mainCreasePatternWorker.del_selected_senbun();
             mainCreasePatternWorker.record();
+        }));
+        actionService.registerAction(new LambdaAction(ActionType.switchReplaceAction, () -> {
+            CustomLineTypes temp = applicationModel.getCustomFromLineType();
+
+            applicationModel.setCustomFromLineType(applicationModel.getCustomToLineType());
+            applicationModel.setCustomToLineType(temp);
         }));
 
         // - line edit actions

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceTypeSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerReplaceTypeSelect.java
@@ -42,14 +42,14 @@ public class MouseHandlerReplaceTypeSelect extends BaseMouseHandlerBoxSelect {
                 switch (from){
                     case ANY:
                         d.getFoldLineSet().deleteLine(s);
-                        s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                        s.setColor(LineColor.fromNumber(to.getNumberForLineColor()));
                         d.addLineSegment(s);
                         d.record();
                         break;
                     case EGDE:
                         if (s.getColor() == LineColor.BLACK_0) {
                             d.getFoldLineSet().deleteLine(s);
-                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            s.setColor(LineColor.fromNumber(to.getNumberForLineColor()));
                             d.addLineSegment(s);
                             d.record();
                         }
@@ -57,7 +57,7 @@ public class MouseHandlerReplaceTypeSelect extends BaseMouseHandlerBoxSelect {
                     case MANDV:
                         if (s.getColor() == LineColor.RED_1 || s.getColor() == LineColor.BLUE_2) {
                             d.getFoldLineSet().deleteLine(s);
-                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            s.setColor(LineColor.fromNumber(to.getNumberForLineColor()));
                             d.addLineSegment(s);
                             d.record();
                         }
@@ -67,7 +67,7 @@ public class MouseHandlerReplaceTypeSelect extends BaseMouseHandlerBoxSelect {
                     case AUX:
                         if (s.getColor() == LineColor.fromNumber(from.getNumber() - 1)) {
                             d.getFoldLineSet().deleteLine(s);
-                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            s.setColor(LineColor.fromNumber(to.getNumberForLineColor()));
                             d.addLineSegment(s);
                             d.record();
                         }

--- a/oriedita/src/main/resources/help.properties
+++ b/oriedita/src/main/resources/help.properties
@@ -123,6 +123,8 @@ selectAnd3ClickAction=<html>\
   etc.)
 replace_lineAction=<html>\
   Replace a line type with a different type.
+switchReplaceAction=<html>\
+  Swap the line types to replace (Can't be applied when "Any" or "M & V" is selected).
 ckbox_add_frame_to_front=<html>\
   Display progress of calculation for<br>\
   folding estimation.

--- a/oriedita/src/main/resources/hotkey.properties
+++ b/oriedita/src/main/resources/hotkey.properties
@@ -39,6 +39,7 @@ edgeLineSegmentDeleteAction=
 auxLiveLineSegmentDeleteAction=
 trimBranchesAction=
 replace_lineAction=
+switchReplaceAction=
 toMountainAction=
 toValleyAction=
 toEdgeAction=

--- a/oriedita/src/main/resources/icons.properties
+++ b/oriedita/src/main/resources/icons.properties
@@ -39,6 +39,7 @@ edgeLineSegmentDeleteAction=\uE014
 auxLiveLineSegmentDeleteAction=\uE015
 del_l_typeAction=\uE013
 replace_lineAction=\uE017
+switchReplaceAction=
 trimBranchesAction=\uE016
 toMountainAction=\uE017
 toValleyAction=\uE018

--- a/oriedita/src/main/resources/name.properties
+++ b/oriedita/src/main/resources/name.properties
@@ -175,6 +175,7 @@ del_lAction=Delete lines included in a line
 del_l_XAction=Delete lines intersecting a line
 selectAnd3ClickAction=
 replace_lineAction=Replace line type with another line type
+switchReplaceAction=Swap line types to replace
 axiom5Action=Axiom 5
 axiom7Action=Axiom 7
 # Grid configure

--- a/oriedita/src/main/resources/tooltip.properties
+++ b/oriedita/src/main/resources/tooltip.properties
@@ -172,6 +172,7 @@ del_lAction=
 del_l_XAction=
 selectAnd3ClickAction=
 replace_lineAction=
+switchReplaceAction=
 del_l_typeAction=
 axiom5Action=
 axiom7Action=

--- a/origami/src/main/java/origami/crease_pattern/CustomLineTypes.java
+++ b/origami/src/main/java/origami/crease_pattern/CustomLineTypes.java
@@ -17,7 +17,7 @@ public enum CustomLineTypes {
         return customType;
     }
 
-    public int getReplaceToTypeNumber(){
+    public int getNumberForLineColor(){
         if(this == CustomLineTypes.ANY){
             return EGDE.customType;
         }

--- a/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -88,10 +88,10 @@ public class FoldLineSet {
         divideLineSegmentWithNewLines(total_old - 1, total_old);
     }
 
-    public void replaceAux(CustomLineTypes from, CustomLineTypes to, List<LineSegment> reserveAux) {
+    public void replaceAux(CustomLineTypes to, List<LineSegment> reserveAux) {
         for (LineSegment s : reserveAux) {
             LineSegment auxChange = s.clone();
-            auxChange.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+            auxChange.setColor(LineColor.fromNumber(to.getNumberForLineColor()));
             deleteLine(s);
             addLineSegmentForReplace(auxChange);
         }
@@ -459,32 +459,32 @@ public class FoldLineSet {
             LineSegment s = lineSegments.get(i);
             LineSegment temp = s.clone();
 
-            if(b.totu_boundary_inside(s) && (from.getNumber() != to.getReplaceToTypeNumber())){
+            if(b.totu_boundary_inside(s) && (from.getNumber() != to.getNumber())){
                 switch (from){
                     case ANY:
                         if(s.getColor() == LineColor.CYAN_3) {
                             reserveAux.add(s);
                         } else {
-                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            s.setColor(LineColor.fromNumber(to.getNumberForLineColor()));
                         }
                         i_r = true;
                         break;
                     case EGDE:
                         if (s.getColor() == LineColor.BLACK_0) {
-                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            s.setColor(LineColor.fromNumber(to.getNumberForLineColor()));
                             i_r = true;
                         }
                         break;
                     case MANDV:
                         if (s.getColor() == LineColor.RED_1 || s.getColor() == LineColor.BLUE_2) {
-                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            s.setColor(LineColor.fromNumber(to.getNumberForLineColor()));
                             i_r = true;
                         }
                         break;
                     case MOUNTAIN:
                     case VALLEY:
                         if (s.getColor() == LineColor.fromNumber(from.getNumber() - 1)) {
-                            s.setColor(LineColor.fromNumber(to.getReplaceToTypeNumber()));
+                            s.setColor(LineColor.fromNumber(to.getNumberForLineColor()));
                             i_r = true;
                         }
                         break;
@@ -508,7 +508,7 @@ public class FoldLineSet {
                 }
             }
         }
-        replaceAux(from, to, reserveAux);
+        replaceAux(to, reserveAux);
         return i_r;
     }
 


### PR DESCRIPTION
- Fixes the condition being written incorrectly which causes some replaces to not be possible (V -> A, MV -> M, and M -> V). Additionally I changed the name of the concerned method to `getNumberForLineColor()` to clarify that the method is only for LineColor conversion if one were to try converting value from `toLineDropBox`  ~~which come to think about it it's very bloated and inefficient lmao~~.
- Added ability to swap the two replace line types (for example M -> V to V -> M)

https://github.com/oriedita/oriedita/assets/94136126/d6e08675-90e7-4370-84d7-bcdaae8d4965

