### PR TITLE
Responsive auto-expand indicator / axiom 5 fix / 2-line symmetryDraw

### DIFF
--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerAxiom5.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerAxiom5.java
@@ -53,7 +53,7 @@ public class MouseHandlerAxiom5 extends BaseMouseHandlerInputRestricted{
         // 3. pivot point
         if(d.getLineStep().size() == 2){
             Point closestPoint = d.getClosestPoint(p);
-            if (p.distance(closestPoint) < d.getSelectionDistance()) {
+            if (p.distance(closestPoint) < d.getSelectionDistance() && OritaCalc.determineLineSegmentDistance(closestPoint, d.getLineStep().get(0)) > Epsilon.UNKNOWN_1EN7) {
                 d.lineStepAdd(new LineSegment(closestPoint, closestPoint, d.getLineColor()));
                 return;
             }

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerAxiom5.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerAxiom5.java
@@ -2,7 +2,6 @@ package oriedita.editor.handler;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.tinylog.Logger;
 import oriedita.editor.canvas.MouseMode;
 import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
@@ -194,14 +193,12 @@ public class MouseHandlerAxiom5 extends BaseMouseHandlerInputRestricted{
             // pivot within span
             if(OritaCalc.distance(pivot, targetSegment.getA()) < Epsilon.UNKNOWN_1EN7){
                 //pivot within span touching A
-                Logger.info("pivot touching A");
                 l1.set(new LineSegment(pivot, OritaCalc.point_rotate(pivot, targetSegment.getB(), 180)));
                 l2.set(new LineSegment(pivot, targetSegment.getB()));
                 return;
             }
             if(OritaCalc.distance(pivot, targetSegment.getB()) < Epsilon.UNKNOWN_1EN7){
                 //pivot within span touching B
-                Logger.info("pivot touching B");
                 l1.set(new LineSegment(pivot, targetSegment.getA()));
                 l2.set(new LineSegment(pivot, OritaCalc.point_rotate(pivot, targetSegment.getA(), 180)));
                 return;

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerAxiom7.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerAxiom7.java
@@ -127,8 +127,8 @@ public class MouseHandlerAxiom7 extends BaseMouseHandlerInputRestricted{
 
         Point mid = OritaCalc.midPoint(target.getA(), OritaCalc.findIntersection(extendLine, targetSegment));
 
-        LineSegment s1 = OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), new LineSegment(mid, OritaCalc.findProjection(OritaCalc.moveParallel(extendLine, 25), mid), LineColor.PURPLE_8));
-        LineSegment s2 = OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), new LineSegment(mid, OritaCalc.findProjection(OritaCalc.moveParallel(extendLine, -25), mid), LineColor.PURPLE_8));
+        LineSegment s1 = OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), new LineSegment(mid, OritaCalc.findProjection(OritaCalc.moveParallel(extendLine, 1), mid), LineColor.PURPLE_8));
+        LineSegment s2 = OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), new LineSegment(mid, OritaCalc.findProjection(OritaCalc.moveParallel(extendLine, -1), mid), LineColor.PURPLE_8));
 
         d.lineStepAdd(s1);
         d.lineStepAdd(s2);

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerAxiom7.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerAxiom7.java
@@ -66,9 +66,21 @@ public class MouseHandlerAxiom7 extends BaseMouseHandlerInputRestricted{
         }
 
         // index 3 and 4 are the purple indicators
-        // 4. destination line (case 2)
+        // 4. indicators (case 1) & destination line (case 2)
         // Don't accept segment that is parallel to the purple indicators
         if(d.getLineStep().size() == 5){
+            if (OritaCalc.determineLineSegmentDistance(p, d.getLineStep().get(3)) < d.getSelectionDistance() ||
+                    OritaCalc.determineLineSegmentDistance(p, d.getLineStep().get(4)) < d.getSelectionDistance()) {
+                LineSegment s = d.get_moyori_step_lineSegment(p, 4, 5);
+                s.set(s.getB(), s.getA(), d.getLineColor());
+                s.set(OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), s));
+
+                d.addLineSegment(s);
+                d.record();
+                d.getLineStep().clear();
+                return;
+            }
+
             LineSegment closestLineSegment = new LineSegment();
             closestLineSegment.set(d.getClosestLineSegment(p));
 
@@ -93,21 +105,6 @@ public class MouseHandlerAxiom7 extends BaseMouseHandlerInputRestricted{
         // First 3 are clicked
         if(d.getLineStep().size() == 3){
             midPoint = drawAxiom7FoldIndicators(d.getLineStep().get(0), d.getLineStep().get(1), d.getLineStep().get(2));
-        }
-
-        // Case 1: Click on the purple indicators auto expand the purple indicators to the nearest lines
-        // (Kinda works)
-        if(d.getLineStep().size() == 5 && d.getClosestPoint(p).distance(p) > d.getSelectionDistance()){
-            if (OritaCalc.determineLineSegmentDistance(p, d.getLineStep().get(3)) < d.getSelectionDistance() ||
-                    OritaCalc.determineLineSegmentDistance(p, d.getLineStep().get(4)) < d.getSelectionDistance()) {
-                LineSegment s = d.get_moyori_step_lineSegment(p, 4, 5);
-                s.set(s.getB(), s.getA(), d.getLineColor());
-                s.set(OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), s));
-
-                d.addLineSegment(s);
-                d.record();
-                d.getLineStep().clear();
-            }
         }
 
         // Case 2: Click on destination line to extend result line from midpoint

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerPerpendicularDraw.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerPerpendicularDraw.java
@@ -52,7 +52,7 @@ public class MouseHandlerPerpendicularDraw extends BaseMouseHandlerInputRestrict
             d.lineStepAdd(closestLineSegment);
 
             //Step 3 (situational if clicked base line): Show purple candidate line if the selected line goes through the selected point
-            if (OritaCalc.determineLineSegmentDistance(d.getLineStep().get(0).getA(), d.getLineStep().get(1)) < Epsilon.UNKNOWN_1EN4) {
+            if (OritaCalc.isPointWithinLineSpan(d.getLineStep().get(0).getA(), d.getLineStep().get(1))) {
                 d.lineStepAdd(OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), new LineSegment(d.getLineStep().get(0).getA(), OritaCalc.findProjection(OritaCalc.moveParallel(d.getLineStep().get(1), 1.0), d.getLineStep().get(0).getA()), LineColor.PURPLE_8)));
                 d.lineStepAdd(OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), new LineSegment(d.getLineStep().get(0).getA(), OritaCalc.findProjection(OritaCalc.moveParallel(d.getLineStep().get(1), -1.0), d.getLineStep().get(0).getA()), LineColor.PURPLE_8)));
             }

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerPerpendicularDraw.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerPerpendicularDraw.java
@@ -89,9 +89,6 @@ public class MouseHandlerPerpendicularDraw extends BaseMouseHandlerInputRestrict
 
     //マウス操作(ボタンを離したとき)を行う関数
     public void mouseReleased(Point p0) {
-        Point p = new Point();
-        p.set(d.getCamera().TV2object(p0));
-
         if (d.getLineStep().size() == 2) {
             //直線t上の点pの影の位置（点pと最も近い直線t上の位置）を求める。public Ten oc.kage_motome(Tyokusen t,Ten p){
             LineSegment add_sen = new LineSegment(d.getLineStep().get(0).getA(), OritaCalc.findProjection(OritaCalc.lineSegmentToStraightLine(d.getLineStep().get(1)), d.getLineStep().get(0).getA()), d.getLineColor());
@@ -105,7 +102,6 @@ public class MouseHandlerPerpendicularDraw extends BaseMouseHandlerInputRestrict
         }
 
         if (d.getLineStep().size() == 5) {
-
             LineSegment point = d.getLineStep().get(0); //Point
             LineSegment perpendicular = d.getLineStep().get(2); //One of the two purple indicators
             LineSegment destinationLine = d.getLineStep().get(4); //Third line

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerSquareBisector.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerSquareBisector.java
@@ -56,6 +56,19 @@ public class MouseHandlerSquareBisector extends BaseMouseHandlerInputRestricted 
                     d.lineStepAdd(line);
                     return;
                 }
+                if(d.getLineStep().size() == 4){
+                    if (OritaCalc.determineLineSegmentDistance(p, d.getLineStep().get(2)) < d.getSelectionDistance() ||
+                            OritaCalc.determineLineSegmentDistance(p, d.getLineStep().get(3)) < d.getSelectionDistance()) {
+                        LineSegment s = d.get_moyori_step_lineSegment(p, 3, 4);
+                        s.set(s.getB(), s.getA(), d.getLineColor());
+                        s.set(OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), s));
+
+                        d.addLineSegment(s);
+                        d.record();
+                        d.getLineStep().clear();
+                        return;
+                    }
+                }
             }
         }
         // Else if condition is for 3 points bisect
@@ -162,20 +175,6 @@ public class MouseHandlerSquareBisector extends BaseMouseHandlerInputRestricted 
             }
         }
 
-        // Step 2.a: Click on the purple indicators auto expand the bisector from the purple indicators to the nearest lines
-        // (Works but might come out a bit weirdly in some cases)
-        if(d.getLineStep().size() == 4 && d.getClosestPoint(p).distance(p) > d.getSelectionDistance()){
-            if (OritaCalc.determineLineSegmentDistance(p, d.getLineStep().get(2)) < d.getSelectionDistance() ||
-                    OritaCalc.determineLineSegmentDistance(p, d.getLineStep().get(3)) < d.getSelectionDistance()) {
-                LineSegment s = d.get_moyori_step_lineSegment(p, 3, 4);
-                s.set(s.getB(), s.getA(), d.getLineColor());
-                s.set(OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), s));
-
-                d.addLineSegment(s);
-                d.record();
-                d.getLineStep().clear();
-            }
-        }
         // Step 2.b: Get the 2 destination lines and form the actual bisector
         if (d.getLineStep().size() == 6) {
             // Find 2 intersection points

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerSquareBisector.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerSquareBisector.java
@@ -31,7 +31,7 @@ public class MouseHandlerSquareBisector extends BaseMouseHandlerInputRestricted 
         p.set(d.getCamera().TV2object(p0));
 
         // If condition is for 2 lines bisect
-        if ((d.getLineStep().isEmpty() || d.getLineStep().get(0).determineLength() > 0)) {
+        if (d.getLineStep().isEmpty() || d.getLineStep().get(0).determineLength() > 0) {
             // Click 2 lines to form bisect and then a destination line
             // Only in first line click, no point is allowed within the selection radius
             if (d.getLineStep().isEmpty() && d.getClosestPoint(p).distance(p) > d.getSelectionDistance()) {

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerSymmetricDraw.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerSymmetricDraw.java
@@ -5,6 +5,7 @@ import jakarta.inject.Inject;
 import oriedita.editor.canvas.MouseMode;
 import origami.Epsilon;
 import origami.crease_pattern.OritaCalc;
+import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 
@@ -18,10 +19,34 @@ public class MouseHandlerSymmetricDraw extends BaseMouseHandlerInputRestricted {
     //マウス操作(ボタンを押したとき)時の作業
     public void mousePressed(Point p0) {
         Point p = new Point();
+        LineSegment line = new LineSegment();
         p.set(d.getCamera().TV2object(p0));
-        Point closestPoint = d.getClosestPoint(p);
-        if (p.distance(closestPoint) < d.getSelectionDistance()) {
-            d.lineStepAdd(new LineSegment(closestPoint, closestPoint, d.getLineColor()));
+
+        if (d.getLineStep().isEmpty() || d.getLineStep().get(0).determineLength() > 0) {
+            if (d.getLineStep().isEmpty() && d.getClosestPoint(p).distance(p) > d.getSelectionDistance()) {
+                line.set(d.getClosestLineSegment(p));
+                if (OritaCalc.determineLineSegmentDistance(p, line) < d.getSelectionDistance()) {
+                    line.setColor(LineColor.GREEN_6);
+                    d.lineStepAdd(line);
+                }
+                return;
+            }
+            if(!d.getLineStep().isEmpty()){
+                line.set(d.getClosestLineSegment(p));
+                if (OritaCalc.determineLineSegmentDistance(p, line) < d.getSelectionDistance() && OritaCalc.isLineSegmentParallel(d.getLineStep().get(0), line) == OritaCalc.ParallelJudgement.NOT_PARALLEL) {
+                    line.setColor(LineColor.GREEN_6);
+                    d.lineStepAdd(line);
+                }
+                return;
+            }
+        }
+
+        if (d.getLineStep().isEmpty() || d.getLineStep().get(0).determineLength() <= 0.0) {
+            Point closestPoint = d.getClosestPoint(p);
+            if (p.distance(closestPoint) < d.getSelectionDistance()) {
+                d.lineStepAdd(new LineSegment(closestPoint, closestPoint, d.getLineColor()));
+            }
+
         }
     }
 
@@ -37,15 +62,28 @@ public class MouseHandlerSymmetricDraw extends BaseMouseHandlerInputRestricted {
 
     //マウス操作(ボタンを離したとき)を行う関数
     public void mouseReleased(Point p0) {
+        if(d.getLineStep().size() == 2 && d.getLineStep().get(0).determineLength() > 0){
+            Point cross = OritaCalc.findIntersection(d.getLineStep().get(0), d.getLineStep().get(1));
+            Point t_taisyou = OritaCalc.findLineSymmetryPoint(cross, d.getLineStep().get(1).determineFurthestEndpoint(cross), d.getLineStep().get(0).determineFurthestEndpoint(cross));
+            LineSegment add_sen = new LineSegment(cross, t_taisyou, d.getLineColor());
+            add_sen.set(d.extendToIntersectionPoint(add_sen));
+
+            if (Epsilon.high.gt0(add_sen.determineLength())) {
+                d.addLineSegment(add_sen);
+                d.record();
+            }
+            d.getLineStep().clear();
+        }
+
         if (d.getLineStep().size() == 3) {
             //２つの点t1,t2を通る直線に関して、点pの対照位置にある点を求める public Ten oc.sentaisyou_ten_motome(Ten t1,Ten t2,Ten p){
             Point t_taisyou = new Point();
             t_taisyou.set(OritaCalc.findLineSymmetryPoint(d.getLineStep().get(1).getA(), d.getLineStep().get(2).getA(), d.getLineStep().get(0).getA()));
 
             LineSegment add_sen = new LineSegment(d.getLineStep().get(1).getA(), t_taisyou);
-
             add_sen.set(d.extendToIntersectionPoint(add_sen));
             add_sen.setColor(d.getLineColor());
+
             if (Epsilon.high.gt0(add_sen.determineLength())) {
                 d.addLineSegment(add_sen);
                 d.record();

--- a/origami/src/main/java/origami/crease_pattern/element/LineSegment.java
+++ b/origami/src/main/java/origami/crease_pattern/element/LineSegment.java
@@ -45,6 +45,14 @@ public class LineSegment implements Serializable, Cloneable {
         selected = 0;
     }
 
+    public LineSegment(LineSegment s0, LineColor color){
+        a.set(s0.getA());
+        b.set(s0.getB());
+        active = ActiveState.INACTIVE_0;
+        this.color = color;
+        selected = 0;
+    }
+
     public LineSegment(double i1, double i2, double i3, double i4) {
         a.set(i1, i2);
         b.set(i3, i4);


### PR DESCRIPTION
- Add auto expand indicator for perpendicular tool
- Fix axiom 5's edge cases
- More responsive auto expand indicators (previously it was unclickable if near to a point/vertex, as well as being able to accidentally auto-expand immediately after selecting a line)