### PR TITLE
Isolate Ctrl InputMap usage for different tools + LeftPanel clean up

### DIFF
--- a/oriedita-data/src/main/java/oriedita/editor/databinding/CanvasModel.java
+++ b/oriedita-data/src/main/java/oriedita/editor/databinding/CanvasModel.java
@@ -138,6 +138,10 @@ public class CanvasModel implements Serializable {
         return toggleLineColor ? lineColor.changeMV() : lineColor;
     }
 
+    public LineColor calculateAuxColor(){
+        return toggleLineColor ? auxLiveLineColor.changeAuxColor() : auxLiveLineColor;
+    }
+
     public LineColor getLineColor() {
         return lineColor;
     }

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/LeftPanel.java
@@ -10,6 +10,7 @@ import org.tinylog.Logger;
 import oriedita.editor.Canvas;
 import oriedita.editor.Colors;
 import oriedita.editor.canvas.CreasePattern_Worker;
+import oriedita.editor.canvas.FoldLineAdditionalInputMode;
 import oriedita.editor.canvas.MouseMode;
 import oriedita.editor.databinding.ApplicationModel;
 import oriedita.editor.databinding.CanvasModel;
@@ -163,6 +164,7 @@ public class LeftPanel {
 
     private HashMap<MouseMode, JButton> selectionTransformationToolLookup;
     private boolean isReplaceHold;
+    private boolean isDelTypeHold;
 
     public double convertAngle(double angle) {
         if (angle >= 0) return angle % 180;
@@ -198,6 +200,7 @@ public class LeftPanel {
         this.selectionTransformationToolLookup.put(MouseMode.CREASE_COPY_4P_32, copy2p2pButton);
 
         isReplaceHold = false;
+        isDelTypeHold = false;
     }
 
     public void init() {
@@ -1052,7 +1055,6 @@ public class LeftPanel {
 
         if (e.getPropertyName() == null || e.getPropertyName().equals("mouseMode") || e.getPropertyName().equals("foldLineAdditionalInputMode")) {
             MouseMode m = data.getMouseMode();
-//            FoldLineAdditionalInputMode f = data.getFoldLineAdditionalInputMode();
 
             drawCreaseFreeButton.setSelected(m == MouseMode.DRAW_CREASE_FREE_1);
             senbun_henkanButton.setSelected(m == MouseMode.CHANGE_CREASE_TYPE_4);
@@ -1090,6 +1092,17 @@ public class LeftPanel {
             replace_lineButton.setSelected(m == MouseMode.REPLACE_LINE_TYPE_SELECT_72);
         }
 
+        Color gray = Colors.get(new Color(150, 150, 150));
+
+        colBlackButton.setBackground(gray);
+        colRedButton.setBackground(gray);
+        colBlueButton.setBackground(gray);
+        colCyanButton.setBackground(gray);
+        colBlackButton.setForeground(Colors.get(Color.black));
+        colRedButton.setForeground(Colors.get(Color.black));
+        colBlueButton.setForeground(Colors.get(Color.black));
+        colCyanButton.setForeground(Colors.get(Color.black));
+
         switch (canvasModel.getMouseMode()) {
             case REPLACE_LINE_TYPE_SELECT_72:
                 if (switchReplaceButton.isEnabled()) {
@@ -1103,8 +1116,22 @@ public class LeftPanel {
                     }
                 }
                 break;
+            case DELETE_LINE_TYPE_SELECT_73:
+                if ((canvasModel.getToggleLineColor() && !isDelTypeHold) || (!canvasModel.getToggleLineColor() && isDelTypeHold)) {
+                    if (applicationModel.getDelLineType() == CustomLineTypes.MOUNTAIN) {
+                        applicationModel.setDelLineType(CustomLineTypes.VALLEY);
+                        isDelTypeHold = !isDelTypeHold;
+                    } else if (applicationModel.getDelLineType() == CustomLineTypes.VALLEY) {
+                        applicationModel.setDelLineType(CustomLineTypes.MOUNTAIN);
+                        isDelTypeHold = !isDelTypeHold;
+                    }
+                }
+                break;
+            case AXIOM_5:
+            case AXIOM_7:
             case DRAW_CREASE_FREE_1:
             case LENGTHEN_CREASE_5:
+            case SQUARE_BISECTOR_7:
             case INWARD_8:
             case PERPENDICULAR_DRAW_9:
             case SYMMETRIC_DRAW_10:
@@ -1122,21 +1149,16 @@ public class LeftPanel {
             case CREASES_ALTERNATE_MV_36:
             case DRAW_CREASE_ANGLE_RESTRICTED_5_37:
             case VERTEX_MAKE_ANGULARLY_FLAT_FOLDABLE_38:
+            case FOLDABLE_LINE_INPUT_39:
             case PARALLEL_DRAW_40:
+            case CIRCLE_DRAW_TANGENT_LINE_45:
             case PARALLEL_DRAW_WIDTH_51:
             case CONTINUOUS_SYMMETRIC_DRAW_52:
             case VORONOI_CREATE_62:
             case FOLDABLE_LINE_DRAW_71:
-                Color gray = Colors.get(new Color(150, 150, 150));
-
-                colBlackButton.setBackground(gray);
-                colRedButton.setBackground(gray);
-                colBlueButton.setBackground(gray);
-                colCyanButton.setBackground(gray);
-                colBlackButton.setForeground(Colors.get(Color.black));
-                colRedButton.setForeground(Colors.get(Color.black));
-                colBlueButton.setForeground(Colors.get(Color.black));
-                colCyanButton.setForeground(Colors.get(Color.black));
+                if (canvasModel.getMouseMode() == MouseMode.DRAW_CREASE_FREE_1 && data.getFoldLineAdditionalInputMode() == FoldLineAdditionalInputMode.AUX_LINE_1) {
+                    break;
+                }
 
                 switch (data.calculateLineColor()) {
                     case BLACK_0:

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/RightPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/RightPanel.java
@@ -133,7 +133,7 @@ public class RightPanel {
         applicationModel.addPropertyChangeListener(e -> setData(applicationModel));
         angleSystemModel.addPropertyChangeListener(e -> setData(angleSystemModel));
         measuresModel.addPropertyChangeListener(e -> setData(measuresModel));
-        canvasModel.addPropertyChangeListener(e -> setData(e, canvasModel, applicationModel));
+        canvasModel.addPropertyChangeListener(e -> setData(e, canvasModel));
 
         auxHistoryState.addPropertyChangeListener(e -> setData(auxHistoryState));
 
@@ -656,7 +656,7 @@ public class RightPanel {
         }
     }
 
-    public void setData(PropertyChangeEvent e, CanvasModel data, ApplicationModel applicationModel) {
+    public void setData(PropertyChangeEvent e, CanvasModel data) {
         if (openFrame != null) openFrame.setData(e, data);
 
         if (e.getPropertyName() == null || e.getPropertyName().equals("mouseMode") || e.getPropertyName().equals("foldLineAdditionalInputMode")) {
@@ -688,16 +688,18 @@ public class RightPanel {
             angleRestrictedButton.setSelected(m == MouseMode.DRAW_CREASE_ANGLE_RESTRICTED_5_37);
         }
 
-        switch (data.getAuxLiveLineColor()) {
-            case ORANGE_4:
-                colOrangeButton.setBackground(Color.ORANGE);
-                colYellowButton.setBackground(new Color(150, 150, 150));
-                break;
-            case YELLOW_7:
-                colYellowButton.setBackground(Color.YELLOW);
-                colOrangeButton.setBackground(new Color(150, 150, 150));
-            default:
-                break;
+        if (data.getMouseMode() == MouseMode.DRAW_CREASE_FREE_1 && data.getFoldLineAdditionalInputMode() == FoldLineAdditionalInputMode.AUX_LINE_1) {
+            switch (data.calculateAuxColor()) {
+                case ORANGE_4:
+                    colOrangeButton.setBackground(Color.ORANGE);
+                    colYellowButton.setBackground(new Color(150, 150, 150));
+                    break;
+                case YELLOW_7:
+                    colYellowButton.setBackground(Color.YELLOW);
+                    colOrangeButton.setBackground(new Color(150, 150, 150));
+                default:
+                    break;
+            }
         }
     }
 

--- a/oriedita/src/main/java/oriedita/editor/App.java
+++ b/oriedita/src/main/java/oriedita/editor/App.java
@@ -630,7 +630,7 @@ public class App {
         actionService.registerAction(new LambdaAction(ActionType.h_undoAction, mainCreasePatternWorker::auxUndo));
         actionService.registerAction(new LambdaAction(ActionType.h_redoAction, mainCreasePatternWorker::auxRedo));
         actionService.registerAction(actionFactory.setMouseModeLineTypeDeleteAction(ActionType.h_senbun_nyuryokuAction, MouseMode.DRAW_CREASE_FREE_1, FoldLineAdditionalInputMode.AUX_LINE_1));
-        actionService.registerAction(actionFactory.setMouseModeLineTypeDeleteAction(ActionType.h_senbun_nyuryokuAction, MouseMode.LINE_SEGMENT_DELETE_3, FoldLineAdditionalInputMode.AUX_LINE_1));
+        actionService.registerAction(actionFactory.setMouseModeLineTypeDeleteAction(ActionType.h_senbun_sakujyoButton, MouseMode.LINE_SEGMENT_DELETE_3, FoldLineAdditionalInputMode.AUX_LINE_1));
 
         // |---------------------------------------------------------------------------|
         // --- Bottom Panel ---

--- a/oriedita/src/main/java/oriedita/editor/canvas/impl/CreasePattern_Worker_Impl.java
+++ b/oriedita/src/main/java/oriedita/editor/canvas/impl/CreasePattern_Worker_Impl.java
@@ -1068,7 +1068,7 @@ public class CreasePattern_Worker_Impl implements CreasePattern_Worker {
     @Override
     public void setData(CanvasModel data) {
         setColor(data.calculateLineColor());
-        setAuxLineColor(data.getAuxLiveLineColor());
+        setAuxLineColor(data.calculateAuxColor());
         setFoldLineAdditional(data.getFoldLineAdditionalInputMode());
         i_select_mode = data.getSelectionOperationMode();
     }

--- a/origami/src/main/java/origami/crease_pattern/element/LineColor.java
+++ b/origami/src/main/java/origami/crease_pattern/element/LineColor.java
@@ -54,6 +54,13 @@ public enum LineColor {
         return this;
     }
 
+    public LineColor changeAuxColor() {
+        if (this == ORANGE_4) return YELLOW_7;
+        if (this == YELLOW_7) return ORANGE_4;
+
+        return this;
+    }
+
     public int getNumber() {
         return this.type;
     }


### PR DESCRIPTION
Ctrl was used to hold-toggle swap MV for quicker drawing, but it was global and any tool that uses some kind of Ctrl+[key] key bind will trigger it. The PR's main purpose is to change that, namely setting the Ctrl usage to function differently depending on the tool being used. In this PR, Ctrl is made to swap MV for most of the drawing tools and some others, and swap replace line types for the replace line tool). Also did a few clean ups inside the LeftPanel.