### PR TITLE
Point to Circle tangent

### DIFF
--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCircleDrawTangentLine.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCircleDrawTangentLine.java
@@ -54,10 +54,6 @@ public class MouseHandlerCircleDrawTangentLine extends BaseMouseHandler {
                    d.getLineStep().clear();
                    d.getCircleStep().clear();
                    return;
-               } else if (Math.abs(closest_circumference.getR() - OritaCalc.distance(closest_circumference.determineCenter(), d.getLineStep().get(0).getA())) < Epsilon.UNKNOWN_1EN7) {
-                   d.getLineStep().clear();
-                   d.getCircleStep().clear();
-                   return;
                }
             }
 
@@ -213,6 +209,12 @@ public class MouseHandlerCircleDrawTangentLine extends BaseMouseHandler {
 
         //point-circle tangent
         if(d.getCircleStep().size() == 1 && d.getLineStep().size() == 1){
+            if(Math.abs(closest_circumference.getR() - OritaCalc.distance(closest_circumference.determineCenter(), d.getLineStep().get(0).getA())) < Epsilon.UNKNOWN_1EN7){
+                LineSegment projectionLine = new LineSegment(closest_circumference.determineCenter(), d.getLineStep().get(0).getA());
+                d.lineStepAdd(OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), new LineSegment(d.getLineStep().get(0).getA(), OritaCalc.findProjection(OritaCalc.moveParallel(projectionLine, 1), d.getLineStep().get(0).getA()), LineColor.PURPLE_8)));
+                d.lineStepAdd(OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), new LineSegment(d.getLineStep().get(0).getA(), OritaCalc.findProjection(OritaCalc.moveParallel(projectionLine, -1), d.getLineStep().get(0).getA()), LineColor.PURPLE_8)));
+                return;
+            }
             LineSegment diameter = new LineSegment(d.getLineStep().get(0).getA(), d.getCircleStep().get(0).determineCenter());
             Circle constructCir = new Circle(diameter, LineColor.GREEN_6);
             LineSegment connectSegment = OritaCalc.circle_to_circle_no_intersection_wo_musubu_lineSegment(constructCir, d.getCircleStep().get(0));

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCircleDrawTangentLine.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCircleDrawTangentLine.java
@@ -92,124 +92,122 @@ public class MouseHandlerCircleDrawTangentLine extends BaseMouseHandler {
     //マウス操作(ボタンを離したとき)を行う関数
     public void mouseReleased(Point p0) {
         // 2-circle tangents
-        if(d.getCircleStep().size() == 2){
-            if (d.getLineStep().isEmpty()) {
-                Circle firstCircle = d.getCircleStep().get(0);
-                Circle secondCircle = d.getCircleStep().get(1);
+        if(d.getCircleStep().size() == 2 & d.getLineStep().isEmpty()){
+            Circle firstCircle = d.getCircleStep().get(0);
+            Circle secondCircle = d.getCircleStep().get(1);
 
-                Point c1 = new Point();
-                c1.set(firstCircle.determineCenter());
-                Point c2 = new Point();
-                c2.set(secondCircle.determineCenter());
+            Point c1 = new Point();
+            c1.set(firstCircle.determineCenter());
+            Point c2 = new Point();
+            c2.set(secondCircle.determineCenter());
 
-                double x1 = firstCircle.getX();
-                double y1 = firstCircle.getY();
-                double r1 = firstCircle.getR();
-                double x2 = secondCircle.getX();
-                double y2 = secondCircle.getY();
-                double r2 = secondCircle.getR();
-                //0,0,r,        xp,yp,R
-                double xp = x2 - x1;
-                double yp = y2 - y1;
+            double x1 = firstCircle.getX();
+            double y1 = firstCircle.getY();
+            double r1 = firstCircle.getR();
+            double x2 = secondCircle.getX();
+            double y2 = secondCircle.getY();
+            double r2 = secondCircle.getR();
+            //0,0,r,        xp,yp,R
+            double xp = x2 - x1;
+            double yp = y2 - y1;
 
-                if (c1.distance(c2) < Epsilon.UNKNOWN_1EN6) {
-                    d.getCircleStep().clear();
-                    return;
-                }//接線0本の場合
+            if (c1.distance(c2) < Epsilon.UNKNOWN_1EN6) {
+                d.getCircleStep().clear();
+                return;
+            }//接線0本の場合
 
-                if ((xp * xp + yp * yp) < (r1 - r2) * (r1 - r2)) {
-                    d.getCircleStep().clear();
-                    return;
-                }//接線0本の場合
+            if ((xp * xp + yp * yp) < (r1 - r2) * (r1 - r2)) {
+                d.getCircleStep().clear();
+                return;
+            }//接線0本の場合
 
-                if (Math.abs((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2)) < Epsilon.UNKNOWN_1EN7) {//外接線1本の場合
-                    Point kouten = new Point();
-                    kouten.set(OritaCalc.internalDivisionRatio(c1, c2, -r1, r2));
-                    StraightLine ty = new StraightLine(c1, kouten);
-                    ty.orthogonalize(kouten);
+            if (Math.abs((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2)) < Epsilon.UNKNOWN_1EN7) {//外接線1本の場合
+                Point kouten = new Point();
+                kouten.set(OritaCalc.internalDivisionRatio(c1, c2, -r1, r2));
+                StraightLine ty = new StraightLine(c1, kouten);
+                ty.orthogonalize(kouten);
 
-                    d.lineStepAdd(OritaCalc.circle_to_straightLine_no_intersect_wo_connect_LineSegment(new Circle(kouten, (r1 + r2) / 2.0, LineColor.BLACK_0), ty));
-                } else if (((r1 - r2) * (r1 - r2) < (xp * xp + yp * yp)) && ((xp * xp + yp * yp) < (r1 + r2) * (r1 + r2))) {//外接線2本の場合
-                    double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                    double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                    double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                    double yq2 = r1 * (yp * (r1 - r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                d.lineStepAdd(OritaCalc.circle_to_straightLine_no_intersect_wo_connect_LineSegment(new Circle(kouten, (r1 + r2) / 2.0, LineColor.BLACK_0), ty));
+            } else if (((r1 - r2) * (r1 - r2) < (xp * xp + yp * yp)) && ((xp * xp + yp * yp) < (r1 + r2) * (r1 + r2))) {//外接線2本の場合
+                double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                double yq2 = r1 * (yp * (r1 - r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
 
-                    double xr1 = xq1 + x1;
-                    double yr1 = yq1 + y1;
-                    double xr2 = xq2 + x1;
-                    double yr2 = yq2 + y1;
+                double xr1 = xq1 + x1;
+                double yr1 = yq1 + y1;
+                double xr2 = xq2 + x1;
+                double yr2 = yq2 + y1;
 
-                    StraightLine t1 = new StraightLine(x1, y1, xr1, yr1);
-                    t1.orthogonalize(new Point(xr1, yr1));
-                    StraightLine t2 = new StraightLine(x1, y1, xr2, yr2);
-                    t2.orthogonalize(new Point(xr2, yr2));
+                StraightLine t1 = new StraightLine(x1, y1, xr1, yr1);
+                t1.orthogonalize(new Point(xr1, yr1));
+                StraightLine t2 = new StraightLine(x1, y1, xr2, yr2);
+                t2.orthogonalize(new Point(xr2, yr2));
 
-                    d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
-                    d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
-                } else if (Math.abs((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2)) < Epsilon.UNKNOWN_1EN7) {//外接線2本と内接線1本の場合
-                    double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                    double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                    double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                    double yq2 = r1 * (yp * (r1 - r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
+                d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
+            } else if (Math.abs((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2)) < Epsilon.UNKNOWN_1EN7) {//外接線2本と内接線1本の場合
+                double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                double yq2 = r1 * (yp * (r1 - r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
 
-                    double xr1 = xq1 + x1;
-                    double yr1 = yq1 + y1;
-                    double xr2 = xq2 + x1;
-                    double yr2 = yq2 + y1;
+                double xr1 = xq1 + x1;
+                double yr1 = yq1 + y1;
+                double xr2 = xq2 + x1;
+                double yr2 = yq2 + y1;
 
-                    StraightLine t1 = new StraightLine(x1, y1, xr1, yr1);
-                    t1.orthogonalize(new Point(xr1, yr1));
-                    StraightLine t2 = new StraightLine(x1, y1, xr2, yr2);
-                    t2.orthogonalize(new Point(xr2, yr2));
+                StraightLine t1 = new StraightLine(x1, y1, xr1, yr1);
+                t1.orthogonalize(new Point(xr1, yr1));
+                StraightLine t2 = new StraightLine(x1, y1, xr2, yr2);
+                t2.orthogonalize(new Point(xr2, yr2));
 
-                    d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
-                    d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
+                d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
+                d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
 
-                    Point kouten = new Point();
-                    kouten.set(OritaCalc.internalDivisionRatio(c1, c2, r1, r2));
-                    StraightLine ty = new StraightLine(c1, kouten);
-                    ty.orthogonalize(kouten);
-                    LineSegment s = OritaCalc.circle_to_straightLine_no_intersect_wo_connect_LineSegment(new Circle(kouten, (r1 + r2) / 2.0, LineColor.BLACK_0), ty);
-                    s.setColor(LineColor.PURPLE_8);
-                    d.lineStepAdd(s);
-                } else if ((r1 + r2) * (r1 + r2) < (xp * xp + yp * yp)) {//外接線2本と内接線2本の場合
-                    //             ---------------------------------------------------------------
-                    //                                     -------------------------------------
-                    //                 -------               -------------   -------   -------       -------------
-                    double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                    double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                    double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                    double yq2 = r1 * (yp * (r1 - r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                    double xq3 = r1 * (xp * (r1 + r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
-                    double yq3 = r1 * (yp * (r1 + r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
-                    double xq4 = r1 * (xp * (r1 + r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
-                    double yq4 = r1 * (yp * (r1 + r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
+                Point kouten = new Point();
+                kouten.set(OritaCalc.internalDivisionRatio(c1, c2, r1, r2));
+                StraightLine ty = new StraightLine(c1, kouten);
+                ty.orthogonalize(kouten);
+                LineSegment s = OritaCalc.circle_to_straightLine_no_intersect_wo_connect_LineSegment(new Circle(kouten, (r1 + r2) / 2.0, LineColor.BLACK_0), ty);
+                s.setColor(LineColor.PURPLE_8);
+                d.lineStepAdd(s);
+            } else if ((r1 + r2) * (r1 + r2) < (xp * xp + yp * yp)) {//外接線2本と内接線2本の場合
+                //             ---------------------------------------------------------------
+                //                                     -------------------------------------
+                //                 -------               -------------   -------   -------       -------------
+                double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                double yq2 = r1 * (yp * (r1 - r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                double xq3 = r1 * (xp * (r1 + r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
+                double yq3 = r1 * (yp * (r1 + r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
+                double xq4 = r1 * (xp * (r1 + r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
+                double yq4 = r1 * (yp * (r1 + r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
 
 
-                    double xr1 = xq1 + x1;
-                    double yr1 = yq1 + y1;
-                    double xr2 = xq2 + x1;
-                    double yr2 = yq2 + y1;
-                    double xr3 = xq3 + x1;
-                    double yr3 = yq3 + y1;
-                    double xr4 = xq4 + x1;
-                    double yr4 = yq4 + y1;
+                double xr1 = xq1 + x1;
+                double yr1 = yq1 + y1;
+                double xr2 = xq2 + x1;
+                double yr2 = yq2 + y1;
+                double xr3 = xq3 + x1;
+                double yr3 = yq3 + y1;
+                double xr4 = xq4 + x1;
+                double yr4 = yq4 + y1;
 
-                    StraightLine t1 = new StraightLine(x1, y1, xr1, yr1);
-                    t1.orthogonalize(new Point(xr1, yr1));
-                    StraightLine t2 = new StraightLine(x1, y1, xr2, yr2);
-                    t2.orthogonalize(new Point(xr2, yr2));
-                    StraightLine t3 = new StraightLine(x1, y1, xr3, yr3);
-                    t3.orthogonalize(new Point(xr3, yr3));
-                    StraightLine t4 = new StraightLine(x1, y1, xr4, yr4);
-                    t4.orthogonalize(new Point(xr4, yr4));
+                StraightLine t1 = new StraightLine(x1, y1, xr1, yr1);
+                t1.orthogonalize(new Point(xr1, yr1));
+                StraightLine t2 = new StraightLine(x1, y1, xr2, yr2);
+                t2.orthogonalize(new Point(xr2, yr2));
+                StraightLine t3 = new StraightLine(x1, y1, xr3, yr3);
+                t3.orthogonalize(new Point(xr3, yr3));
+                StraightLine t4 = new StraightLine(x1, y1, xr4, yr4);
+                t4.orthogonalize(new Point(xr4, yr4));
 
-                    d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
-                    d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
-                    d.lineStepAdd(new LineSegment(new Point(xr3, yr3), OritaCalc.findProjection(t3, new Point(x2, y2)), LineColor.PURPLE_8));
-                    d.lineStepAdd(new LineSegment(new Point(xr4, yr4), OritaCalc.findProjection(t4, new Point(x2, y2)), LineColor.PURPLE_8));
-                }
+                d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
+                d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
+                d.lineStepAdd(new LineSegment(new Point(xr3, yr3), OritaCalc.findProjection(t3, new Point(x2, y2)), LineColor.PURPLE_8));
+                d.lineStepAdd(new LineSegment(new Point(xr4, yr4), OritaCalc.findProjection(t4, new Point(x2, y2)), LineColor.PURPLE_8));
             }
         }
 

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCircleDrawTangentLine.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCircleDrawTangentLine.java
@@ -31,10 +31,34 @@ public class MouseHandlerCircleDrawTangentLine extends BaseMouseHandler {
         p.set(d.getCamera().TV2object(p0));
         closest_circumference.set(d.getClosestCircleMidpoint(p));
 
-        if (d.getCircleStep().size() == 0 || d.getCircleStep().size() == 1) {
-            d.getLineStep().clear();
-            if (OritaCalc.distance_circumference(p, closest_circumference) > d.getSelectionDistance()) {
+        // Select a point
+        if(d.getLineStep().isEmpty()){
+            Point closestPoint = d.getClosestPoint(p);
+            if (p.distance(closestPoint) < d.getSelectionDistance()) {
+                d.lineStepAdd(new LineSegment(closestPoint, closestPoint, d.getLineColor()));
                 return;
+            }
+        }
+
+        // Select a circle if:
+        // - There's no circle
+        // - There's no circle and no Point
+        // - There's one circle and no Point
+        if((d.getCircleStep().isEmpty() && d.getLineStep().size() == 1) ||
+                (d.getCircleStep().isEmpty() && d.getLineStep().isEmpty()) ||
+                (d.getCircleStep().size() == 1 && d.getLineStep().isEmpty())){
+            if (OritaCalc.distance_circumference(p, closest_circumference) > d.getSelectionDistance()) { return; }
+
+            if(!d.getLineStep().isEmpty()){ // Assuming there's a point, check if that point is within the selected circle
+               if(closest_circumference.getR() > OritaCalc.distance(closest_circumference.determineCenter(), d.getLineStep().get(0).getA())){
+                   d.getLineStep().clear();
+                   d.getCircleStep().clear();
+                   return;
+               } else if (Math.abs(closest_circumference.getR() - OritaCalc.distance(closest_circumference.determineCenter(), d.getLineStep().get(0).getA())) < Epsilon.UNKNOWN_1EN7) {
+                   d.getLineStep().clear();
+                   d.getCircleStep().clear();
+                   return;
+               }
             }
 
             Circle stepCircle = new Circle();
@@ -42,17 +66,21 @@ public class MouseHandlerCircleDrawTangentLine extends BaseMouseHandler {
             stepCircle.setColor(LineColor.GREEN_6);
 
             d.getCircleStep().add(stepCircle);
-        } else if (d.getLineStep().size() > 1) {//			i_egaki_dankai=0;i_circle_drawing_stage=1;
+        }
+
+        if (d.getLineStep().size() > 1) {//			i_egaki_dankai=0;i_circle_drawing_stage=1;
             LineSegment closest_step_lineSegment = new LineSegment();
             closest_step_lineSegment.set(d.get_moyori_step_lineSegment(p, 1, d.getLineStep().size()));
 
-            if (OritaCalc.determineLineSegmentDistance(p, closest_step_lineSegment) > d.getSelectionDistance()) {
-                return;
-            }
+            if (OritaCalc.determineLineSegmentDistance(p, closest_step_lineSegment) > d.getSelectionDistance()) { return; }
 
+            closest_step_lineSegment.set(OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), closest_step_lineSegment));
+            closest_step_lineSegment.set(closest_step_lineSegment.getB(), closest_step_lineSegment.getA(), d.getLineColor());
+            closest_step_lineSegment.set(OritaCalc.fullExtendUntilHit(d.getFoldLineSet(), closest_step_lineSegment));
+
+            d.addLineSegment(closest_step_lineSegment);
+            d.record();
             d.getLineStep().clear();
-
-            d.lineStepAdd(closest_step_lineSegment);
         }
     }
 
@@ -62,134 +90,135 @@ public class MouseHandlerCircleDrawTangentLine extends BaseMouseHandler {
 
     //マウス操作(ボタンを離したとき)を行う関数
     public void mouseReleased(Point p0) {
-        if ((d.getLineStep().size() == 0) && (d.getCircleStep().size() == 2)) {
-            Circle firstCircle = d.getCircleStep().get(0);
-            Circle secondCircle = d.getCircleStep().get(1);
+        // 2-circle tangents
+        if(d.getCircleStep().size() == 2){
+            if (d.getLineStep().isEmpty()) {
+                Circle firstCircle = d.getCircleStep().get(0);
+                Circle secondCircle = d.getCircleStep().get(1);
 
-            Point c1 = new Point();
-            c1.set(firstCircle.determineCenter());
-            Point c2 = new Point();
-            c2.set(secondCircle.determineCenter());
+                Point c1 = new Point();
+                c1.set(firstCircle.determineCenter());
+                Point c2 = new Point();
+                c2.set(secondCircle.determineCenter());
 
-            double x1 = firstCircle.getX();
-            double y1 = firstCircle.getY();
-            double r1 = firstCircle.getR();
-            double x2 = secondCircle.getX();
-            double y2 = secondCircle.getY();
-            double r2 = secondCircle.getR();
-            //0,0,r,        xp,yp,R
-            double xp = x2 - x1;
-            double yp = y2 - y1;
+                double x1 = firstCircle.getX();
+                double y1 = firstCircle.getY();
+                double r1 = firstCircle.getR();
+                double x2 = secondCircle.getX();
+                double y2 = secondCircle.getY();
+                double r2 = secondCircle.getR();
+                //0,0,r,        xp,yp,R
+                double xp = x2 - x1;
+                double yp = y2 - y1;
 
-            if (c1.distance(c2) < Epsilon.UNKNOWN_1EN6) {
-                d.getCircleStep().clear();
-                return;
-            }//接線0本の場合
+                if (c1.distance(c2) < Epsilon.UNKNOWN_1EN6) {
+                    d.getCircleStep().clear();
+                    return;
+                }//接線0本の場合
 
-            if ((xp * xp + yp * yp) < (r1 - r2) * (r1 - r2)) {
-                d.getCircleStep().clear();
-                return;
-            }//接線0本の場合
+                if ((xp * xp + yp * yp) < (r1 - r2) * (r1 - r2)) {
+                    d.getCircleStep().clear();
+                    return;
+                }//接線0本の場合
 
-            if (Math.abs((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2)) < Epsilon.UNKNOWN_1EN7) {//外接線1本の場合
-                Point kouten = new Point();
-                kouten.set(OritaCalc.internalDivisionRatio(c1, c2, -r1, r2));
-                StraightLine ty = new StraightLine(c1, kouten);
-                ty.orthogonalize(kouten);
+                if (Math.abs((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2)) < Epsilon.UNKNOWN_1EN7) {//外接線1本の場合
+                    Point kouten = new Point();
+                    kouten.set(OritaCalc.internalDivisionRatio(c1, c2, -r1, r2));
+                    StraightLine ty = new StraightLine(c1, kouten);
+                    ty.orthogonalize(kouten);
 
-                d.lineStepAdd(OritaCalc.circle_to_straightLine_no_intersect_wo_connect_LineSegment(new Circle(kouten, (r1 + r2) / 2.0, LineColor.BLACK_0), ty));
-            } else if (((r1 - r2) * (r1 - r2) < (xp * xp + yp * yp)) && ((xp * xp + yp * yp) < (r1 + r2) * (r1 + r2))) {//外接線2本の場合
-                double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                double yq2 = r1 * (yp * (r1 - r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                    d.lineStepAdd(OritaCalc.circle_to_straightLine_no_intersect_wo_connect_LineSegment(new Circle(kouten, (r1 + r2) / 2.0, LineColor.BLACK_0), ty));
+                } else if (((r1 - r2) * (r1 - r2) < (xp * xp + yp * yp)) && ((xp * xp + yp * yp) < (r1 + r2) * (r1 + r2))) {//外接線2本の場合
+                    double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                    double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                    double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                    double yq2 = r1 * (yp * (r1 - r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
 
-                double xr1 = xq1 + x1;
-                double yr1 = yq1 + y1;
-                double xr2 = xq2 + x1;
-                double yr2 = yq2 + y1;
+                    double xr1 = xq1 + x1;
+                    double yr1 = yq1 + y1;
+                    double xr2 = xq2 + x1;
+                    double yr2 = yq2 + y1;
 
-                StraightLine t1 = new StraightLine(x1, y1, xr1, yr1);
-                t1.orthogonalize(new Point(xr1, yr1));
-                StraightLine t2 = new StraightLine(x1, y1, xr2, yr2);
-                t2.orthogonalize(new Point(xr2, yr2));
+                    StraightLine t1 = new StraightLine(x1, y1, xr1, yr1);
+                    t1.orthogonalize(new Point(xr1, yr1));
+                    StraightLine t2 = new StraightLine(x1, y1, xr2, yr2);
+                    t2.orthogonalize(new Point(xr2, yr2));
 
-                d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
-                d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
-            } else if (Math.abs((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2)) < Epsilon.UNKNOWN_1EN7) {//外接線2本と内接線1本の場合
-                double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                double yq2 = r1 * (yp * (r1 - r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                    d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
+                    d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
+                } else if (Math.abs((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2)) < Epsilon.UNKNOWN_1EN7) {//外接線2本と内接線1本の場合
+                    double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                    double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                    double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                    double yq2 = r1 * (yp * (r1 - r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
 
-                double xr1 = xq1 + x1;
-                double yr1 = yq1 + y1;
-                double xr2 = xq2 + x1;
-                double yr2 = yq2 + y1;
+                    double xr1 = xq1 + x1;
+                    double yr1 = yq1 + y1;
+                    double xr2 = xq2 + x1;
+                    double yr2 = yq2 + y1;
 
-                StraightLine t1 = new StraightLine(x1, y1, xr1, yr1);
-                t1.orthogonalize(new Point(xr1, yr1));
-                StraightLine t2 = new StraightLine(x1, y1, xr2, yr2);
-                t2.orthogonalize(new Point(xr2, yr2));
+                    StraightLine t1 = new StraightLine(x1, y1, xr1, yr1);
+                    t1.orthogonalize(new Point(xr1, yr1));
+                    StraightLine t2 = new StraightLine(x1, y1, xr2, yr2);
+                    t2.orthogonalize(new Point(xr2, yr2));
 
-                d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
-                d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
+                    d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
+                    d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
 
-                Point kouten = new Point();
-                kouten.set(OritaCalc.internalDivisionRatio(c1, c2, r1, r2));
-                StraightLine ty = new StraightLine(c1, kouten);
-                ty.orthogonalize(kouten);
-                LineSegment s = OritaCalc.circle_to_straightLine_no_intersect_wo_connect_LineSegment(new Circle(kouten, (r1 + r2) / 2.0, LineColor.BLACK_0), ty);
-                s.setColor(LineColor.PURPLE_8);
-                d.lineStepAdd(s);
-            } else if ((r1 + r2) * (r1 + r2) < (xp * xp + yp * yp)) {//外接線2本と内接線2本の場合
-                //             ---------------------------------------------------------------
-                //                                     -------------------------------------
-                //                 -------               -------------   -------   -------       -------------
-                double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                double yq2 = r1 * (yp * (r1 - r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
-                double xq3 = r1 * (xp * (r1 + r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
-                double yq3 = r1 * (yp * (r1 + r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
-                double xq4 = r1 * (xp * (r1 + r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
-                double yq4 = r1 * (yp * (r1 + r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
+                    Point kouten = new Point();
+                    kouten.set(OritaCalc.internalDivisionRatio(c1, c2, r1, r2));
+                    StraightLine ty = new StraightLine(c1, kouten);
+                    ty.orthogonalize(kouten);
+                    LineSegment s = OritaCalc.circle_to_straightLine_no_intersect_wo_connect_LineSegment(new Circle(kouten, (r1 + r2) / 2.0, LineColor.BLACK_0), ty);
+                    s.setColor(LineColor.PURPLE_8);
+                    d.lineStepAdd(s);
+                } else if ((r1 + r2) * (r1 + r2) < (xp * xp + yp * yp)) {//外接線2本と内接線2本の場合
+                    //             ---------------------------------------------------------------
+                    //                                     -------------------------------------
+                    //                 -------               -------------   -------   -------       -------------
+                    double xq1 = r1 * (xp * (r1 - r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                    double yq1 = r1 * (yp * (r1 - r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                    double xq2 = r1 * (xp * (r1 - r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                    double yq2 = r1 * (yp * (r1 - r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 - r2) * (r1 - r2))) / (xp * xp + yp * yp);//共通外接線
+                    double xq3 = r1 * (xp * (r1 + r2) + yp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
+                    double yq3 = r1 * (yp * (r1 + r2) - xp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
+                    double xq4 = r1 * (xp * (r1 + r2) - yp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
+                    double yq4 = r1 * (yp * (r1 + r2) + xp * Math.sqrt((xp * xp + yp * yp) - (r1 + r2) * (r1 + r2))) / (xp * xp + yp * yp);//共通内接線
 
 
-                double xr1 = xq1 + x1;
-                double yr1 = yq1 + y1;
-                double xr2 = xq2 + x1;
-                double yr2 = yq2 + y1;
-                double xr3 = xq3 + x1;
-                double yr3 = yq3 + y1;
-                double xr4 = xq4 + x1;
-                double yr4 = yq4 + y1;
+                    double xr1 = xq1 + x1;
+                    double yr1 = yq1 + y1;
+                    double xr2 = xq2 + x1;
+                    double yr2 = yq2 + y1;
+                    double xr3 = xq3 + x1;
+                    double yr3 = yq3 + y1;
+                    double xr4 = xq4 + x1;
+                    double yr4 = yq4 + y1;
 
-                StraightLine t1 = new StraightLine(x1, y1, xr1, yr1);
-                t1.orthogonalize(new Point(xr1, yr1));
-                StraightLine t2 = new StraightLine(x1, y1, xr2, yr2);
-                t2.orthogonalize(new Point(xr2, yr2));
-                StraightLine t3 = new StraightLine(x1, y1, xr3, yr3);
-                t3.orthogonalize(new Point(xr3, yr3));
-                StraightLine t4 = new StraightLine(x1, y1, xr4, yr4);
-                t4.orthogonalize(new Point(xr4, yr4));
+                    StraightLine t1 = new StraightLine(x1, y1, xr1, yr1);
+                    t1.orthogonalize(new Point(xr1, yr1));
+                    StraightLine t2 = new StraightLine(x1, y1, xr2, yr2);
+                    t2.orthogonalize(new Point(xr2, yr2));
+                    StraightLine t3 = new StraightLine(x1, y1, xr3, yr3);
+                    t3.orthogonalize(new Point(xr3, yr3));
+                    StraightLine t4 = new StraightLine(x1, y1, xr4, yr4);
+                    t4.orthogonalize(new Point(xr4, yr4));
 
-                d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
-                d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
-                d.lineStepAdd(new LineSegment(new Point(xr3, yr3), OritaCalc.findProjection(t3, new Point(x2, y2)), LineColor.PURPLE_8));
-                d.lineStepAdd(new LineSegment(new Point(xr4, yr4), OritaCalc.findProjection(t4, new Point(x2, y2)), LineColor.PURPLE_8));
+                    d.lineStepAdd(new LineSegment(new Point(xr1, yr1), OritaCalc.findProjection(t1, new Point(x2, y2)), LineColor.PURPLE_8));
+                    d.lineStepAdd(new LineSegment(new Point(xr2, yr2), OritaCalc.findProjection(t2, new Point(x2, y2)), LineColor.PURPLE_8));
+                    d.lineStepAdd(new LineSegment(new Point(xr3, yr3), OritaCalc.findProjection(t3, new Point(x2, y2)), LineColor.PURPLE_8));
+                    d.lineStepAdd(new LineSegment(new Point(xr4, yr4), OritaCalc.findProjection(t4, new Point(x2, y2)), LineColor.PURPLE_8));
+                }
             }
         }
 
-        if (d.getLineStep().size() == 1) {
-            d.getCircleStep().clear();
-
-            LineSegment s = d.getLineStep().get(0);
-            s.setColor(d.getLineColor());
-            d.addLineSegment(s);
-
-            d.getLineStep().clear();
-            d.record();
+        //point-circle tangent
+        if(d.getCircleStep().size() == 1 && d.getLineStep().size() == 1){
+            LineSegment diameter = new LineSegment(d.getLineStep().get(0).getA(), d.getCircleStep().get(0).determineCenter());
+            Circle constructCir = new Circle(diameter, LineColor.GREEN_6);
+            LineSegment connectSegment = OritaCalc.circle_to_circle_no_intersection_wo_musubu_lineSegment(constructCir, d.getCircleStep().get(0));
+            d.lineStepAdd(new LineSegment(d.getLineStep().get(0).getA(), connectSegment.getA(), LineColor.PURPLE_8));
+            d.lineStepAdd(new LineSegment(d.getLineStep().get(0).getA(), connectSegment.getB(), LineColor.PURPLE_8));
         }
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCircleDrawTangentLine.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCircleDrawTangentLine.java
@@ -81,6 +81,7 @@ public class MouseHandlerCircleDrawTangentLine extends BaseMouseHandler {
             d.addLineSegment(closest_step_lineSegment);
             d.record();
             d.getLineStep().clear();
+            d.getCircleStep().clear();
         }
     }
 


### PR DESCRIPTION
Added a feature for circle-circle tangent drawing tool to now also draw tangent of a circle going through a Point. 


https://github.com/oriedita/oriedita/assets/94136126/17d43bc8-6580-4521-a9af-b39424e14ccb



Select a point and a circle. Like the circle-circle tangent, you have to click on one of the purple indicators, though the indicators will now also auto expand. Note that if the selected indicator is intersecting with an existing crease, it will not auto expand and will instead draw point to point. You can also use the point-circle tangent in any order (point -> circle and circle -> point will both work).

Minor issue: VERY FEW times the point-circle tangent tool doesn't show the indicators at all and just leaves with a point segment from where you select the point. Currently unable to replicate it consistently, or at all.