### PR TITLE
Improve startup performance

### DIFF
--- a/oriedita-common/src/main/java/oriedita/common/task/MultiStagedExecutor.java
+++ b/oriedita-common/src/main/java/oriedita/common/task/MultiStagedExecutor.java
@@ -1,0 +1,44 @@
+package oriedita.common.task;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class MultiStagedExecutor implements Executor {
+
+    private ExecutorService executor;
+
+    public MultiStagedExecutor() {
+        this.create();
+    }
+
+    public void create() {
+        this.executor = Executors.newWorkStealingPool();
+    }
+
+    public void stopStage() throws InterruptedException {
+        this.executor.shutdown();
+
+        if (!this.executor.awaitTermination(10L, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Could not start");
+        }
+    }
+
+    /**
+     * Wait until every task is finished and start a new stage.
+     */
+    public void nextStage() throws InterruptedException {
+        this.stopStage();
+
+        this.executor = Executors.newWorkStealingPool();
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        if (this.executor == null) {
+            throw new IllegalStateException("MultiStageExecutor not started");
+        }
+        executor.execute(command);
+    }
+}

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/BottomPanel.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/BottomPanel.java
@@ -101,6 +101,9 @@ public class BottomPanel {
     }
 
     public void init() {
+        foldedFigureResize.init();
+        foldedFigureRotate.init();
+
         buttonService.addDefaultListener($$$getRootComponent$$$());
 
         buttonService.registerButton(foldedFigureAntiAliasButton, "foldedFigureToggleAntiAliasAction");
@@ -295,7 +298,7 @@ public class BottomPanel {
 
     private void createUIComponents() {
         panel1 = new JPanel();
-        foldedFigureResize = new FoldedFigureResize(applicationModel, buttonService, foldedFigureModel, measuresModel, animationService);
+        foldedFigureResize = new FoldedFigureResize(buttonService, foldedFigureModel, measuresModel, animationService);
         foldedFigureRotate = new FoldedFigureRotate(buttonService, foldedFigureModel, measuresModel);
         foldedFigureBox = new JComboBox<>();
     }

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/Editor.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/Editor.java
@@ -9,6 +9,7 @@ import oriedita.editor.CanvasUI;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import java.awt.BorderLayout;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -35,11 +36,11 @@ public class Editor {
         $$$setupUI$$$();
     }
 
-    public void init(ExecutorService service) throws InterruptedException {
-        service.submit(leftPanel::init);
-        service.submit(topPanel::init);
-        service.submit(rightPanel::init);
-        service.submit(bottomPanel::init);
+    public void init(Executor service) throws InterruptedException {
+        service.execute(leftPanel::init);
+        service.execute(topPanel::init);
+        service.execute(rightPanel::init);
+        service.execute(bottomPanel::init);
     }
 
     private void createUIComponents() {

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/component/FoldedFigureResize.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/component/FoldedFigureResize.java
@@ -23,19 +23,28 @@ import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 
 public class FoldedFigureResize extends JPanel {
+    private final ButtonService buttonService;
+    private final FoldedFigureModel foldedFigureModel;
+    private final MeasuresModel measuresModel;
+    private final AnimationService animationService;
     private JButton foldedFigureSizeDecreaseButton;
     private JPanel panel1;
     private JTextField foldedFigureSizeTextField;
     private JButton foldedFigureSizeSetButton;
     private JButton foldedFigureSizeIncreaseButton;
 
-    public FoldedFigureResize(ApplicationModel applicationModel,
-                              ButtonService buttonService,
+    public FoldedFigureResize(ButtonService buttonService,
                               FoldedFigureModel foldedFigureModel,
                               MeasuresModel measuresModel,
                               AnimationService animationService) {
+        this.buttonService = buttonService;
+        this.foldedFigureModel = foldedFigureModel;
+        this.measuresModel = measuresModel;
+        this.animationService = animationService;
         add($$$getRootComponent$$$());
+    }
 
+    public void init() {
         buttonService.registerButton(foldedFigureSizeSetButton, "foldedFigureSizeSetAction");
         buttonService.registerButton(foldedFigureSizeDecreaseButton, "foldedFigureSizeDecreaseAction");
         buttonService.registerButton(foldedFigureSizeIncreaseButton, "foldedFigureSizeIncreaseAction");

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/component/FoldedFigureRotate.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/component/FoldedFigureRotate.java
@@ -21,6 +21,9 @@ import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 
 public class FoldedFigureRotate extends JPanel {
+    private final ButtonService buttonService;
+    private final FoldedFigureModel foldedFigureModel;
+    private final MeasuresModel measuresModel;
     private JButton foldedFigureRotateAntiClockwiseButton;
     private JPanel panel1;
     private JTextField foldedFigureRotateTextField;
@@ -28,8 +31,14 @@ public class FoldedFigureRotate extends JPanel {
     private JButton foldedFigureRotateSetButton;
 
     public FoldedFigureRotate(ButtonService buttonService, FoldedFigureModel foldedFigureModel, MeasuresModel measuresModel) {
-        add($$$getRootComponent$$$());
+        this.buttonService = buttonService;
+        this.foldedFigureModel = foldedFigureModel;
+        this.measuresModel = measuresModel;
 
+        add($$$getRootComponent$$$());
+    }
+
+    public void init() {
         buttonService.registerButton(foldedFigureRotateAntiClockwiseButton, "foldedFigureRotateAntiClockwiseAction");
         buttonService.registerButton(foldedFigureRotateSetButton, "foldedFigureRotateSetAction");
         buttonService.registerButton(foldedFigureRotateClockwiseButton, "foldedFigureRotateClockwiseAction");

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/LoadingDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/LoadingDialog.java
@@ -44,7 +44,6 @@ public class LoadingDialog extends JDialog {
             pack();
             setLocationRelativeTo(null);
             setVisible(true);
-
         } catch (ImageReadException | IOException e) {
             e.printStackTrace();
         }

--- a/oriedita/src/main/java/oriedita/editor/App.java
+++ b/oriedita/src/main/java/oriedita/editor/App.java
@@ -292,23 +292,24 @@ public class App {
         angleSystemModel.addPropertyChangeListener(e -> mainCreasePatternWorker.setData(angleSystemModel));
         canvasModel.addPropertyChangeListener(e -> mainCreasePatternWorker.setData(canvasModel));
         fileModel.addPropertyChangeListener(e -> mainCreasePatternWorker.setTitle(fileModel.determineFrameTitle()));
+        
+        foldedFigureModel.addPropertyChangeListener(e -> {
+            FoldedFigure_Drawer selectedFigure = foldedFiguresList.getActiveItem();
+
+            if (selectedFigure != null) {
+                selectedFigure.setData(foldedFigureModel);
+            }
+        });
+
+        canvasModel.addPropertyChangeListener(e -> {
+            if (e.getPropertyName() == null || e.getPropertyName().equals("mouseMode")) {
+                Logger.info("mouseMode = " + canvasModel.getMouseMode().toReadableString());
+            }
+        });
+
 
         executor.execute(() -> {
             applicationModel.reload();
-
-            foldedFigureModel.addPropertyChangeListener(e -> {
-                FoldedFigure_Drawer selectedFigure = foldedFiguresList.getActiveItem();
-
-                if (selectedFigure != null) {
-                    selectedFigure.setData(foldedFigureModel);
-                }
-            });
-
-            canvasModel.addPropertyChangeListener(e -> {
-                if (e.getPropertyName() == null || e.getPropertyName().equals("mouseMode")) {
-                    Logger.info("mouseMode = " + canvasModel.getMouseMode().toReadableString());
-                }
-            });
 
             fileModel.addPropertyChangeListener(e -> frame.setTitle(fileModel.determineFrameTitle()));
 

--- a/oriedita/src/main/java/oriedita/editor/App.java
+++ b/oriedita/src/main/java/oriedita/editor/App.java
@@ -149,10 +149,10 @@ public class App {
     }
 
     public void start() throws InterruptedException, InvocationTargetException {
+        loadFont();
         MultiStagedExecutor executor = new MultiStagedExecutor();
         executor.execute(actionRegistrationService::registerActionsInitial);
         executor.execute(canvas::init);
-        executor.execute(App::loadFont);
         editor.init(executor);
         executor.execute(appMenuBar::init);
 
@@ -292,7 +292,7 @@ public class App {
         angleSystemModel.addPropertyChangeListener(e -> mainCreasePatternWorker.setData(angleSystemModel));
         canvasModel.addPropertyChangeListener(e -> mainCreasePatternWorker.setData(canvasModel));
         fileModel.addPropertyChangeListener(e -> mainCreasePatternWorker.setTitle(fileModel.determineFrameTitle()));
-        
+
         foldedFigureModel.addPropertyChangeListener(e -> {
             FoldedFigure_Drawer selectedFigure = foldedFiguresList.getActiveItem();
 

--- a/oriedita/src/main/java/oriedita/editor/Oriedita.java
+++ b/oriedita/src/main/java/oriedita/editor/Oriedita.java
@@ -53,7 +53,7 @@ public class Oriedita {
 
         System.setProperty("apple.laf.useScreenMenuBar", "true");
 
-        loadFont();
+//        loadFont();
 
         // Initialize look and feel service, this will bind to the applicationModel update the look and feel (must be done early).
         lookAndFeelService.init();
@@ -66,6 +66,7 @@ public class Oriedita {
 
         try {
             app.start();
+            Logger.trace("App.start finished");
         } catch (InterruptedException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }

--- a/oriedita/src/main/java/oriedita/editor/Oriedita.java
+++ b/oriedita/src/main/java/oriedita/editor/Oriedita.java
@@ -16,11 +16,13 @@ import oriedita.editor.swing.dialog.LoadingDialogUtil;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
+import java.awt.EventQueue;
 import java.awt.Font;
 import java.awt.FontFormatException;
 import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Objects;
 
@@ -41,10 +43,10 @@ public class Oriedita {
     @Parameters
     List<String> argv;
 
-    public void start(@Observes ContainerInitialized event) {
+    public void start(@Observes ContainerInitialized event) throws InterruptedException, InvocationTargetException {
         long startTime = System.currentTimeMillis();
 
-        if (! event.getContainerId().equals(RegistrySingletonProvider.STATIC_INSTANCE)) {
+        if (!event.getContainerId().equals(RegistrySingletonProvider.STATIC_INSTANCE)) {
             Logger.warn("Not starting Oriedita outside of normal mode");
             return;
         }
@@ -60,30 +62,31 @@ public class Oriedita {
 
         Logger.info("Setup in {} ms.", System.currentTimeMillis() - startTime);
 
-        SwingUtilities.invokeLater(() -> {
-            lookAndFeelService.registerFlatLafSource();
+        lookAndFeelService.registerFlatLafSource();
 
+        try {
+            app.start();
+        } catch (InterruptedException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+
+        LoadingDialogUtil.hide();
+
+        app.afterStart();
+
+
+        if (argv.size() == 1) {
+            // We got a file
             try {
-                app.start();
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
+                fileSaveService.openFile(new File(argv.get(0)));
+            } catch (FileReadingException e) {
+                Logger.error(e, "Error reading file");
+                JOptionPane.showMessageDialog(null, "An error occurred when reading this file", "Read Error", JOptionPane.ERROR_MESSAGE);
             }
+        }
 
-            LoadingDialogUtil.hide();
-
-            if (argv.size() == 1) {
-                // We got a file
-                try {
-                    fileSaveService.openFile(new File(argv.get(0)));
-                } catch (FileReadingException e) {
-                    Logger.error(e, "Error reading file");
-                    JOptionPane.showMessageDialog(null, "An error occurred when reading this file", "Read Error", JOptionPane.ERROR_MESSAGE);
-                }
-            }
-
-            fileSaveService.initAutoSave();
-            Logger.info("Startup in {} ms.", System.currentTimeMillis() - startTime);
-        });
+        fileSaveService.initAutoSave();
+        Logger.info("Startup in {} ms.", System.currentTimeMillis() - startTime);
     }
 
     private static void loadFont() {

--- a/oriedita/src/main/java/oriedita/editor/canvas/impl/CreasePattern_Worker_Impl.java
+++ b/oriedita/src/main/java/oriedita/editor/canvas/impl/CreasePattern_Worker_Impl.java
@@ -153,8 +153,6 @@ public class CreasePattern_Worker_Impl implements CreasePattern_Worker {
 
         text_cp_setumei = "1/";
         s_title = "no title";
-
-        reset();
     }
 
     @Override

--- a/oriedita/src/main/resources/tinylog.properties
+++ b/oriedita/src/main/resources/tinylog.properties
@@ -1,3 +1,3 @@
 writer=console
 writer.level=info
-writer.format=\u001B[34m{date: HH:mm:ss.SSS} \u001B[90m[{thread}] {class}.{method}()\n\u001B[36m{level}:\u001B[0m {message}.
+writer.format={date: HH:mm:ss.SSS} \u001B[36m{level}:\u001B[90m[{thread}] {class}.{method}() \u001B[0m{message}.


### PR DESCRIPTION
Improves startup performance in the following ways:

- Run main startup from the main thread, this also makes sure that the first render of the main frame is actually correct and does not flash a wrong layout
- Multithread every non-ui setup task

Multithreading is done in multiple stages (see `App.start()`)
1. Initialize the editor, this registers buttons and adds action listeners (multithreaded)
2. Configure the main frame
3. Configure property change listeners in the model
4. Reset the UI state based on the model (multithreaded)
5. Pack main frame and correct position