### PR TITLE
Selection undo inconsistency

### DIFF
--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseSelect.java
@@ -55,21 +55,11 @@ public class MouseHandlerCreaseSelect extends BaseMouseHandlerBoxSelect {
             Logger.info("3_Click");//("トリプルクリック"
             tripleClick = true;
             switch (canvasModel.getSelectionOperationMode()) {
-                case MOVE_1:
-                    canvasModel.setMouseMode(MouseMode.CREASE_MOVE_21);
-                    break;
-                case MOVE4P_2:
-                    canvasModel.setMouseMode(MouseMode.CREASE_MOVE_4P_31);
-                    break;
-                case COPY_3:
-                    canvasModel.setMouseMode(MouseMode.CREASE_COPY_22);
-                    break;
-                case COPY4P_4:
-                    canvasModel.setMouseMode(MouseMode.CREASE_COPY_4P_32);
-                    break;
-                case MIRROR_5:
-                    canvasModel.setMouseMode(MouseMode.DRAW_CREASE_SYMMETRIC_12);
-                    break;
+                case MOVE_1 -> canvasModel.setMouseMode(MouseMode.CREASE_MOVE_21);
+                case MOVE4P_2 -> canvasModel.setMouseMode(MouseMode.CREASE_MOVE_4P_31);
+                case COPY_3 -> canvasModel.setMouseMode(MouseMode.CREASE_COPY_22);
+                case COPY4P_4 -> canvasModel.setMouseMode(MouseMode.CREASE_COPY_4P_32);
+                case MIRROR_5 -> canvasModel.setMouseMode(MouseMode.DRAW_CREASE_SYMMETRIC_12);
             }
         } else {
             tripleClick = false;
@@ -87,24 +77,12 @@ public class MouseHandlerCreaseSelect extends BaseMouseHandlerBoxSelect {
             return;
         }
         switch (d.getI_select_mode()) {
-            case NORMAL_0:
-                super.mousePressed(p0);
-                break;
-            case MOVE_1:
-                mouseHandlerCreaseMove.mousePressed(p0);//move
-                break;
-            case MOVE4P_2:
-                mouseHandlerCreaseMove4p.mousePressed(p0);//move 2p2p
-                break;
-            case COPY_3:
-                mouseHandlerCreaseCopy.mousePressed(p0);//copy
-                break;
-            case COPY4P_4:
-                mouseHandlerCreaseCopy4p.mousePressed(p0);//copy 2p2p
-                break;
-            case MIRROR_5:
-                mouseHandlerDrawCreaseSymmetric.mousePressed(p0);//鏡映
-                break;
+            case NORMAL_0 -> super.mousePressed(p0);
+            case MOVE_1 -> mouseHandlerCreaseMove.mousePressed(p0);//move
+            case MOVE4P_2 -> mouseHandlerCreaseMove4p.mousePressed(p0);//move 2p2p
+            case COPY_3 -> mouseHandlerCreaseCopy.mousePressed(p0);//copy
+            case COPY4P_4 -> mouseHandlerCreaseCopy4p.mousePressed(p0);//copy 2p2p
+            case MIRROR_5 -> mouseHandlerDrawCreaseSymmetric.mousePressed(p0);//鏡映
         }
     }
 
@@ -118,24 +96,12 @@ public class MouseHandlerCreaseSelect extends BaseMouseHandlerBoxSelect {
         }
 
         switch (d.getI_select_mode()) {
-            case NORMAL_0:
-                super.mouseDragged(p0);
-                break;
-            case MOVE_1:
-                mouseHandlerCreaseMove.mouseDragged(p0);//move
-                break;
-            case MOVE4P_2:
-                mouseHandlerCreaseMove4p.mouseDragged(p0);//move 2p2p
-                break;
-            case COPY_3:
-                mouseHandlerCreaseCopy.mouseDragged(p0);//copy
-                break;
-            case COPY4P_4:
-                mouseHandlerCreaseCopy4p.mouseDragged(p0);//copy 2p2p
-                break;
-            case MIRROR_5:
-                mouseHandlerDrawCreaseSymmetric.mouseDragged(p0);//鏡映
-                break;
+            case NORMAL_0 -> super.mouseDragged(p0);
+            case MOVE_1 -> mouseHandlerCreaseMove.mouseDragged(p0);//move
+            case MOVE4P_2 -> mouseHandlerCreaseMove4p.mouseDragged(p0);//move 2p2p
+            case COPY_3 -> mouseHandlerCreaseCopy.mouseDragged(p0);//copy
+            case COPY4P_4 -> mouseHandlerCreaseCopy4p.mouseDragged(p0);//copy 2p2p
+            case MIRROR_5 -> mouseHandlerDrawCreaseSymmetric.mouseDragged(p0);//鏡映
         }
     }
 
@@ -144,7 +110,6 @@ public class MouseHandlerCreaseSelect extends BaseMouseHandlerBoxSelect {
 
         if (!tripleClick) {
             mReleased_A_box_select(p0);
-            d.record();
             return;
         }
         switch (d.getI_select_mode()) {
@@ -156,12 +121,13 @@ public class MouseHandlerCreaseSelect extends BaseMouseHandlerBoxSelect {
             case MIRROR_5 -> mouseHandlerDrawCreaseSymmetric.mouseReleased(p0);//鏡映
         }
         tripleClick = false;
-        d.record();
     }
 
     public void mReleased_A_box_select(Point p0) {
         super.mouseReleased(p0);
         d.getLineStep().clear();
+
+        int beforeSelectNum = d.getFoldLineTotalForSelectFolding();
 
         d.select(selectionStart, p0);
         if (selectionStart.distance(p0) <= Epsilon.UNKNOWN_1EN6) {
@@ -171,5 +137,8 @@ public class MouseHandlerCreaseSelect extends BaseMouseHandlerBoxSelect {
                 d.setIsSelectionEmpty(false);
             }
         }
+        int afterSelectNum = d.getFoldLineTotalForSelectFolding();
+
+        if(beforeSelectNum != afterSelectNum) d.record();
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseSelect.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseSelect.java
@@ -144,29 +144,19 @@ public class MouseHandlerCreaseSelect extends BaseMouseHandlerBoxSelect {
 
         if (!tripleClick) {
             mReleased_A_box_select(p0);
+            d.record();
             return;
         }
         switch (d.getI_select_mode()) {
-            case NORMAL_0:
-                mReleased_A_box_select(p0);
-                break;
-            case MOVE_1:
-                mouseHandlerCreaseMove.mouseReleased(p0);//move
-                break;
-            case MOVE4P_2:
-                mouseHandlerCreaseMove4p.mouseReleased(p0);//move 2p2p
-                break;
-            case COPY_3:
-                mouseHandlerCreaseCopy.mouseReleased(p0);//copy
-                break;
-            case COPY4P_4:
-                mouseHandlerCreaseCopy4p.mouseReleased(p0);//copy 2p2p
-                break;
-            case MIRROR_5:
-                mouseHandlerDrawCreaseSymmetric.mouseReleased(p0);//鏡映
-                break;
+            case NORMAL_0 -> mReleased_A_box_select(p0);
+            case MOVE_1 -> mouseHandlerCreaseMove.mouseReleased(p0);//move
+            case MOVE4P_2 -> mouseHandlerCreaseMove4p.mouseReleased(p0);//move 2p2p
+            case COPY_3 -> mouseHandlerCreaseCopy.mouseReleased(p0);//copy
+            case COPY4P_4 -> mouseHandlerCreaseCopy4p.mouseReleased(p0);//copy 2p2p
+            case MIRROR_5 -> mouseHandlerDrawCreaseSymmetric.mouseReleased(p0);//鏡映
         }
         tripleClick = false;
+        d.record();
     }
 
     public void mReleased_A_box_select(Point p0) {


### PR DESCRIPTION
Initially, selecting lines doesn't create state to undo to, so performing undo skips the subsequent selections at once (and continue to do so if theres groups of subsequent selections interspersed with other actions). 

This PR aims to fix that, by checking if the number of selected lines change after each selection, `record()` if it does.

https://github.com/user-attachments/assets/2d9a7964-2c64-4e71-be34-1c9bca5754c2

