### PR TITLE
Fix garbled characters in preference dialog

### DIFF
--- a/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/dialog/PreferenceDialog.java
@@ -63,6 +63,7 @@ import java.awt.event.WindowEvent;
 import java.beans.PropertyChangeListener;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PushbackInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -654,7 +655,14 @@ public class PreferenceDialog extends JDialog {
             InputStream is = this.getClass().getResourceAsStream("/categories.csv");
 
             assert is != null;
-            InputStreamReader inputStreamReader = new InputStreamReader(is);
+            PushbackInputStream pushbackInputStream = new PushbackInputStream(is, 3);
+            InputStreamReader inputStreamReader = new InputStreamReader(pushbackInputStream, "UTF-8");
+
+            // Check for BOM
+            byte[] bom = new byte[3];
+            int bytesRead = pushbackInputStream.read(bom, 0, 3);
+            boolean hasBOM = bytesRead == 3 && bom[0] == (byte) 0xEF && bom[1] == (byte) 0xBB && bom[2] == (byte) 0xBF;
+            if (!hasBOM) pushbackInputStream.unread(bom, 0, bytesRead);
 
             // create csvParser object with custom separator semicolon
             CSVParser parser = new CSVParserBuilder().withSeparator(';').build();


### PR DESCRIPTION
This PR fixes the garbled characters appearing in the preference dialog (only for Asian language PCs perhaps):

![image](https://github.com/user-attachments/assets/4c774420-9e00-48d6-8420-9c08b5ee34c4)

The source of this issue is because categories.csv is encoded under UTF-8 with BOM. Here I add checking to the input stream, so that it will correctly read the csv file, with or without BOM (as we don't want to make assumptions on whoever is editing the csv file).