### PR TITLE
Temporarily revert #440 and #448 for debugging

### DIFF
--- a/origami/src/main/java/origami/crease_pattern/PointSet.java
+++ b/origami/src/main/java/origami/crease_pattern/PointSet.java
@@ -394,12 +394,7 @@ public class PointSet implements Serializable {
                 }
             }
             if (addNewFace && tempFace.getNumPoints() != 0 && calculateArea(tempFace) > 0.0) {
-                try {
-                    addFace(tempFace, map);
-                } catch (Exception e) {
-                    Logger.error("ERROR: cannot add face.");
-                    return false;
-                }
+                addFace(tempFace, map);
             }
 
             tempFace = Face_request(lines[i].getEnd(), lines[i].getBegin());
@@ -411,12 +406,7 @@ public class PointSet implements Serializable {
                 }
             }
             if (addNewFace && tempFace.getNumPoints() != 0 && calculateArea(tempFace) > 0.0) {
-                try {
-                    addFace(tempFace, map);
-                } catch (Exception e) {
-                    Logger.error("ERROR: cannot add face.");
-                    return false;
-                }
+                addFace(tempFace, map);
             }
 
             // No need for InterruptedException here since this algorithm is now way too


### PR DESCRIPTION
The calculating face patches seem to be causing issues with folding (showing wireframe in colored fold when it's not supposed to). Those patches will be pull backed for now to investigate a bit more properly.

With that being said, if you're using the latest build from this PR going forward, please make sure to backup your file in a different format like `.ori`, or refer to the auto-save folder as it might save your working file there if it does get wiped out when saving/exporting failed. 