### PR TITLE
Double the precision for comparing points

### DIFF
--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerDrawCreaseAngleRestricted.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerDrawCreaseAngleRestricted.java
@@ -193,7 +193,7 @@ public class MouseHandlerDrawCreaseAngleRestricted extends BaseMouseHandler {
                 //２つの線分が平行かどうかを判定する関数。oc.heikou_hantei(Tyokusen t1,Tyokusen t2)//0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
                 //0=平行でない、1=平行で２直線が一致しない、2=平行で２直線が一致する
 
-                if (OritaCalc.isLineSegmentParallel(d.getLineStep().get(d.getLineStep().size() - 1 - 1), d.getLineStep().get(d.getLineStep().size() - 1), Epsilon.UNKNOWN_01) != OritaCalc.ParallelJudgement.NOT_PARALLEL) {//ここは安全を見て閾値を0.1と大目にとっておこのがよさそう
+                if (OritaCalc.isLineSegmentParallel(d.getLineStep().get(d.getLineStep().size() - 1 - 1), d.getLineStep().get(d.getLineStep().size() - 1)) != OritaCalc.ParallelJudgement.NOT_PARALLEL) {//ここは安全を見て閾値を0.1と大目にとっておこのがよさそう
                     d.getLineStep().clear();
                     return;
                 }

--- a/oriedita/src/main/java/oriedita/editor/tools/SnappingUtil.java
+++ b/oriedita/src/main/java/oriedita/editor/tools/SnappingUtil.java
@@ -30,7 +30,7 @@ public class SnappingUtil {
         LineSegment snapLine = new LineSegment(s.getB(), new Point(s.determineBX() + Math.cos(d_rad), s.determineBY() + Math.sin(d_rad)));
         Point pret = OritaCalc.findProjection(snapLine, p);
         if (OritaCalc.determineLineSegmentDistance(p, s2) <= d.getSelectionDistance()) {
-            if (OritaCalc.isLineSegmentParallel(s2, snapLine, Epsilon.PARALLEL) == OritaCalc.ParallelJudgement.NOT_PARALLEL) {
+            if (OritaCalc.isLineSegmentParallel(s2, snapLine, Epsilon.PARALLEL_FOR_FIX) == OritaCalc.ParallelJudgement.NOT_PARALLEL) {
                 pret = OritaCalc.findIntersection(s2, snapLine);
             }
         }

--- a/origami/src/main/java/origami/Epsilon.java
+++ b/origami/src/main/java/origami/Epsilon.java
@@ -24,7 +24,6 @@ public class Epsilon {
     // Most likely, they don't actually have a fixed meaning throughout the code base,
     // and in each of their use cases it just happen to require an epsilon of that magnitude.
 
-    public static final double UNKNOWN_01 = factor * 0.1;
     public static final double UNKNOWN_05 = factor * 0.5;
     public static final double UNKNOWN_001 = factor * 1E-2;
     public static final double UNKNOWN_0001 = factor * 1E-3;
@@ -32,12 +31,15 @@ public class Epsilon {
     public static final double UNKNOWN_1EN5 = factor * 1E-5;
     public static final double UNKNOWN_1EN6 = factor * 1E-6;
     public static final double UNKNOWN_1EN7 = factor * 1E-7;
+
     // These are the constants with a known purpose.
 
-    public static final double PARALLEL = factor * 0.5;
+    public static final double PARALLEL_FOR_EDIT = factor * 0.1;
+    public static final double PARALLEL_FOR_FIX = factor * 0.5; // TODO: do we need two parallel comparison standards?
     public static final double FLAT = factor * 1E-4;
     public static final double QUAD_TREE_ITEM = factor * 0.5;
     public static final double GRID_ANGLE_THRESHOLD = 1;
+
     /**
      * For the most part, this is the smallest epsilon used in the code. Any value
      * that is even smaller is considered zero.

--- a/origami/src/main/java/origami/Epsilon.java
+++ b/origami/src/main/java/origami/Epsilon.java
@@ -11,16 +11,18 @@ import origami.crease_pattern.OritaCalc;
 public class Epsilon {
 
     /**
-     * In the following, all constants after "factor" are the original epsilon
-     * constants used by Orihime. Those epsilons are, however, too big for
-     * super-complex models such as full Ryujin with shaped scales. Before we have a
-     * better understanding of the purpose of these different epsilons, let's just
-     * multiply all of them by a factor to fix this problem. By using a factor of
-     * 0.01, that essentially means all CPs are now 100x larger than the origin.
+     * In the following, all constants after "factor" are the original epsilon constants used by Orihime
+     * (except for those in the "modified" section).
+     * Those epsilons are, however, too big for super-complex models such as full Ryujin with shaped scales.
+     * Before we have a better understanding of the purpose of these different epsilons,
+     * let's just multiply all of them by a factor to fix this problem.
+     * By using a factor of 0.01, that essentially means all CPs are now 100x larger than the origin.
      */
     private static final double factor = 0.01;
 
     // These are the constants of which purpose is uncertain.
+    // Most likely, they don't actually have a fixed meaning throughout the code base,
+    // and in each of their use cases it just happen to require an epsilon of that magnitude.
 
     public static final double UNKNOWN_01 = factor * 0.1;
     public static final double UNKNOWN_05 = factor * 0.5;
@@ -51,6 +53,10 @@ public class Epsilon {
      * found. So I settled with this particular value which seems to work best.
      */
     public static final double SWEET_DISTANCE = factor * 1E-10;
+
+    // These are the constants that has been modified from the original values.
+
+    public static final double POINT = factor * 0.05; // Originally the value was 0.1
 
     /**
      * This is the default instance of the Epsilon class. In the future I expect

--- a/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
+++ b/origami/src/main/java/origami/crease_pattern/FoldLineSet.java
@@ -221,7 +221,7 @@ public class FoldLineSet {
             }
         }
     }
-    
+
     public boolean isSelectionEmpty(){
         for (int i = 1; i <= total; i++) {
             LineSegment s = lineSegments.get(i);
@@ -1585,7 +1585,7 @@ public class FoldLineSet {
     public LineSegment getClosestLineSegment(Point p) {
         int minrid = 0;
         double minr = 100000.0;
-        LineSegment s1 = new LineSegment(100000.0, 100000.0, 100000.0, 100000.0 + Epsilon.UNKNOWN_01);
+        LineSegment s1 = new LineSegment(100000.0, 100000.0, 100000.0, 100000.1);
         for (int i = 1; i <= total; i++) {
             double sk = OritaCalc.determineLineSegmentDistance(p, get(i));
             if (minr > sk) {

--- a/origami/src/main/java/origami/crease_pattern/OritaCalc.java
+++ b/origami/src/main/java/origami/crease_pattern/OritaCalc.java
@@ -34,7 +34,7 @@ public class OritaCalc {
 
     //A function that determines whether two points are in the same position (true) or different (false) -------------------------------- -
     public static boolean equal(Point p1, Point p2) {
-        return equal(p1, p2, Epsilon.UNKNOWN_01);//The error is defined here.
+        return equal(p1, p2, Epsilon.POINT);
     }
 
     public static boolean equal(Point p1, Point p2, double r) {//r is the error tolerance. Strict judgment if r is negative.
@@ -222,16 +222,16 @@ public class OritaCalc {
             y2min = s2.determineBY();
         }
 
-        if (x1max + rhit + Epsilon.UNKNOWN_01 < x2min) {
+        if (x1max + rhit + Epsilon.POINT < x2min) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
-        if (x1min - rhit - Epsilon.UNKNOWN_01 > x2max) {
+        if (x1min - rhit - Epsilon.POINT > x2max) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
-        if (y1max + rhit + Epsilon.UNKNOWN_01 < y2min) {
+        if (y1max + rhit + Epsilon.POINT < y2min) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
-        if (y1min - rhit - Epsilon.UNKNOWN_01 > y2max) {
+        if (y1min - rhit - Epsilon.POINT > y2max) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
 
@@ -440,16 +440,16 @@ public class OritaCalc {
             y2min = s2.determineBY();
         }
 
-        if (x1max + rhit + Epsilon.UNKNOWN_01 < x2min) {
+        if (x1max + rhit + Epsilon.POINT < x2min) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
-        if (x1min - rhit - Epsilon.UNKNOWN_01 > x2max) {
+        if (x1min - rhit - Epsilon.POINT > x2max) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
-        if (y1max + rhit + Epsilon.UNKNOWN_01 < y2min) {
+        if (y1max + rhit + Epsilon.POINT < y2min) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
-        if (y1min - rhit - Epsilon.UNKNOWN_01 > y2max) {
+        if (y1min - rhit - Epsilon.POINT > y2max) {
             return LineSegment.Intersection.NO_INTERSECTION_0;
         }
 

--- a/origami/src/main/java/origami/crease_pattern/OritaCalc.java
+++ b/origami/src/main/java/origami/crease_pattern/OritaCalc.java
@@ -701,7 +701,7 @@ public class OritaCalc {
 
     //A function that determines whether two straight lines are parallel.
     public static ParallelJudgement isLineSegmentParallel(StraightLine t1, StraightLine t2) {
-        return isLineSegmentParallel(t1, t2, Epsilon.UNKNOWN_01);
+        return isLineSegmentParallel(t1, t2, Epsilon.PARALLEL_FOR_EDIT);
     }
 
     //A function that determines whether two straight lines are parallel.

--- a/origami/src/main/java/origami/crease_pattern/element/StraightLine.java
+++ b/origami/src/main/java/origami/crease_pattern/element/StraightLine.java
@@ -21,7 +21,7 @@ public class StraightLine {
             tmpB = -tmpB;
             tmpC = -tmpC;
         }
-        if ((-Epsilon.UNKNOWN_01 < tmpA) && (tmpA < Epsilon.UNKNOWN_01)) {
+        if ((-Epsilon.PARALLEL_FOR_EDIT < tmpA) && (tmpA < Epsilon.PARALLEL_FOR_EDIT)) {
             if (tmpB < 0.0) {
                 tmpA = -tmpA;
                 tmpB = -tmpB;

--- a/origami/src/main/java/origami/crease_pattern/worker/foldlineset/Check1.java
+++ b/origami/src/main/java/origami/crease_pattern/worker/foldlineset/Check1.java
@@ -20,7 +20,7 @@ public class Check1 {
                 LineSegment si1 = new LineSegment(si);
                 LineSegment sj1 = new LineSegment(sj);
 
-                LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersection(si, sj, Epsilon.UNKNOWN_0001, Epsilon.PARALLEL);
+                LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersection(si, sj, Epsilon.UNKNOWN_0001, Epsilon.PARALLEL_FOR_FIX);
                 switch (intersection) {
                     case PARALLEL_EQUAL_31:
                     case PARALLEL_START_OF_S1_CONTAINS_START_OF_S2_321:

--- a/origami/src/main/java/origami/crease_pattern/worker/foldlineset/Check2.java
+++ b/origami/src/main/java/origami/crease_pattern/worker/foldlineset/Check2.java
@@ -21,7 +21,7 @@ public class Check2 {
                 LineSegment sj1 = new LineSegment(sj);
 
                 //T-shaped intersection
-                LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersectionSweet(si, sj, Epsilon.UNKNOWN_0001, Epsilon.PARALLEL);
+                LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersectionSweet(si, sj, Epsilon.UNKNOWN_0001, Epsilon.PARALLEL_FOR_FIX);
                 switch (intersection) {
                     case INTERSECTS_TSHAPE_S1_VERTICAL_BAR_25:
                     case INTERSECTS_TSHAPE_S1_VERTICAL_BAR_26:

--- a/origami/src/main/java/origami/crease_pattern/worker/foldlineset/Fix1.java
+++ b/origami/src/main/java/origami/crease_pattern/worker/foldlineset/Fix1.java
@@ -16,7 +16,7 @@ public class Fix1 {
                     LineSegment sj = foldLineSet.get(j);//r_hitosiiとr_heikouhanteiは、hitosiiとheikou_hanteiのずれの許容程度
                     if (sj.getColor() != LineColor.CYAN_3) {
                         //T字型交差
-                        LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersection(si, sj, Epsilon.UNKNOWN_0001, Epsilon.PARALLEL);
+                        LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersection(si, sj, Epsilon.UNKNOWN_0001, Epsilon.PARALLEL_FOR_FIX);
                         switch (intersection) {
                             case PARALLEL_EQUAL_31:
                                 si.setColor(sj.getColor());

--- a/origami/src/main/java/origami/crease_pattern/worker/foldlineset/Fix2.java
+++ b/origami/src/main/java/origami/crease_pattern/worker/foldlineset/Fix2.java
@@ -23,7 +23,7 @@ public class Fix2 {
                         //T-intersection
                         //折線iをその点pの影で分割する。ただし、点pの影がどれか折線の端点と同じとみなされる場合は何もしない。
                         //r_hitosiiとr_heikouhanteiは、hitosiiとheikou_hanteiのずれの許容程度
-                        LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersectionSweet(si, sj, Epsilon.UNKNOWN_0001, Epsilon.PARALLEL);
+                        LineSegment.Intersection intersection = OritaCalc.determineLineSegmentIntersectionSweet(si, sj, Epsilon.UNKNOWN_0001, Epsilon.PARALLEL_FOR_FIX);
                         switch (intersection) {
                             case INTERSECTS_TSHAPE_S1_VERTICAL_BAR_25:
                                 applyLineSegmentDivide(foldLineSet, si.getA(), j);


### PR DESCRIPTION
This PR doubles the precision for point comparison, fixing folding errors found in some of the CPs.
It also completely determines the meaning of all `Epsilon.UNKNOWN_01` and gives them proper names.