### PR TITLE
Fix folding when selecting from CP

### DIFF
--- a/oriedita/src/main/java/oriedita/editor/service/impl/SingleTaskExecutorServiceImpl.java
+++ b/oriedita/src/main/java/oriedita/editor/service/impl/SingleTaskExecutorServiceImpl.java
@@ -15,9 +15,9 @@ import java.util.concurrent.TimeoutException;
 @ApplicationScoped
 public class SingleTaskExecutorServiceImpl implements TaskExecutorService {
     private final ExecutorService pool;
-    private static Future<?> currentTask = CompletableFuture.completedFuture(null);
+    private Future<?> currentTask = CompletableFuture.completedFuture(null);
 
-    private static String taskName = "";
+    private String taskName = "";
 
     public SingleTaskExecutorServiceImpl() {
         pool = Executors.newFixedThreadPool(1);


### PR DESCRIPTION
The cause of the issue is that some fields in `SingleTaskExecutorServiceImpl` are declared `static`, resulting in camvExecutor stopping foldingExecutor.