### PR TITLE
Show dialog for when recent file doesn't exist

### DIFF
--- a/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
@@ -621,8 +621,11 @@ public class AppMenuBar {
                     applicationModel.addRecentFile(recentFile);
                     revealInFEButton.setEnabled(true);
                 } catch (FileReadingException ex) {
-                    Logger.error(ex.getMessage());
-                    JOptionPane.showMessageDialog(frameProvider.get(), "An error occurred when reading this file", "Read Error", JOptionPane.ERROR_MESSAGE);
+                    String exMsg = ex.getMessage();
+                    JOptionPane.showMessageDialog(frameProvider.get(),
+                            "Can't open file: " + exMsg.substring(exMsg.split(":")[0].length() + 2),
+                            "Read Error",
+                            JOptionPane.ERROR_MESSAGE);
                     applicationModel.removeRecentFile(recentFile);
                 }
             });

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
@@ -622,20 +622,13 @@ public class AppMenuBar {
                     revealInFEButton.setEnabled(true);
                 } catch (FileReadingException ex) {
                     String exMsg = ex.getMessage();
-//                    JOptionPane.showMessageDialog(frameProvider.get(),
-//                            "Can't open file: " + exMsg.substring(exMsg.split(":")[0].length() + 2),
-//                            "Read Error",
-//                            JOptionPane.ERROR_MESSAGE);
                     Object[] options = {"Yes", "No"};
                     int choice = JOptionPane.showOptionDialog(frameProvider.get(),
                             "Can't open file: " + exMsg.substring(exMsg.split(":")[0].length() + 2)
                                     + ".\nDo you want to remove this entry?",
                             "Read Error",
-                            JOptionPane.YES_NO_OPTION,
-                            JOptionPane.WARNING_MESSAGE,
-                            null,
-                            options,
-                            options[0]);
+                            JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE, null,
+                            options, options[0]);
                     if(choice == JOptionPane.YES_OPTION) applicationModel.removeRecentFile(recentFile);
                 }
             });
@@ -667,7 +660,5 @@ public class AppMenuBar {
         }
     }
 
-    private static class AppMenuBarUI extends JMenuBar {
-
-    }
+    private static class AppMenuBarUI extends JMenuBar { }
 }

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
@@ -626,7 +626,7 @@ public class AppMenuBar {
                     int choice = JOptionPane.showOptionDialog(frameProvider.get(),
                             "Can't open file: " + exMsg.substring(exMsg.split(":")[0].length() + 2)
                                     + ".\nDo you want to remove this entry?",
-                            "Read Error",
+                            "Error reading recent file",
                             JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE, null,
                             options, options[0]);
                     if(choice == JOptionPane.YES_OPTION) applicationModel.removeRecentFile(recentFile);

--- a/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
+++ b/oriedita-ui/src/main/java/oriedita/editor/swing/AppMenuBar.java
@@ -622,11 +622,21 @@ public class AppMenuBar {
                     revealInFEButton.setEnabled(true);
                 } catch (FileReadingException ex) {
                     String exMsg = ex.getMessage();
-                    JOptionPane.showMessageDialog(frameProvider.get(),
-                            "Can't open file: " + exMsg.substring(exMsg.split(":")[0].length() + 2),
+//                    JOptionPane.showMessageDialog(frameProvider.get(),
+//                            "Can't open file: " + exMsg.substring(exMsg.split(":")[0].length() + 2),
+//                            "Read Error",
+//                            JOptionPane.ERROR_MESSAGE);
+                    Object[] options = {"Yes", "No"};
+                    int choice = JOptionPane.showOptionDialog(frameProvider.get(),
+                            "Can't open file: " + exMsg.substring(exMsg.split(":")[0].length() + 2)
+                                    + ".\nDo you want to remove this entry?",
                             "Read Error",
-                            JOptionPane.ERROR_MESSAGE);
-                    applicationModel.removeRecentFile(recentFile);
+                            JOptionPane.YES_NO_OPTION,
+                            JOptionPane.WARNING_MESSAGE,
+                            null,
+                            options,
+                            options[0]);
+                    if(choice == JOptionPane.YES_OPTION) applicationModel.removeRecentFile(recentFile);
                 }
             });
             openRecentMenu.add(recentFileMenuItem);

--- a/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
+++ b/oriedita/src/main/java/oriedita/editor/service/impl/FileSaveServiceImpl.java
@@ -106,7 +106,7 @@ public class FileSaveServiceImpl implements FileSaveService {
     @Override
     public void openFile(File file) throws FileReadingException {
         if (file == null || !file.exists()) {
-            return;
+            throw new FileReadingException(new Throwable("File doesn't exist or null"));
         }
 
         fileModel.setSaved(true);


### PR DESCRIPTION
Initial behavior for that scenario is that nothing happens, no indication whatsoever even though the dialog itself is implemented. `openFile()` simply returns if a file doesn't exist, so it was never caught. For the same reason, opening a non-existent file will also delete the item with the file path in the recent files list.

I haven't tested this much and it might affect how the message is displayed in the dialog for other kinds of exceptions meant for the original implementation (but I doubt it will be an issue). Please review this and let me know for any concern.