### PR TITLE
Fix app not minimizing on Mac

### DIFF
--- a/oriedita/src/main/java/oriedita/editor/App.java
+++ b/oriedita/src/main/java/oriedita/editor/App.java
@@ -172,6 +172,7 @@ public class App {
 
         frame.addWindowStateListener(new WindowAdapter() {
             public void windowStateChanged(WindowEvent eve) {
+                if(eve.getNewState() == Frame.ICONIFIED) return;
                 applicationModel.setWindowState(eve.getNewState());
             }
         });


### PR DESCRIPTION
There's no reason for app being minimized or not to be saved for the next relaunch. It's also somehow causing the problem (at least on MacOS) which this PR aims to fix.