### PR TITLE
fix(camera): avoid reversing x if camera is mirrored.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.next
 pom.xml.tag
 release.properties
 .DS_Store
+.vscode/

--- a/oriedita-common/src/main/java/oriedita/editor/drawing/tools/Camera.java
+++ b/oriedita-common/src/main/java/oriedita/editor/drawing/tools/Camera.java
@@ -185,7 +185,6 @@ public class Camera implements Serializable { // Mediation between actual coordi
         double x2 = cos_rad * x1 + sin_rad * y1;
         double y2 = -sin_rad * x1 + cos_rad * y1;
 
-        x2 = x2 * camera_mirror;       //鏡
         x2 = x2 * camera_zoom_x;
         y2 = y2 * camera_zoom_y;
         Point t_tv = new Point(x2 + display_position_x, y2 + display_position_y);
@@ -228,8 +227,6 @@ public class Camera implements Serializable { // Mediation between actual coordi
         y1 = y1 - display_position_y;
         x1 = x1 / camera_zoom_x;
         y1 = y1 / camera_zoom_y;
-
-        x1 = x1 * camera_mirror;       //鏡
 
         x2 = cos_rad * x1 - sin_rad * y1;
         y2 = sin_rad * x1 + cos_rad * y1;


### PR DESCRIPTION
When camera are created, position of Object is reflected by the camera mirror factor. This is an issue as it invert the x position of the rendered object if cp lines are not on the default grid (which can happen if you are in a full grid mode)
Example before: 
<img width="1792" alt="Screenshot 2025-04-05 at 14 30 32" src="https://github.com/user-attachments/assets/0323a9d6-bea0-41a0-9e99-49a5b1270ce0" />
Notice how the flipped version is rendered far on the left with an exact inverse value of the x position

Then after: 
<img width="1792" alt="Screenshot 2025-04-05 at 14 33 46" src="https://github.com/user-attachments/assets/110c7190-d7bd-4ab1-bbd2-f0f111810b35" />
Flipped version is position above the front version with the classic +20 offset

Not sure if it can be improved by getting the x size of the front object and add this as an offset.