### PR TITLE
Add Point-to-point selection and multiple copy to copy and move tools

### DIFF
--- a/oriedita/src/main/java/oriedita/editor/handler/BaseMouseHandlerLineTransform.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/BaseMouseHandlerLineTransform.java
@@ -2,82 +2,88 @@ package oriedita.editor.handler;
 
 import org.tinylog.Logger;
 import oriedita.editor.databinding.AngleSystemModel;
-import oriedita.editor.databinding.CanvasModel;
 import oriedita.editor.drawing.tools.Camera;
 import oriedita.editor.drawing.tools.DrawingUtil;
+import oriedita.editor.handler.step.StepMouseHandler;
 import oriedita.editor.save.Save;
 import oriedita.editor.save.SaveProvider;
+import oriedita.editor.tools.SnappingUtil;
 import origami.crease_pattern.FoldLineSet;
+import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 
-public abstract class BaseMouseHandlerLineTransform extends BaseMouseHandlerLineSelect {
+public abstract class BaseMouseHandlerLineTransform <T extends Enum <T>> extends StepMouseHandler<T> {
 
-    protected CanvasModel canvasModel;
-    protected FoldLineSet lines;
+    protected final AngleSystemModel angleSystemModel;
+    protected boolean snapping;
+    protected FoldLineSet ori_s_temp;
+    protected int total_old, total_new;
     protected Point delta;
+    protected Point p1, p2;
+    protected LineSegment l1;
+    protected Save save;
 
+    private FoldLineSet lines;
     private BufferedImage image;
     private boolean cacheTooBig;
-    private boolean needsRerender = false;
-    protected boolean active = false;
+    private boolean needsRerender;
+    private boolean active;
     private double lastZoomX;
     private double lastZoomY;
     private double lastAngle;
     private Point bottomLeft, topRight;
 
-    protected BaseMouseHandlerLineTransform(CanvasModel canvasModel, AngleSystemModel angleSystemModel) {
-        super(angleSystemModel);
-        this.canvasModel = canvasModel;
+
+    protected BaseMouseHandlerLineTransform(T step, AngleSystemModel angleSystemModel) {
+        super(step);
+        this.angleSystemModel = angleSystemModel;
     }
 
     @Override
-    public void mousePressed(Point p0) {
-        super.mousePressed(p0);
-
-        delta = new Point(0, 0);
-        FoldLineSet ori_s_temp = new FoldLineSet();    //セレクトされた折線だけ取り出すために使う
-        Save save = SaveProvider.createInstance();
-        d.getFoldLineSet().getMemoSelectOption(save, 2);
-        ori_s_temp.setSave(save);
-        lines = ori_s_temp;
-        active = true;
-        needsRerender = true;
+    public void reset() {
+        resetStep();
+        image = null;
+        needsRerender = false;
         bottomLeft = null;
         topRight = null;
-    }
-
-    @Override
-    public void mouseDragged(Point p0) {
-        super.mouseDragged(p0);
-        delta = new Point(
-                -selectionLine.determineBX() + selectionLine.determineAX(),
-                -selectionLine.determineBY() + selectionLine.determineAY()
-        );
-    }
-
-    @Override
-    public void mouseReleased(Point p0) {
-        //  <-------20180919この行はセレクトした線の端点を選ぶと、移動とかコピー等をさせると判断するが、その操作が終わったときに必要だから追加した。
-
-        delta = new Point(
-                -selectionLine.determineBX() + selectionLine.determineAX(),
-                -selectionLine.determineBY() + selectionLine.determineAY()
-        );
-        d.getLineStep().clear();
-        active = false;
-        image = null;
         cacheTooBig = false;
+        active = false;
+        lastAngle = 100000;
+        lastZoomX = 0;
+        lastZoomY = 0;
+        delta = new Point(0,0);
+        p1 = null;
+        p2 = null;
+        lines = null;
+        l1 = null;
+        total_old = 0;
+        total_new = 0;
+        snapping = false;
+        ori_s_temp = null;
+        save = null;
+    }
+
+    @Override
+    public void mouseDragged(Point p0, MouseEvent e) {
+        super.mouseDragged(p0, e);
+        snapping = e.isControlDown();
     }
 
     @Override
     public void drawPreview(Graphics2D g2, Camera camera, DrawingSettings settings) {
         super.drawPreview(g2, camera, settings);
-        if (!active) {
+        if(l1 != null)
+            DrawingUtil.drawLineStep(g2, l1, camera, settings.getLineWidth());
+        DrawingUtil.drawStepVertex(g2, p1, LineColor.GREEN_6, camera);
+        DrawingUtil.drawStepVertex(g2, p2, LineColor.GREEN_6, camera);
+
+        if (!active || lines == null) {
             return;
         }
         if (lines.getTotal() < 1000) { // no need to cache with so few lines
@@ -114,7 +120,7 @@ public abstract class BaseMouseHandlerLineTransform extends BaseMouseHandlerLine
         }
     }
 
-    private void initCacheImage(Graphics2D g2, Camera camera, DrawingSettings settings) {
+    protected void initCacheImage(Graphics2D g2, Camera camera, DrawingSettings settings) {
         if (bottomLeft == null) {
             double minX = lines.getMinX();
             double maxX = lines.getMaxX();
@@ -172,20 +178,66 @@ public abstract class BaseMouseHandlerLineTransform extends BaseMouseHandlerLine
         }
     }
 
-    private boolean determineCameraChanged(Camera camera) {
+    protected boolean determineCameraChanged(Camera camera) {
         return camera.getCameraZoomX() != lastZoomX || camera.getCameraZoomY() != lastZoomY || camera.getCameraAngle() != lastAngle;
     }
 
-    @Override
-    public void reset() {
-        super.reset();
-        image = null;
-        needsRerender = false;
-        bottomLeft = null;
-        cacheTooBig = false;
-        active = false;
-        lastAngle = 100000;
-        lastZoomX = 0;
-        lastZoomY = 0;
+    protected void move_click_drag_point(Point p) {
+        reset();
+        active = true;
+        needsRerender = true;
+
+        ori_s_temp = new FoldLineSet();    //セレクトされた折線だけ取り出すために使う
+        save = SaveProvider.createInstance();
+        d.getFoldLineSet().getMemoSelectOption(save, 2);
+        ori_s_temp.setSave(save);
+        lines = ori_s_temp;
+
+        p1 = p;
+        p2 = p;
+        Point tmpPoint = d.getClosestPoint(p);
+        if (p.distance(tmpPoint) < d.getSelectionDistance()) {
+            p1 = new Point(tmpPoint);
+            p2 = new Point(tmpPoint);
+        }
     }
+
+    protected void drag_click_drag_point(Point p) {
+        if (p1 == null)
+            return;
+
+        p2 = p;
+        Point tmpPoint = d.getClosestPoint(p);
+        if (p.distance(tmpPoint) < d.getSelectionDistance())
+            p2 = new Point(tmpPoint);
+
+        l1 = new LineSegment(p1, p2, LineColor.GREEN_6);
+
+        if(snapping)
+            snapLine();
+
+        delta = new Point(
+                l1.determineBX() - l1.determineAX(),
+                l1.determineBY() - l1.determineAY()
+        );
+    }
+
+    protected abstract T release_click_drag_point(Point p);
+
+    protected void click_select_2(Point p){
+        p2 = p;
+        Point tmpPoint = d.getClosestPoint(p);
+        if (p.distance(tmpPoint) < d.getSelectionDistance())
+            p2 = new Point(tmpPoint);
+    }
+
+    protected abstract T release_select_2(Point p);
+
+    protected void snapLine() {
+        l1 = l1.withB(SnappingUtil.snapToClosePointInActiveAngleSystem(
+                d, l1.getA(), l1.getB(),
+                angleSystemModel.getCurrentAngleSystemDivider(), angleSystemModel.getAngles()));
+    }
+
+    protected abstract void doAction();
 }

--- a/oriedita/src/main/java/oriedita/editor/handler/BaseMouseHandlerLineTransform.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/BaseMouseHandlerLineTransform.java
@@ -17,18 +17,25 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
+import java.util.ArrayList;
 
 public abstract class BaseMouseHandlerLineTransform <T extends Enum <T>> extends StepMouseHandler<T> {
 
-    protected final AngleSystemModel angleSystemModel;
-    protected boolean snapping;
-    protected FoldLineSet ori_s_temp;
-    protected int total_old, total_new;
+    protected T enum_step_first;
+    protected T enum_step_second;
     protected Point delta;
-    protected Point p1, p2;
-    protected LineSegment l1;
     protected Save save;
+    protected FoldLineSet fls_selected;
+    protected boolean multiple;
 
+    private Point anchor;
+    private Point candidate;
+    private ArrayList<Point> destinations;
+    private LineSegment l1;
+    private boolean snapping;
+    private final AngleSystemModel angleSystemModel;
+
+    // Rendering
     private FoldLineSet lines;
     private BufferedImage image;
     private boolean cacheTooBig;
@@ -39,7 +46,6 @@ public abstract class BaseMouseHandlerLineTransform <T extends Enum <T>> extends
     private double lastAngle;
     private Point bottomLeft, topRight;
 
-
     protected BaseMouseHandlerLineTransform(T step, AngleSystemModel angleSystemModel) {
         super(step);
         this.angleSystemModel = angleSystemModel;
@@ -48,25 +54,27 @@ public abstract class BaseMouseHandlerLineTransform <T extends Enum <T>> extends
     @Override
     public void reset() {
         resetStep();
+        delta = new Point(0,0);
+        save = null;
+        fls_selected = null;
+        multiple = false;
+
+        anchor = null;
+        candidate = null;
+        destinations = new ArrayList<>();
+        l1 = null;
+        snapping = false;
+
+        lines = null;
         image = null;
-        needsRerender = false;
-        bottomLeft = null;
-        topRight = null;
         cacheTooBig = false;
+        needsRerender = false;
         active = false;
-        lastAngle = 100000;
         lastZoomX = 0;
         lastZoomY = 0;
-        delta = new Point(0,0);
-        p1 = null;
-        p2 = null;
-        lines = null;
-        l1 = null;
-        total_old = 0;
-        total_new = 0;
-        snapping = false;
-        ori_s_temp = null;
-        save = null;
+        lastAngle = 100000;
+        bottomLeft = null;
+        topRight = null;
     }
 
     @Override
@@ -76,16 +84,27 @@ public abstract class BaseMouseHandlerLineTransform <T extends Enum <T>> extends
     }
 
     @Override
+    public void mousePressed(Point p, MouseEvent e, int b) {
+        super.mousePressed(p,e,b);
+        multiple = e.isShiftDown();
+    }
+
+    @Override
     public void drawPreview(Graphics2D g2, Camera camera, DrawingSettings settings) {
         super.drawPreview(g2, camera, settings);
+
         if(l1 != null)
             DrawingUtil.drawLineStep(g2, l1, camera, settings.getLineWidth());
-        DrawingUtil.drawStepVertex(g2, p1, LineColor.GREEN_6, camera);
-        DrawingUtil.drawStepVertex(g2, p2, LineColor.GREEN_6, camera);
+        if (anchor != null)
+            DrawingUtil.drawStepVertex(g2, anchor, LineColor.GREEN_6, camera);
+        if (candidate != null)
+            DrawingUtil.drawStepVertex(g2, candidate, LineColor.GREEN_6, camera);
+        for (Point p : destinations)
+            DrawingUtil.drawStepVertex(g2, p, LineColor.GREEN_6, camera);
 
-        if (!active || lines == null) {
+        if (!active)
             return;
-        }
+
         if (lines.getTotal() < 1000) { // no need to cache with so few lines
             drawDirect(g2, camera, settings);
             return;
@@ -120,7 +139,7 @@ public abstract class BaseMouseHandlerLineTransform <T extends Enum <T>> extends
         }
     }
 
-    protected void initCacheImage(Graphics2D g2, Camera camera, DrawingSettings settings) {
+    private void initCacheImage(Graphics2D g2, Camera camera, DrawingSettings settings) {
         if (bottomLeft == null) {
             double minX = lines.getMinX();
             double maxX = lines.getMaxX();
@@ -140,7 +159,7 @@ public abstract class BaseMouseHandlerLineTransform <T extends Enum <T>> extends
         }
     }
 
-    protected void drawDirect(Graphics2D g2, Camera camera, DrawingSettings settings) {
+    private void drawDirect(Graphics2D g2, Camera camera, DrawingSettings settings) {
         Point origin = camera.object2TV(new Point(0, 0));
         Point deltaTransformed = camera.object2TV(delta);
         int minx = (int) -(deltaTransformed.getX() - origin.getX());
@@ -164,7 +183,7 @@ public abstract class BaseMouseHandlerLineTransform <T extends Enum <T>> extends
         }
     }
 
-    protected void rerender(Camera camera, DrawingSettings settings) {
+    private void rerender(Camera camera, DrawingSettings settings) {
         Point zero = camera.TV2object(new Point(0, 0));
         Point boObject = camera.TV2object(bottomLeft);
         FoldLineSet ori_s_temp = new FoldLineSet();
@@ -178,40 +197,42 @@ public abstract class BaseMouseHandlerLineTransform <T extends Enum <T>> extends
         }
     }
 
-    protected boolean determineCameraChanged(Camera camera) {
+    private boolean determineCameraChanged(Camera camera) {
         return camera.getCameraZoomX() != lastZoomX || camera.getCameraZoomY() != lastZoomY || camera.getCameraAngle() != lastAngle;
     }
 
-    protected void move_click_drag_point(Point p) {
+    protected void first_click_hover(Point p) {
         reset();
         active = true;
         needsRerender = true;
-
-        ori_s_temp = new FoldLineSet();    //セレクトされた折線だけ取り出すために使う
+        fls_selected = new FoldLineSet();    //セレクトされた折線だけ取り出すために使う
         save = SaveProvider.createInstance();
-        d.getFoldLineSet().getMemoSelectOption(save, 2);
-        ori_s_temp.setSave(save);
-        lines = ori_s_temp;
+        d.getFoldLineSet().getMemoSelectOption(save, 2); // get selected lines
+        fls_selected.setSave(save);
+        lines = fls_selected;
 
-        p1 = p;
-        p2 = p;
         Point tmpPoint = d.getClosestPoint(p);
         if (p.distance(tmpPoint) < d.getSelectionDistance()) {
-            p1 = new Point(tmpPoint);
-            p2 = new Point(tmpPoint);
+            anchor = tmpPoint;
+            candidate =  tmpPoint;
+        }
+        else {
+            candidate = p;
+            anchor = p;
         }
     }
 
-    protected void drag_click_drag_point(Point p) {
-        if (p1 == null)
+    protected void first_click_drag(Point p) {
+        if (anchor == null)
             return;
 
-        p2 = p;
         Point tmpPoint = d.getClosestPoint(p);
         if (p.distance(tmpPoint) < d.getSelectionDistance())
-            p2 = new Point(tmpPoint);
+            candidate = tmpPoint;
+        else
+            candidate = p;
 
-        l1 = new LineSegment(p1, p2, LineColor.GREEN_6);
+        l1 = new LineSegment(anchor, candidate, LineColor.GREEN_6);
 
         if(snapping)
             snapLine();
@@ -222,22 +243,80 @@ public abstract class BaseMouseHandlerLineTransform <T extends Enum <T>> extends
         );
     }
 
-    protected abstract T release_click_drag_point(Point p);
+    protected T first_click_release(Point p) {
+        if (anchor == null || candidate == null)
+            return enum_step_first;
 
-    protected void click_select_2(Point p){
-        p2 = p;
-        Point tmpPoint = d.getClosestPoint(p);
-        if (p.distance(tmpPoint) < d.getSelectionDistance())
-            p2 = new Point(tmpPoint);
+        if (anchor.distance(candidate) < d.getSelectionDistance())
+            return enum_step_second;
+
+        doAction();
+        d.record();
+        d.check4();
+        return enum_step_first;
     }
 
-    protected abstract T release_select_2(Point p);
+    protected void further_click_hover(Point p){
+        Point tmpPoint = d.getClosestPoint(p);
+        if (p.distance(tmpPoint) < d.getSelectionDistance())
+            candidate = tmpPoint;
+        else
+            candidate = p;
+    }
 
-    protected void snapLine() {
+    protected T further_click_release(Point p){
+        if (candidate == null)
+            return enum_step_second;
+        // If Shift is held you can select multiple points
+        if (multiple) {
+            candidate = null;
+            Point tmpPoint = d.getClosestPoint(p);
+            if (p.distance(tmpPoint) < d.getSelectionDistance())
+                destinations.add(tmpPoint);
+            else
+                destinations.add(p);
+            return enum_step_second;
+        }
+        else {
+            // Process all points placed with Shift first
+            for (Point dest : destinations) {
+                l1 = new LineSegment(anchor, dest,  LineColor.GREEN_6);
+                delta = new Point(
+                        l1.determineBX() - l1.determineAX(),
+                        l1.determineBY() - l1.determineAY());
+                // "multiple" is reused in doAction implementations of moveAction
+                // to deselect the moved points.
+                multiple = true;
+                doAction();
+            }
+            // Then do the single point (either the only selected end point or the last one when stopped holding Shift)
+            // And set it back to "false" to keep the last copy selected
+            multiple = false;
+
+            Point tmpPoint = d.getClosestPoint(p);
+            if (p.distance(tmpPoint) < d.getSelectionDistance())
+                candidate = tmpPoint;
+            else
+                candidate = p;
+
+            l1 = new LineSegment(anchor, candidate, LineColor.GREEN_6);
+            delta = new Point(
+                    l1.determineBX() - l1.determineAX(),
+                    l1.determineBY() - l1.determineAY());
+            doAction();
+
+            d.record();
+            d.check4();
+            return enum_step_first;
+        }
+    }
+
+    private void snapLine() {
         l1 = l1.withB(SnappingUtil.snapToClosePointInActiveAngleSystem(
                 d, l1.getA(), l1.getB(),
                 angleSystemModel.getCurrentAngleSystemDivider(), angleSystemModel.getAngles()));
     }
 
+    // Actual move/copy action
     protected abstract void doAction();
 }

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseCopy.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseCopy.java
@@ -2,263 +2,54 @@ package oriedita.editor.handler;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.tinylog.Logger;
 import oriedita.editor.canvas.MouseMode;
 import oriedita.editor.databinding.AngleSystemModel;
-import oriedita.editor.drawing.tools.Camera;
-import oriedita.editor.drawing.tools.DrawingUtil;
 import oriedita.editor.handler.step.ObjCoordStepNode;
-import oriedita.editor.handler.step.StepMouseHandler;
 import oriedita.editor.save.Save;
 import oriedita.editor.save.SaveProvider;
-import oriedita.editor.tools.SnappingUtil;
-import origami.crease_pattern.FoldLineSet;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.event.MouseEvent;
-import java.awt.image.BufferedImage;
-
-enum CreaseCopyStep {
-    CLICK_DRAG_OR_SELECT_POINT,
-    SELECT_POINT
-}
 
 @ApplicationScoped
 @Handles(MouseMode.CREASE_COPY_22)
-public class MouseHandlerCreaseCopy extends StepMouseHandler<CreaseCopyStep> {
-    private final AngleSystemModel angleSystemModel;
-    private FoldLineSet lines;
-    private Point delta;
-    private Point p1, p2;
-    private LineSegment l1;
-    private FoldLineSet ori_s_temp;
-    private Save save;
-    private int total_old, total_new;
+public class MouseHandlerCreaseCopy extends BaseMouseHandlerLineTransform<MouseHandlerCreaseCopy.Step> {
 
-    private BufferedImage image;
-    private boolean cacheTooBig;
-    private boolean needsRerender = false;
-    private boolean active = false;
-    private double lastZoomX;
-    private double lastZoomY;
-    private double lastAngle;
-    private Point bottomLeft, topRight;
-    private boolean snapping = false;
+    enum Step {
+        CLICK_DRAG_OR_SELECT_POINT,
+        SELECT_POINT
+    }
 
     @Inject
     public MouseHandlerCreaseCopy(AngleSystemModel angleSystemModel) {
-        super(CreaseCopyStep.CLICK_DRAG_OR_SELECT_POINT);
-        this.angleSystemModel = angleSystemModel;
-        steps.addNode(ObjCoordStepNode.createNode(CreaseCopyStep.CLICK_DRAG_OR_SELECT_POINT,
+        super(Step.CLICK_DRAG_OR_SELECT_POINT, angleSystemModel);
+        steps.addNode(ObjCoordStepNode.createNode(Step.CLICK_DRAG_OR_SELECT_POINT,
                 this::move_click_drag_point,
                 (p) -> {
                 }, this::drag_click_drag_point, this::release_click_drag_point));
-        steps.addNode(ObjCoordStepNode.createNode_MD_R(CreaseCopyStep.SELECT_POINT,
+        steps.addNode(ObjCoordStepNode.createNode_MD_R(Step.SELECT_POINT,
                 this::click_select_2,
                 this::release_select_2));
     }
 
     @Override
-    public void reset() {
-        resetStep();
-        image = null;
-        needsRerender = false;
-        bottomLeft = null;
-        cacheTooBig = false;
-        active = false;
-        lastAngle = 100000;
-        lastZoomX = 0;
-        lastZoomY = 0;
-        delta = new Point(0,0);
-        p1 = null;
-        p2 = null;
-        lines = null;
-        l1 = null;
-        total_old = 0;
-        total_new = 0;
-    }
-
-    @Override
-    public void mouseDragged(Point p0, MouseEvent e) {
-        super.mouseDragged(p0, e);
-        snapping = e.isControlDown();
-    }
-
-    @Override
-    public void drawPreview(Graphics2D g2, Camera camera, DrawingSettings settings) {
-        super.drawPreview(g2, camera, settings);
-        if(l1 != null)
-            DrawingUtil.drawLineStep(g2, l1, camera, settings.getLineWidth());
-        DrawingUtil.drawStepVertex(g2, p1, LineColor.GREEN_6, camera);
-        DrawingUtil.drawStepVertex(g2, p2, LineColor.GREEN_6, camera);
-
-        if (!active || lines == null) {
-            return;
-        }
-        if (lines.getTotal() < 1000) { // no need to cache with so few lines
-            drawDirect(g2, camera, settings);
-            return;
-        }
-        if (determineCameraChanged(camera)) {
-            cacheTooBig = false;
-            needsRerender = true;
-        }
-        lastZoomX = camera.getCameraZoomX();
-        lastZoomY = camera.getCameraZoomY();
-        lastAngle = camera.getCameraAngle();
-
-        if (needsRerender && lines != null && !cacheTooBig) {
-            initCacheImage(g2, camera, settings);
-            if (image != null) { // image won't be created if it would be too big
-                rerender(camera, settings);
-                needsRerender = false;
-            }
-        }
-
-        if (image != null) {
-            Point origin = camera.object2TV(new Point(0, 0));
-            Point deltaTransformed = camera.object2TV(delta);
-            Logger.info(delta);
-            g2.drawImage(image,
-                    (int) (bottomLeft.getX() + deltaTransformed.getX() - origin.getX()),
-                    (int) (bottomLeft.getY() + deltaTransformed.getY() - origin.getY()),
-                    image.getWidth(), image.getHeight(), null);
-        }
-        if (image == null && lines != null) {
-            drawDirect(g2, camera, settings);
-        }
-    }
-
-    private void initCacheImage(Graphics2D g2, Camera camera, DrawingSettings settings) {
-        if (bottomLeft == null) {
-            double minX = lines.getMinX();
-            double maxX = lines.getMaxX();
-            double minY = lines.getMinY();
-            double maxY = lines.getMaxY();
-
-            bottomLeft = camera.object2TV(new Point(minX, minY));
-            topRight = camera.object2TV(new Point(maxX, maxY));
-        }
-
-        int width = (int) (topRight.getX() - bottomLeft.getX()) + 3;
-        int height = (int) (topRight.getY() - bottomLeft.getY()) + 3;
-        image = null;
-        if (width * height < settings.getWidth() * settings.getHeight() * 1.5) {
-            image = g2.getDeviceConfiguration().createCompatibleImage(width, height, BufferedImage.BITMASK);
-            bottomLeft = bottomLeft.move(new Point(-1, -1));
-        }
-    }
-
-    protected void drawDirect(Graphics2D g2, Camera camera, DrawingSettings settings) {
-        Point origin = camera.object2TV(new Point(0, 0));
-        Point deltaTransformed = camera.object2TV(delta);
-        int minx = (int) -(deltaTransformed.getX() - origin.getX());
-        int miny = (int) -(deltaTransformed.getY() - origin.getY());
-        int maxx = minx + settings.getWidth();
-        int maxy = miny + settings.getHeight();
-
-        // do cohen-sutherland clipping
-        for (var s : lines.getLineSegmentsIterable()) {
-            Point a = camera.object2TV(s.getA());
-            Point b = camera.object2TV(s.getB());
-            int regionA = DrawingUtil.cohenSutherlandRegion(minx, miny, maxx, maxy, a);
-            int regionB = DrawingUtil.cohenSutherlandRegion(minx, miny, maxx, maxy, b);
-            if ((regionA & regionB) == DrawingUtil.CENTER) {
-                Point pa = s.getA().move(delta);
-                Point pb = s.getB().move(delta);
-                LineSegment s2 = new LineSegment(pa, pb, s.getColor());
-                DrawingUtil.drawCpLine(g2, s2, camera, settings.getLineStyle(), settings.getLineWidth(),
-                        d.getPointSize(), settings.getWidth(), settings.getHeight(), settings.useRoundedEnds());
-            }
-        }
-    }
-
-    protected void rerender(Camera camera, DrawingSettings settings) {
-        Point zero = camera.TV2object(new Point(0, 0));
-        Point boObject = camera.TV2object(bottomLeft);
-        FoldLineSet ori_s_temp = new FoldLineSet();
-        ori_s_temp.set(lines);
-        ori_s_temp.move(zero.getX() - boObject.getX(), zero.getY() - boObject.getY());
-        Graphics2D g = image.createGraphics();
-        g.setBackground(new Color(0f, 0, 0, 0));
-        for (var ls : ori_s_temp.getLineSegmentsIterable()) {
-            DrawingUtil.drawCpLine(g, ls, camera, settings.getLineStyle(),
-                    settings.getLineWidth(), d.getPointSize(), image.getWidth(), image.getHeight(), settings.useRoundedEnds());
-        }
-    }
-
-    private boolean determineCameraChanged(Camera camera) {
-        return camera.getCameraZoomX() != lastZoomX || camera.getCameraZoomY() != lastZoomY || camera.getCameraAngle() != lastAngle;
-    }
-
-    private void move_click_drag_point(Point p) {
-        reset();
-        active = true;
-        needsRerender = true;
-        bottomLeft = null;
-        topRight = null;
-
-        ori_s_temp = new FoldLineSet();    //セレクトされた折線だけ取り出すために使う
-        save = SaveProvider.createInstance();
-        d.getFoldLineSet().getMemoSelectOption(save, 2);
-        ori_s_temp.setSave(save);
-        lines = ori_s_temp;
-
-        p1 = p;
-        p2 = p;
-        Point tmpPoint = d.getClosestPoint(p);
-        if (p.distance(tmpPoint) < d.getSelectionDistance()) {
-            p1 = new Point(tmpPoint);
-            p2 = new Point(tmpPoint);
-        }
-    }
-
-    private void drag_click_drag_point(Point p) {
-        if (p1 == null)
-            return;
-
-        p2 = p;
-        Point tmpPoint = d.getClosestPoint(p);
-        if (p.distance(tmpPoint) < d.getSelectionDistance())
-            p2 = new Point(tmpPoint);
-
-        l1 = new LineSegment(p1, p2, LineColor.GREEN_6);
-
-        if(snapping)
-            snapLine();
-
-        delta = new Point(
-                l1.determineBX() - l1.determineAX(),
-                l1.determineBY() - l1.determineAY()
-        );
-    }
-
-    private CreaseCopyStep release_click_drag_point(Point p) {
+    protected Step release_click_drag_point(Point p) {
         if (p1 == null || p2 == null)
-            return CreaseCopyStep.CLICK_DRAG_OR_SELECT_POINT;
+            return Step.CLICK_DRAG_OR_SELECT_POINT;
 
         if (p.distance(p1) < d.getSelectionDistance())
-            return CreaseCopyStep.SELECT_POINT;
+            return Step.SELECT_POINT;
 
-        move();
+        doAction();
         d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
         d.record();
         d.check4();
-        return CreaseCopyStep.CLICK_DRAG_OR_SELECT_POINT;
+        return Step.CLICK_DRAG_OR_SELECT_POINT;
     }
 
-    private void click_select_2(Point p){
-        p2 = p;
-        Point tmpPoint = d.getClosestPoint(p);
-        if (p.distance(tmpPoint) < d.getSelectionDistance())
-            p2 = new Point(tmpPoint);
-    }
-
-    private CreaseCopyStep release_select_2(Point p) {
+    @Override
+    protected Step release_select_2(Point p) {
         if (p2 != null) {
 
             l1 = new LineSegment(p1, p2, LineColor.GREEN_6);
@@ -269,22 +60,17 @@ public class MouseHandlerCreaseCopy extends StepMouseHandler<CreaseCopyStep> {
                     l1.determineBX() - l1.determineAX(),
                     l1.determineBY() - l1.determineAY()
             );
-            move();
+            doAction();
             d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
             d.record();
             d.check4();
-            return CreaseCopyStep.CLICK_DRAG_OR_SELECT_POINT;
+            return Step.CLICK_DRAG_OR_SELECT_POINT;
         }
-        return CreaseCopyStep.SELECT_POINT;
+        return Step.SELECT_POINT;
     }
 
-    private void snapLine() {
-        l1 = l1.withB(SnappingUtil.snapToClosePointInActiveAngleSystem(
-                d, l1.getA(), l1.getB(),
-                angleSystemModel.getCurrentAngleSystemDivider(), angleSystemModel.getAngles()));
-    }
-
-    private void move() {
+    @Override
+    protected void doAction() {
         ori_s_temp.setSave(save);//セレクトされた折線だけ取り出してori_s_tempを作る
         ori_s_temp.move(delta.getX(), delta.getY());//全体を移動する
         ori_s_temp.unselect_all();

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseCopy.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseCopy.java
@@ -2,49 +2,296 @@ package oriedita.editor.handler;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import oriedita.editor.canvas.CreasePattern_Worker;
+import org.tinylog.Logger;
 import oriedita.editor.canvas.MouseMode;
 import oriedita.editor.databinding.AngleSystemModel;
-import oriedita.editor.databinding.CanvasModel;
+import oriedita.editor.drawing.tools.Camera;
+import oriedita.editor.drawing.tools.DrawingUtil;
+import oriedita.editor.handler.step.ObjCoordStepNode;
+import oriedita.editor.handler.step.StepMouseHandler;
 import oriedita.editor.save.Save;
 import oriedita.editor.save.SaveProvider;
-import origami.Epsilon;
+import oriedita.editor.tools.SnappingUtil;
 import origami.crease_pattern.FoldLineSet;
+import origami.crease_pattern.element.LineColor;
+import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+
+enum CreaseCopyStep {
+    CLICK_DRAG_OR_SELECT_POINT,
+    SELECT_POINT
+}
 
 @ApplicationScoped
 @Handles(MouseMode.CREASE_COPY_22)
-public class MouseHandlerCreaseCopy extends BaseMouseHandlerLineTransform {
+public class MouseHandlerCreaseCopy extends StepMouseHandler<CreaseCopyStep> {
+    private final AngleSystemModel angleSystemModel;
+    private FoldLineSet lines;
+    private Point delta;
+    private Point p1, p2;
+    private LineSegment l1;
+    private FoldLineSet ori_s_temp;
+    private Save save;
+    private int total_old, total_new;
+
+    private BufferedImage image;
+    private boolean cacheTooBig;
+    private boolean needsRerender = false;
+    private boolean active = false;
+    private double lastZoomX;
+    private double lastZoomY;
+    private double lastAngle;
+    private Point bottomLeft, topRight;
+    private boolean snapping = false;
+
     @Inject
-    public MouseHandlerCreaseCopy(@Named("mainCreasePattern_Worker") CreasePattern_Worker d, CanvasModel canvasModel, AngleSystemModel angleSystemModel) {
-        super(canvasModel, angleSystemModel);
-        this.d = d;
+    public MouseHandlerCreaseCopy(AngleSystemModel angleSystemModel) {
+        super(CreaseCopyStep.CLICK_DRAG_OR_SELECT_POINT);
+        this.angleSystemModel = angleSystemModel;
+        steps.addNode(ObjCoordStepNode.createNode(CreaseCopyStep.CLICK_DRAG_OR_SELECT_POINT,
+                this::move_click_drag_point,
+                (p) -> {
+                }, this::drag_click_drag_point, this::release_click_drag_point));
+        steps.addNode(ObjCoordStepNode.createNode_MD_R(CreaseCopyStep.SELECT_POINT,
+                this::click_select_2,
+                this::release_select_2));
     }
 
-    //マウスリリース----------------------------------------------------
-    public void mouseReleased(Point p0) {
-        super.mouseReleased(p0);
-
-        if (Epsilon.high.gt0(delta.distance(new Point(0, 0)))) {
-            //やりたい動作はここに書く
-
-            FoldLineSet ori_s_temp = lines;
-            ori_s_temp.move(delta.getX(), delta.getY());
-            ori_s_temp.unselect_all();
-
-            int sousuu_old = d.getFoldLineSet().getTotal();
-            Save save1 = SaveProvider.createInstance();
-            ori_s_temp.getSave(save1);
-            d.getFoldLineSet().addSave(save1);
-            int sousuu_new = d.getFoldLineSet().getTotal();
-            d.getFoldLineSet().divideLineSegmentWithNewLines(sousuu_old, sousuu_new);
-
-            d.unselect_all(false);
-            d.record();
-        }
+    @Override
+    public void reset() {
+        resetStep();
+        image = null;
+        needsRerender = false;
+        bottomLeft = null;
+        cacheTooBig = false;
+        active = false;
+        lastAngle = 100000;
+        lastZoomX = 0;
+        lastZoomY = 0;
+        delta = new Point(0,0);
+        p1 = null;
+        p2 = null;
         lines = null;
+        l1 = null;
+        total_old = 0;
+        total_new = 0;
     }
 
+    @Override
+    public void mouseDragged(Point p0, MouseEvent e) {
+        super.mouseDragged(p0, e);
+        snapping = e.isControlDown();
+    }
 
+    @Override
+    public void drawPreview(Graphics2D g2, Camera camera, DrawingSettings settings) {
+        super.drawPreview(g2, camera, settings);
+        if(l1 != null)
+            DrawingUtil.drawLineStep(g2, l1, camera, settings.getLineWidth());
+        DrawingUtil.drawStepVertex(g2, p1, LineColor.GREEN_6, camera);
+        DrawingUtil.drawStepVertex(g2, p2, LineColor.GREEN_6, camera);
+
+        if (!active || lines == null) {
+            return;
+        }
+        if (lines.getTotal() < 1000) { // no need to cache with so few lines
+            drawDirect(g2, camera, settings);
+            return;
+        }
+        if (determineCameraChanged(camera)) {
+            cacheTooBig = false;
+            needsRerender = true;
+        }
+        lastZoomX = camera.getCameraZoomX();
+        lastZoomY = camera.getCameraZoomY();
+        lastAngle = camera.getCameraAngle();
+
+        if (needsRerender && lines != null && !cacheTooBig) {
+            initCacheImage(g2, camera, settings);
+            if (image != null) { // image won't be created if it would be too big
+                rerender(camera, settings);
+                needsRerender = false;
+            }
+        }
+
+        if (image != null) {
+            Point origin = camera.object2TV(new Point(0, 0));
+            Point deltaTransformed = camera.object2TV(delta);
+            Logger.info(delta);
+            g2.drawImage(image,
+                    (int) (bottomLeft.getX() + deltaTransformed.getX() - origin.getX()),
+                    (int) (bottomLeft.getY() + deltaTransformed.getY() - origin.getY()),
+                    image.getWidth(), image.getHeight(), null);
+        }
+        if (image == null && lines != null) {
+            drawDirect(g2, camera, settings);
+        }
+    }
+
+    private void initCacheImage(Graphics2D g2, Camera camera, DrawingSettings settings) {
+        if (bottomLeft == null) {
+            double minX = lines.getMinX();
+            double maxX = lines.getMaxX();
+            double minY = lines.getMinY();
+            double maxY = lines.getMaxY();
+
+            bottomLeft = camera.object2TV(new Point(minX, minY));
+            topRight = camera.object2TV(new Point(maxX, maxY));
+        }
+
+        int width = (int) (topRight.getX() - bottomLeft.getX()) + 3;
+        int height = (int) (topRight.getY() - bottomLeft.getY()) + 3;
+        image = null;
+        if (width * height < settings.getWidth() * settings.getHeight() * 1.5) {
+            image = g2.getDeviceConfiguration().createCompatibleImage(width, height, BufferedImage.BITMASK);
+            bottomLeft = bottomLeft.move(new Point(-1, -1));
+        }
+    }
+
+    protected void drawDirect(Graphics2D g2, Camera camera, DrawingSettings settings) {
+        Point origin = camera.object2TV(new Point(0, 0));
+        Point deltaTransformed = camera.object2TV(delta);
+        int minx = (int) -(deltaTransformed.getX() - origin.getX());
+        int miny = (int) -(deltaTransformed.getY() - origin.getY());
+        int maxx = minx + settings.getWidth();
+        int maxy = miny + settings.getHeight();
+
+        // do cohen-sutherland clipping
+        for (var s : lines.getLineSegmentsIterable()) {
+            Point a = camera.object2TV(s.getA());
+            Point b = camera.object2TV(s.getB());
+            int regionA = DrawingUtil.cohenSutherlandRegion(minx, miny, maxx, maxy, a);
+            int regionB = DrawingUtil.cohenSutherlandRegion(minx, miny, maxx, maxy, b);
+            if ((regionA & regionB) == DrawingUtil.CENTER) {
+                Point pa = s.getA().move(delta);
+                Point pb = s.getB().move(delta);
+                LineSegment s2 = new LineSegment(pa, pb, s.getColor());
+                DrawingUtil.drawCpLine(g2, s2, camera, settings.getLineStyle(), settings.getLineWidth(),
+                        d.getPointSize(), settings.getWidth(), settings.getHeight(), settings.useRoundedEnds());
+            }
+        }
+    }
+
+    protected void rerender(Camera camera, DrawingSettings settings) {
+        Point zero = camera.TV2object(new Point(0, 0));
+        Point boObject = camera.TV2object(bottomLeft);
+        FoldLineSet ori_s_temp = new FoldLineSet();
+        ori_s_temp.set(lines);
+        ori_s_temp.move(zero.getX() - boObject.getX(), zero.getY() - boObject.getY());
+        Graphics2D g = image.createGraphics();
+        g.setBackground(new Color(0f, 0, 0, 0));
+        for (var ls : ori_s_temp.getLineSegmentsIterable()) {
+            DrawingUtil.drawCpLine(g, ls, camera, settings.getLineStyle(),
+                    settings.getLineWidth(), d.getPointSize(), image.getWidth(), image.getHeight(), settings.useRoundedEnds());
+        }
+    }
+
+    private boolean determineCameraChanged(Camera camera) {
+        return camera.getCameraZoomX() != lastZoomX || camera.getCameraZoomY() != lastZoomY || camera.getCameraAngle() != lastAngle;
+    }
+
+    private void move_click_drag_point(Point p) {
+        reset();
+        active = true;
+        needsRerender = true;
+        bottomLeft = null;
+        topRight = null;
+
+        ori_s_temp = new FoldLineSet();    //セレクトされた折線だけ取り出すために使う
+        save = SaveProvider.createInstance();
+        d.getFoldLineSet().getMemoSelectOption(save, 2);
+        ori_s_temp.setSave(save);
+        lines = ori_s_temp;
+
+        p1 = p;
+        p2 = p;
+        Point tmpPoint = d.getClosestPoint(p);
+        if (p.distance(tmpPoint) < d.getSelectionDistance()) {
+            p1 = new Point(tmpPoint);
+            p2 = new Point(tmpPoint);
+        }
+    }
+
+    private void drag_click_drag_point(Point p) {
+        if (p1 == null)
+            return;
+
+        p2 = p;
+        Point tmpPoint = d.getClosestPoint(p);
+        if (p.distance(tmpPoint) < d.getSelectionDistance())
+            p2 = new Point(tmpPoint);
+
+        l1 = new LineSegment(p1, p2, LineColor.GREEN_6);
+
+        if(snapping)
+            snapLine();
+
+        delta = new Point(
+                l1.determineBX() - l1.determineAX(),
+                l1.determineBY() - l1.determineAY()
+        );
+    }
+
+    private CreaseCopyStep release_click_drag_point(Point p) {
+        if (p1 == null || p2 == null)
+            return CreaseCopyStep.CLICK_DRAG_OR_SELECT_POINT;
+
+        if (p.distance(p1) < d.getSelectionDistance())
+            return CreaseCopyStep.SELECT_POINT;
+
+        move();
+        d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
+        d.record();
+        d.check4();
+        return CreaseCopyStep.CLICK_DRAG_OR_SELECT_POINT;
+    }
+
+    private void click_select_2(Point p){
+        p2 = p;
+        Point tmpPoint = d.getClosestPoint(p);
+        if (p.distance(tmpPoint) < d.getSelectionDistance())
+            p2 = new Point(tmpPoint);
+    }
+
+    private CreaseCopyStep release_select_2(Point p) {
+        if (p2 != null) {
+
+            l1 = new LineSegment(p1, p2, LineColor.GREEN_6);
+            if(snapping)
+                snapLine();
+
+            delta = new Point(
+                    l1.determineBX() - l1.determineAX(),
+                    l1.determineBY() - l1.determineAY()
+            );
+            move();
+            d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
+            d.record();
+            d.check4();
+            return CreaseCopyStep.CLICK_DRAG_OR_SELECT_POINT;
+        }
+        return CreaseCopyStep.SELECT_POINT;
+    }
+
+    private void snapLine() {
+        l1 = l1.withB(SnappingUtil.snapToClosePointInActiveAngleSystem(
+                d, l1.getA(), l1.getB(),
+                angleSystemModel.getCurrentAngleSystemDivider(), angleSystemModel.getAngles()));
+    }
+
+    private void move() {
+        ori_s_temp.setSave(save);//セレクトされた折線だけ取り出してori_s_tempを作る
+        ori_s_temp.move(delta.getX(), delta.getY());//全体を移動する
+        ori_s_temp.unselect_all();
+        total_old = d.getFoldLineSet().getTotal();
+        Save save1 = SaveProvider.createInstance();
+        ori_s_temp.getSave(save1);
+        d.getFoldLineSet().addSave(save1);
+        total_new = d.getFoldLineSet().getTotal();
+    }
 }

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseCopy.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseCopy.java
@@ -7,9 +7,6 @@ import oriedita.editor.databinding.AngleSystemModel;
 import oriedita.editor.handler.step.ObjCoordStepNode;
 import oriedita.editor.save.Save;
 import oriedita.editor.save.SaveProvider;
-import origami.crease_pattern.element.LineColor;
-import origami.crease_pattern.element.LineSegment;
-import origami.crease_pattern.element.Point;
 
 
 @ApplicationScoped
@@ -24,60 +21,29 @@ public class MouseHandlerCreaseCopy extends BaseMouseHandlerLineTransform<MouseH
     @Inject
     public MouseHandlerCreaseCopy(AngleSystemModel angleSystemModel) {
         super(Step.CLICK_DRAG_OR_SELECT_POINT, angleSystemModel);
-        steps.addNode(ObjCoordStepNode.createNode(Step.CLICK_DRAG_OR_SELECT_POINT,
-                this::move_click_drag_point,
+
+        enum_step_first = Step.CLICK_DRAG_OR_SELECT_POINT;
+        enum_step_second = Step.SELECT_POINT;
+
+        steps.addNode(ObjCoordStepNode.createNode(enum_step_first,
+                this::first_click_hover,
                 (p) -> {
-                }, this::drag_click_drag_point, this::release_click_drag_point));
-        steps.addNode(ObjCoordStepNode.createNode_MD_R(Step.SELECT_POINT,
-                this::click_select_2,
-                this::release_select_2));
-    }
-
-    @Override
-    protected Step release_click_drag_point(Point p) {
-        if (p1 == null || p2 == null)
-            return Step.CLICK_DRAG_OR_SELECT_POINT;
-
-        if (p.distance(p1) < d.getSelectionDistance())
-            return Step.SELECT_POINT;
-
-        doAction();
-        d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
-        d.record();
-        d.check4();
-        return Step.CLICK_DRAG_OR_SELECT_POINT;
-    }
-
-    @Override
-    protected Step release_select_2(Point p) {
-        if (p2 != null) {
-
-            l1 = new LineSegment(p1, p2, LineColor.GREEN_6);
-            if(snapping)
-                snapLine();
-
-            delta = new Point(
-                    l1.determineBX() - l1.determineAX(),
-                    l1.determineBY() - l1.determineAY()
-            );
-            doAction();
-            d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
-            d.record();
-            d.check4();
-            return Step.CLICK_DRAG_OR_SELECT_POINT;
-        }
-        return Step.SELECT_POINT;
+                }, this::first_click_drag, this::first_click_release));
+        steps.addNode(ObjCoordStepNode.createNode_MD_R(enum_step_second,
+                this::further_click_hover,
+                this::further_click_release));
     }
 
     @Override
     protected void doAction() {
-        ori_s_temp.setSave(save);//セレクトされた折線だけ取り出してori_s_tempを作る
-        ori_s_temp.move(delta.getX(), delta.getY());//全体を移動する
-        ori_s_temp.unselect_all();
-        total_old = d.getFoldLineSet().getTotal();
+        fls_selected.setSave(save);//セレクトされた折線だけ取り出してori_s_tempを作る
+        fls_selected.move(delta.getX(), delta.getY());//全体を移動する
+        fls_selected.unselect_all();
+        int total_old = d.getFoldLineSet().getTotal();
         Save save1 = SaveProvider.createInstance();
-        ori_s_temp.getSave(save1);
+        fls_selected.getSave(save1);
         d.getFoldLineSet().addSave(save1);
-        total_new = d.getFoldLineSet().getTotal();
+        int total_new = d.getFoldLineSet().getTotal();
+        d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseMove.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseMove.java
@@ -2,264 +2,54 @@ package oriedita.editor.handler;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.tinylog.Logger;
 import oriedita.editor.canvas.MouseMode;
 import oriedita.editor.databinding.AngleSystemModel;
-import oriedita.editor.drawing.tools.Camera;
-import oriedita.editor.drawing.tools.DrawingUtil;
 import oriedita.editor.handler.step.ObjCoordStepNode;
-import oriedita.editor.handler.step.StepMouseHandler;
 import oriedita.editor.save.Save;
 import oriedita.editor.save.SaveProvider;
-import oriedita.editor.tools.SnappingUtil;
-import origami.crease_pattern.FoldLineSet;
 import origami.crease_pattern.element.LineColor;
 import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
 
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.event.MouseEvent;
-import java.awt.image.BufferedImage;
-
-enum CreaseMoveStep {
-    CLICK_DRAG_OR_SELECT_POINT,
-    SELECT_POINT
-}
 
 @ApplicationScoped
 @Handles(MouseMode.CREASE_MOVE_21)
-public class MouseHandlerCreaseMove extends StepMouseHandler<CreaseMoveStep> {
-    private final AngleSystemModel angleSystemModel;
-    private FoldLineSet lines;
-    private Point delta;
-    private Point p1, p2;
-    private LineSegment l1;
-    private FoldLineSet ori_s_temp;
-    private Save save;
-    private int total_old, total_new;
+public class MouseHandlerCreaseMove extends BaseMouseHandlerLineTransform<MouseHandlerCreaseMove.Step> {
 
-    private BufferedImage image;
-    private boolean cacheTooBig;
-    private boolean needsRerender = false;
-    private boolean active = false;
-    private double lastZoomX;
-    private double lastZoomY;
-    private double lastAngle;
-    private Point bottomLeft, topRight;
-    private boolean snapping = false;
+    enum Step {
+        CLICK_DRAG_OR_SELECT_POINT,
+        SELECT_POINT
+    }
 
     @Inject
     public MouseHandlerCreaseMove(AngleSystemModel angleSystemModel) {
-        super(CreaseMoveStep.CLICK_DRAG_OR_SELECT_POINT);
-        this.angleSystemModel = angleSystemModel;
-        steps.addNode(ObjCoordStepNode.createNode(CreaseMoveStep.CLICK_DRAG_OR_SELECT_POINT,
+        super(Step.CLICK_DRAG_OR_SELECT_POINT, angleSystemModel);
+        steps.addNode(ObjCoordStepNode.createNode(Step.CLICK_DRAG_OR_SELECT_POINT,
                 this::move_click_drag_point,
                 (p) -> {
                 }, this::drag_click_drag_point, this::release_click_drag_point));
-        steps.addNode(ObjCoordStepNode.createNode_MD_R(CreaseMoveStep.SELECT_POINT,
+        steps.addNode(ObjCoordStepNode.createNode_MD_R(Step.SELECT_POINT,
                 this::click_select_2,
                 this::release_select_2));
     }
 
     @Override
-    public void reset() {
-        resetStep();
-        image = null;
-        needsRerender = false;
-        bottomLeft = null;
-        cacheTooBig = false;
-        active = false;
-        lastAngle = 100000;
-        lastZoomX = 0;
-        lastZoomY = 0;
-        delta = new Point(0,0);
-        p1 = null;
-        p2 = null;
-        lines = null;
-        l1 = null;
-        total_old = 0;
-        total_new = 0;
-    }
-
-    @Override
-    public void mouseDragged(Point p0, MouseEvent e) {
-        super.mouseDragged(p0, e);
-        snapping = e.isControlDown();
-    }
-
-    @Override
-    public void drawPreview(Graphics2D g2, Camera camera, DrawingSettings settings) {
-        super.drawPreview(g2, camera, settings);
-        if(l1 != null)
-            DrawingUtil.drawLineStep(g2, l1, camera, settings.getLineWidth());
-        DrawingUtil.drawStepVertex(g2, p1, LineColor.GREEN_6, camera);
-        DrawingUtil.drawStepVertex(g2, p2, LineColor.GREEN_6, camera);
-
-        if (!active || lines == null) {
-            return;
-        }
-        if (lines.getTotal() < 1000) { // no need to cache with so few lines
-            drawDirect(g2, camera, settings);
-            return;
-        }
-        if (determineCameraChanged(camera)) {
-            cacheTooBig = false;
-            needsRerender = true;
-        }
-        lastZoomX = camera.getCameraZoomX();
-        lastZoomY = camera.getCameraZoomY();
-        lastAngle = camera.getCameraAngle();
-
-        if (needsRerender && lines != null && !cacheTooBig) {
-            initCacheImage(g2, camera, settings);
-            if (image != null) { // image won't be created if it would be too big
-                rerender(camera, settings);
-                needsRerender = false;
-            }
-        }
-
-        if (image != null) {
-            Point origin = camera.object2TV(new Point(0, 0));
-            Point deltaTransformed = camera.object2TV(delta);
-            Logger.info(delta);
-            g2.drawImage(image,
-                    (int) (bottomLeft.getX() + deltaTransformed.getX() - origin.getX()),
-                    (int) (bottomLeft.getY() + deltaTransformed.getY() - origin.getY()),
-                    image.getWidth(), image.getHeight(), null);
-        }
-        if (image == null && lines != null) {
-            drawDirect(g2, camera, settings);
-        }
-    }
-
-    private void initCacheImage(Graphics2D g2, Camera camera, DrawingSettings settings) {
-        if (bottomLeft == null) {
-            double minX = lines.getMinX();
-            double maxX = lines.getMaxX();
-            double minY = lines.getMinY();
-            double maxY = lines.getMaxY();
-
-            bottomLeft = camera.object2TV(new Point(minX, minY));
-            topRight = camera.object2TV(new Point(maxX, maxY));
-        }
-
-        int width = (int) (topRight.getX() - bottomLeft.getX()) + 3;
-        int height = (int) (topRight.getY() - bottomLeft.getY()) + 3;
-        image = null;
-        if (width * height < settings.getWidth() * settings.getHeight() * 1.5) {
-            image = g2.getDeviceConfiguration().createCompatibleImage(width, height, BufferedImage.BITMASK);
-            bottomLeft = bottomLeft.move(new Point(-1, -1));
-        }
-    }
-
-    protected void drawDirect(Graphics2D g2, Camera camera, DrawingSettings settings) {
-        Point origin = camera.object2TV(new Point(0, 0));
-        Point deltaTransformed = camera.object2TV(delta);
-        int minx = (int) -(deltaTransformed.getX() - origin.getX());
-        int miny = (int) -(deltaTransformed.getY() - origin.getY());
-        int maxx = minx + settings.getWidth();
-        int maxy = miny + settings.getHeight();
-
-        // do cohen-sutherland clipping
-        for (var s : lines.getLineSegmentsIterable()) {
-            Point a = camera.object2TV(s.getA());
-            Point b = camera.object2TV(s.getB());
-            int regionA = DrawingUtil.cohenSutherlandRegion(minx, miny, maxx, maxy, a);
-            int regionB = DrawingUtil.cohenSutherlandRegion(minx, miny, maxx, maxy, b);
-            if ((regionA & regionB) == DrawingUtil.CENTER) {
-                Point pa = s.getA().move(delta);
-                Point pb = s.getB().move(delta);
-                LineSegment s2 = new LineSegment(pa, pb, s.getColor());
-                DrawingUtil.drawCpLine(g2, s2, camera, settings.getLineStyle(), settings.getLineWidth(),
-                        d.getPointSize(), settings.getWidth(), settings.getHeight(), settings.useRoundedEnds());
-            }
-        }
-    }
-
-    protected void rerender(Camera camera, DrawingSettings settings) {
-        Point zero = camera.TV2object(new Point(0, 0));
-        Point boObject = camera.TV2object(bottomLeft);
-        FoldLineSet ori_s_temp = new FoldLineSet();
-        ori_s_temp.set(lines);
-        ori_s_temp.move(zero.getX() - boObject.getX(), zero.getY() - boObject.getY());
-        Graphics2D g = image.createGraphics();
-        g.setBackground(new Color(0f, 0, 0, 0));
-        for (var ls : ori_s_temp.getLineSegmentsIterable()) {
-            DrawingUtil.drawCpLine(g, ls, camera, settings.getLineStyle(),
-                    settings.getLineWidth(), d.getPointSize(), image.getWidth(), image.getHeight(), settings.useRoundedEnds());
-        }
-    }
-
-    private boolean determineCameraChanged(Camera camera) {
-        return camera.getCameraZoomX() != lastZoomX || camera.getCameraZoomY() != lastZoomY || camera.getCameraAngle() != lastAngle;
-    }
-
-    private void move_click_drag_point(Point p) {
-        reset();
-        active = true;
-        needsRerender = true;
-        bottomLeft = null;
-        topRight = null;
-
-        ori_s_temp = new FoldLineSet();    //セレクトされた折線だけ取り出すために使う
-        save = SaveProvider.createInstance();
-        d.getFoldLineSet().getMemoSelectOption(save, 2);
-        ori_s_temp.setSave(save);
-        lines = ori_s_temp;
-
-        p1 = p;
-        p2 = p;
-        Point tmpPoint = d.getClosestPoint(p);
-        if (p.distance(tmpPoint) < d.getSelectionDistance()) {
-            p1 = new Point(tmpPoint);
-            p2 = new Point(tmpPoint);
-        }
-    }
-
-    private void drag_click_drag_point(Point p) {
-        if (p1 == null)
-            return;
-
-        p2 = p;
-        Point tmpPoint = d.getClosestPoint(p);
-        if (p.distance(tmpPoint) < d.getSelectionDistance())
-            p2 = new Point(tmpPoint);
-
-        l1 = new LineSegment(p1, p2, LineColor.GREEN_6);
-
-        if(snapping)
-            snapLine();
-
-        delta = new Point(
-                l1.determineBX() - l1.determineAX(),
-                l1.determineBY() - l1.determineAY()
-        );
-    }
-
-    private CreaseMoveStep release_click_drag_point(Point p) {
+    protected Step release_click_drag_point(Point p) {
         if (p1 == null || p2 == null)
-            return CreaseMoveStep.CLICK_DRAG_OR_SELECT_POINT;
+            return Step.CLICK_DRAG_OR_SELECT_POINT;
 
         if (p.distance(p1) < d.getSelectionDistance())
-            return CreaseMoveStep.SELECT_POINT;
+            return Step.SELECT_POINT;
 
-        move();
+        doAction();
         d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
         d.record();
         d.check4();
-        return CreaseMoveStep.CLICK_DRAG_OR_SELECT_POINT;
-
+        return Step.CLICK_DRAG_OR_SELECT_POINT;
     }
 
-    private void click_select_2(Point p){
-        p2 = p;
-        Point tmpPoint = d.getClosestPoint(p);
-        if (p.distance(tmpPoint) < d.getSelectionDistance())
-            p2 = new Point(tmpPoint);
-    }
-
-    private CreaseMoveStep release_select_2(Point p) {
+    @Override
+    protected Step release_select_2(Point p) {
         if (p2 != null) {
 
             l1 = new LineSegment(p1, p2, LineColor.GREEN_6);
@@ -270,22 +60,17 @@ public class MouseHandlerCreaseMove extends StepMouseHandler<CreaseMoveStep> {
                     l1.determineBX() - l1.determineAX(),
                     l1.determineBY() - l1.determineAY()
             );
-            move();
+            doAction();
             d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
             d.record();
             d.check4();
-            return CreaseMoveStep.CLICK_DRAG_OR_SELECT_POINT;
+            return Step.CLICK_DRAG_OR_SELECT_POINT;
         }
-        return CreaseMoveStep.SELECT_POINT;
+        return Step.SELECT_POINT;
     }
 
-    private void snapLine() {
-        l1 = l1.withB(SnappingUtil.snapToClosePointInActiveAngleSystem(
-                d, l1.getA(), l1.getB(),
-                angleSystemModel.getCurrentAngleSystemDivider(), angleSystemModel.getAngles()));
-    }
-
-    private void move() {
+    @Override
+    protected void doAction() {
         ori_s_temp.setSave(save);//セレクトされた折線だけ取り出してori_s_tempを作る
         d.getFoldLineSet().delSelectedLineSegmentFast();//セレクトされた折線を削除する。
         ori_s_temp.move(delta.getX(), delta.getY());//全体を移動する

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseMove.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseMove.java
@@ -7,9 +7,6 @@ import oriedita.editor.databinding.AngleSystemModel;
 import oriedita.editor.handler.step.ObjCoordStepNode;
 import oriedita.editor.save.Save;
 import oriedita.editor.save.SaveProvider;
-import origami.crease_pattern.element.LineColor;
-import origami.crease_pattern.element.LineSegment;
-import origami.crease_pattern.element.Point;
 
 
 @ApplicationScoped
@@ -24,60 +21,33 @@ public class MouseHandlerCreaseMove extends BaseMouseHandlerLineTransform<MouseH
     @Inject
     public MouseHandlerCreaseMove(AngleSystemModel angleSystemModel) {
         super(Step.CLICK_DRAG_OR_SELECT_POINT, angleSystemModel);
-        steps.addNode(ObjCoordStepNode.createNode(Step.CLICK_DRAG_OR_SELECT_POINT,
-                this::move_click_drag_point,
+
+        enum_step_first = Step.CLICK_DRAG_OR_SELECT_POINT;
+        enum_step_second = Step.SELECT_POINT;
+
+        steps.addNode(ObjCoordStepNode.createNode(enum_step_first,
+                this::first_click_hover,
                 (p) -> {
-                }, this::drag_click_drag_point, this::release_click_drag_point));
-        steps.addNode(ObjCoordStepNode.createNode_MD_R(Step.SELECT_POINT,
-                this::click_select_2,
-                this::release_select_2));
-    }
-
-    @Override
-    protected Step release_click_drag_point(Point p) {
-        if (p1 == null || p2 == null)
-            return Step.CLICK_DRAG_OR_SELECT_POINT;
-
-        if (p.distance(p1) < d.getSelectionDistance())
-            return Step.SELECT_POINT;
-
-        doAction();
-        d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
-        d.record();
-        d.check4();
-        return Step.CLICK_DRAG_OR_SELECT_POINT;
-    }
-
-    @Override
-    protected Step release_select_2(Point p) {
-        if (p2 != null) {
-
-            l1 = new LineSegment(p1, p2, LineColor.GREEN_6);
-            if(snapping)
-                snapLine();
-
-            delta = new Point(
-                    l1.determineBX() - l1.determineAX(),
-                    l1.determineBY() - l1.determineAY()
-            );
-            doAction();
-            d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
-            d.record();
-            d.check4();
-            return Step.CLICK_DRAG_OR_SELECT_POINT;
-        }
-        return Step.SELECT_POINT;
+                }, this::first_click_drag, this::first_click_release));
+        steps.addNode(ObjCoordStepNode.createNode_MD_R(enum_step_second,
+                this::further_click_hover,
+                this::further_click_release));
     }
 
     @Override
     protected void doAction() {
-        ori_s_temp.setSave(save);//セレクトされた折線だけ取り出してori_s_tempを作る
-        d.getFoldLineSet().delSelectedLineSegmentFast();//セレクトされた折線を削除する。
-        ori_s_temp.move(delta.getX(), delta.getY());//全体を移動する
-        total_old = d.getFoldLineSet().getTotal();
+        fls_selected.setSave(save); //"save" are all selected lines before any moving
+        d.getFoldLineSet().delSelectedLineSegmentFast(); // delete the original lines
+        fls_selected.move(delta.getX(), delta.getY()); // move the selected ones
+        // The desired behavior is to keep the last copy selected, so a check is necessary.
+        // "multiple" is set appropriately in inherited definition
+        if(multiple)
+            fls_selected.unselect_all(); // deselect lines so they don't get deleted by the above line next iteration
+        int total_old = d.getFoldLineSet().getTotal();
         Save save1 = SaveProvider.createInstance();
-        ori_s_temp.getSave(save1);
+        fls_selected.getSave(save1);
         d.getFoldLineSet().addSave(save1);
-        total_new = d.getFoldLineSet().getTotal();
+        int total_new = d.getFoldLineSet().getTotal();
+        d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
     }
 }

--- a/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseMove.java
+++ b/oriedita/src/main/java/oriedita/editor/handler/MouseHandlerCreaseMove.java
@@ -2,48 +2,297 @@ package oriedita.editor.handler;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import oriedita.editor.canvas.CreasePattern_Worker;
+import org.tinylog.Logger;
 import oriedita.editor.canvas.MouseMode;
 import oriedita.editor.databinding.AngleSystemModel;
-import oriedita.editor.databinding.CanvasModel;
+import oriedita.editor.drawing.tools.Camera;
+import oriedita.editor.drawing.tools.DrawingUtil;
+import oriedita.editor.handler.step.ObjCoordStepNode;
+import oriedita.editor.handler.step.StepMouseHandler;
 import oriedita.editor.save.Save;
 import oriedita.editor.save.SaveProvider;
-import origami.Epsilon;
+import oriedita.editor.tools.SnappingUtil;
 import origami.crease_pattern.FoldLineSet;
+import origami.crease_pattern.element.LineColor;
+import origami.crease_pattern.element.LineSegment;
 import origami.crease_pattern.element.Point;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+
+enum CreaseMoveStep {
+    CLICK_DRAG_OR_SELECT_POINT,
+    SELECT_POINT
+}
 
 @ApplicationScoped
 @Handles(MouseMode.CREASE_MOVE_21)
-public class MouseHandlerCreaseMove extends BaseMouseHandlerLineTransform {
+public class MouseHandlerCreaseMove extends StepMouseHandler<CreaseMoveStep> {
+    private final AngleSystemModel angleSystemModel;
+    private FoldLineSet lines;
+    private Point delta;
+    private Point p1, p2;
+    private LineSegment l1;
+    private FoldLineSet ori_s_temp;
+    private Save save;
+    private int total_old, total_new;
+
+    private BufferedImage image;
+    private boolean cacheTooBig;
+    private boolean needsRerender = false;
+    private boolean active = false;
+    private double lastZoomX;
+    private double lastZoomY;
+    private double lastAngle;
+    private Point bottomLeft, topRight;
+    private boolean snapping = false;
+
     @Inject
-    public MouseHandlerCreaseMove(@Named("mainCreasePattern_Worker") CreasePattern_Worker d, CanvasModel canvasModel, AngleSystemModel angleSystemModel) {
-        super(canvasModel, angleSystemModel);
-        this.d = d;
+    public MouseHandlerCreaseMove(AngleSystemModel angleSystemModel) {
+        super(CreaseMoveStep.CLICK_DRAG_OR_SELECT_POINT);
+        this.angleSystemModel = angleSystemModel;
+        steps.addNode(ObjCoordStepNode.createNode(CreaseMoveStep.CLICK_DRAG_OR_SELECT_POINT,
+                this::move_click_drag_point,
+                (p) -> {
+                }, this::drag_click_drag_point, this::release_click_drag_point));
+        steps.addNode(ObjCoordStepNode.createNode_MD_R(CreaseMoveStep.SELECT_POINT,
+                this::click_select_2,
+                this::release_select_2));
     }
 
-    //マウスリリース----------------------------------------------------
-    public void mouseReleased(Point p0) {
-        super.mouseReleased(p0);
-        if (Epsilon.high.gt0(delta.distance(new Point(0, 0)))) {
-            //やりたい動作はここに書く
-
-            FoldLineSet ori_s_temp = new FoldLineSet();    //セレクトされた折線だけ取り出すために使う
-            Save save = SaveProvider.createInstance();
-            d.getFoldLineSet().getMemoSelectOption(save, 2);
-            ori_s_temp.setSave(save);//セレクトされた折線だけ取り出してori_s_tempを作る
-            d.getFoldLineSet().delSelectedLineSegmentFast();//セレクトされた折線を削除する。
-            ori_s_temp.move(delta.getX(), delta.getY());//全体を移動する
-            int total_old = d.getFoldLineSet().getTotal();
-            Save save1 = SaveProvider.createInstance();
-            ori_s_temp.getSave(save1);
-            d.getFoldLineSet().addSave(save1);
-            int total_new = d.getFoldLineSet().getTotal();
-            d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
-
-            d.unselect_all(false);
-            d.record();
-        }
+    @Override
+    public void reset() {
+        resetStep();
+        image = null;
+        needsRerender = false;
+        bottomLeft = null;
+        cacheTooBig = false;
+        active = false;
+        lastAngle = 100000;
+        lastZoomX = 0;
+        lastZoomY = 0;
+        delta = new Point(0,0);
+        p1 = null;
+        p2 = null;
         lines = null;
+        l1 = null;
+        total_old = 0;
+        total_new = 0;
+    }
+
+    @Override
+    public void mouseDragged(Point p0, MouseEvent e) {
+        super.mouseDragged(p0, e);
+        snapping = e.isControlDown();
+    }
+
+    @Override
+    public void drawPreview(Graphics2D g2, Camera camera, DrawingSettings settings) {
+        super.drawPreview(g2, camera, settings);
+        if(l1 != null)
+            DrawingUtil.drawLineStep(g2, l1, camera, settings.getLineWidth());
+        DrawingUtil.drawStepVertex(g2, p1, LineColor.GREEN_6, camera);
+        DrawingUtil.drawStepVertex(g2, p2, LineColor.GREEN_6, camera);
+
+        if (!active || lines == null) {
+            return;
+        }
+        if (lines.getTotal() < 1000) { // no need to cache with so few lines
+            drawDirect(g2, camera, settings);
+            return;
+        }
+        if (determineCameraChanged(camera)) {
+            cacheTooBig = false;
+            needsRerender = true;
+        }
+        lastZoomX = camera.getCameraZoomX();
+        lastZoomY = camera.getCameraZoomY();
+        lastAngle = camera.getCameraAngle();
+
+        if (needsRerender && lines != null && !cacheTooBig) {
+            initCacheImage(g2, camera, settings);
+            if (image != null) { // image won't be created if it would be too big
+                rerender(camera, settings);
+                needsRerender = false;
+            }
+        }
+
+        if (image != null) {
+            Point origin = camera.object2TV(new Point(0, 0));
+            Point deltaTransformed = camera.object2TV(delta);
+            Logger.info(delta);
+            g2.drawImage(image,
+                    (int) (bottomLeft.getX() + deltaTransformed.getX() - origin.getX()),
+                    (int) (bottomLeft.getY() + deltaTransformed.getY() - origin.getY()),
+                    image.getWidth(), image.getHeight(), null);
+        }
+        if (image == null && lines != null) {
+            drawDirect(g2, camera, settings);
+        }
+    }
+
+    private void initCacheImage(Graphics2D g2, Camera camera, DrawingSettings settings) {
+        if (bottomLeft == null) {
+            double minX = lines.getMinX();
+            double maxX = lines.getMaxX();
+            double minY = lines.getMinY();
+            double maxY = lines.getMaxY();
+
+            bottomLeft = camera.object2TV(new Point(minX, minY));
+            topRight = camera.object2TV(new Point(maxX, maxY));
+        }
+
+        int width = (int) (topRight.getX() - bottomLeft.getX()) + 3;
+        int height = (int) (topRight.getY() - bottomLeft.getY()) + 3;
+        image = null;
+        if (width * height < settings.getWidth() * settings.getHeight() * 1.5) {
+            image = g2.getDeviceConfiguration().createCompatibleImage(width, height, BufferedImage.BITMASK);
+            bottomLeft = bottomLeft.move(new Point(-1, -1));
+        }
+    }
+
+    protected void drawDirect(Graphics2D g2, Camera camera, DrawingSettings settings) {
+        Point origin = camera.object2TV(new Point(0, 0));
+        Point deltaTransformed = camera.object2TV(delta);
+        int minx = (int) -(deltaTransformed.getX() - origin.getX());
+        int miny = (int) -(deltaTransformed.getY() - origin.getY());
+        int maxx = minx + settings.getWidth();
+        int maxy = miny + settings.getHeight();
+
+        // do cohen-sutherland clipping
+        for (var s : lines.getLineSegmentsIterable()) {
+            Point a = camera.object2TV(s.getA());
+            Point b = camera.object2TV(s.getB());
+            int regionA = DrawingUtil.cohenSutherlandRegion(minx, miny, maxx, maxy, a);
+            int regionB = DrawingUtil.cohenSutherlandRegion(minx, miny, maxx, maxy, b);
+            if ((regionA & regionB) == DrawingUtil.CENTER) {
+                Point pa = s.getA().move(delta);
+                Point pb = s.getB().move(delta);
+                LineSegment s2 = new LineSegment(pa, pb, s.getColor());
+                DrawingUtil.drawCpLine(g2, s2, camera, settings.getLineStyle(), settings.getLineWidth(),
+                        d.getPointSize(), settings.getWidth(), settings.getHeight(), settings.useRoundedEnds());
+            }
+        }
+    }
+
+    protected void rerender(Camera camera, DrawingSettings settings) {
+        Point zero = camera.TV2object(new Point(0, 0));
+        Point boObject = camera.TV2object(bottomLeft);
+        FoldLineSet ori_s_temp = new FoldLineSet();
+        ori_s_temp.set(lines);
+        ori_s_temp.move(zero.getX() - boObject.getX(), zero.getY() - boObject.getY());
+        Graphics2D g = image.createGraphics();
+        g.setBackground(new Color(0f, 0, 0, 0));
+        for (var ls : ori_s_temp.getLineSegmentsIterable()) {
+            DrawingUtil.drawCpLine(g, ls, camera, settings.getLineStyle(),
+                    settings.getLineWidth(), d.getPointSize(), image.getWidth(), image.getHeight(), settings.useRoundedEnds());
+        }
+    }
+
+    private boolean determineCameraChanged(Camera camera) {
+        return camera.getCameraZoomX() != lastZoomX || camera.getCameraZoomY() != lastZoomY || camera.getCameraAngle() != lastAngle;
+    }
+
+    private void move_click_drag_point(Point p) {
+        reset();
+        active = true;
+        needsRerender = true;
+        bottomLeft = null;
+        topRight = null;
+
+        ori_s_temp = new FoldLineSet();    //セレクトされた折線だけ取り出すために使う
+        save = SaveProvider.createInstance();
+        d.getFoldLineSet().getMemoSelectOption(save, 2);
+        ori_s_temp.setSave(save);
+        lines = ori_s_temp;
+
+        p1 = p;
+        p2 = p;
+        Point tmpPoint = d.getClosestPoint(p);
+        if (p.distance(tmpPoint) < d.getSelectionDistance()) {
+            p1 = new Point(tmpPoint);
+            p2 = new Point(tmpPoint);
+        }
+    }
+
+    private void drag_click_drag_point(Point p) {
+        if (p1 == null)
+            return;
+
+        p2 = p;
+        Point tmpPoint = d.getClosestPoint(p);
+        if (p.distance(tmpPoint) < d.getSelectionDistance())
+            p2 = new Point(tmpPoint);
+
+        l1 = new LineSegment(p1, p2, LineColor.GREEN_6);
+
+        if(snapping)
+            snapLine();
+
+        delta = new Point(
+                l1.determineBX() - l1.determineAX(),
+                l1.determineBY() - l1.determineAY()
+        );
+    }
+
+    private CreaseMoveStep release_click_drag_point(Point p) {
+        if (p1 == null || p2 == null)
+            return CreaseMoveStep.CLICK_DRAG_OR_SELECT_POINT;
+
+        if (p.distance(p1) < d.getSelectionDistance())
+            return CreaseMoveStep.SELECT_POINT;
+
+        move();
+        d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
+        d.record();
+        d.check4();
+        return CreaseMoveStep.CLICK_DRAG_OR_SELECT_POINT;
+
+    }
+
+    private void click_select_2(Point p){
+        p2 = p;
+        Point tmpPoint = d.getClosestPoint(p);
+        if (p.distance(tmpPoint) < d.getSelectionDistance())
+            p2 = new Point(tmpPoint);
+    }
+
+    private CreaseMoveStep release_select_2(Point p) {
+        if (p2 != null) {
+
+            l1 = new LineSegment(p1, p2, LineColor.GREEN_6);
+            if(snapping)
+                snapLine();
+
+            delta = new Point(
+                    l1.determineBX() - l1.determineAX(),
+                    l1.determineBY() - l1.determineAY()
+            );
+            move();
+            d.getFoldLineSet().divideLineSegmentWithNewLines(total_old, total_new);
+            d.record();
+            d.check4();
+            return CreaseMoveStep.CLICK_DRAG_OR_SELECT_POINT;
+        }
+        return CreaseMoveStep.SELECT_POINT;
+    }
+
+    private void snapLine() {
+        l1 = l1.withB(SnappingUtil.snapToClosePointInActiveAngleSystem(
+                d, l1.getA(), l1.getB(),
+                angleSystemModel.getCurrentAngleSystemDivider(), angleSystemModel.getAngles()));
+    }
+
+    private void move() {
+        ori_s_temp.setSave(save);//セレクトされた折線だけ取り出してori_s_tempを作る
+        d.getFoldLineSet().delSelectedLineSegmentFast();//セレクトされた折線を削除する。
+        ori_s_temp.move(delta.getX(), delta.getY());//全体を移動する
+        total_old = d.getFoldLineSet().getTotal();
+        Save save1 = SaveProvider.createInstance();
+        ori_s_temp.getSave(save1);
+        d.getFoldLineSet().addSave(save1);
+        total_new = d.getFoldLineSet().getTotal();
     }
 }

--- a/oriedita/src/main/resources/help.properties
+++ b/oriedita/src/main/resources/help.properties
@@ -152,8 +152,18 @@ copy2p2pAction=<html>\
   Tip: Set points AB to corners of selection<br>\
   to make it more intuitive to use.
 copyAction=<html>\
-  Copy selected lines by drawing a line or<br>\
-  selecting 2 points.
+  Copy selected lines with a line or points.<br>\
+  <br>\
+  1. Draw a line or select an origin point:<br>\
+  &nbsp;&#x2022; Draw a line to copy selected lines.<br>\
+  &nbsp;&#x2022; Select an origin point.<br>\
+  <br>\
+  1. Select a target point or points:<br>\
+  &nbsp;&#x2022; Select target points by holding Shift.<br>\
+  &nbsp;&#x2022; Select a target point to confirm.<br>\
+  <br>\
+  Selected lines are copied to the positions of<br>\
+  the target points.
 deg1Action=<html>\
   Draw converging lines with angle offset.<br>\
   <br>\
@@ -421,8 +431,18 @@ move2p2pAction=<html>\
   Tip: Set points AB to corners of selection<br>\
   to make it more intuitive to use.
 moveAction=<html>\
-  Move selected lines by drawing a line or<br>\
-  selecting 2 points.
+  Move selected lines with a line or points.<br>\
+  <br>\
+  1. Draw a line or select an origin point:<br>\
+  &nbsp;&#x2022; Draw a line to move selected lines.<br>\
+  &nbsp;&#x2022; Select an origin point.<br>\
+  <br>\
+  2. Select a target point or points:<br>\
+  &nbsp;&#x2022; Select target points by holding Shift.<br>\
+  &nbsp;&#x2022; Select a target point to confirm.<br>\
+  <br>\
+  Selected lines are moved and copied to the<br>\
+  positions of the target points.
 l1Action=<html>\
   Measure length by selecting 2 points.<br>\
   <br>\

--- a/oriedita/src/main/resources/help.properties
+++ b/oriedita/src/main/resources/help.properties
@@ -152,7 +152,8 @@ copy2p2pAction=<html>\
   Tip: Set points AB to corners of selection<br>\
   to make it more intuitive to use.
 copyAction=<html>\
-  Copy selected lines by drawing a line.
+  Copy selected lines by drawing a line or<br>\
+  selecting 2 points.
 deg1Action=<html>\
   Draw converging lines with angle offset.<br>\
   <br>\
@@ -420,7 +421,8 @@ move2p2pAction=<html>\
   Tip: Set points AB to corners of selection<br>\
   to make it more intuitive to use.
 moveAction=<html>\
-  Move selected lines by drawing a line.
+  Move selected lines by drawing a line or<br>\
+  selecting 2 points.
 l1Action=<html>\
   Measure length by selecting 2 points.<br>\
   <br>\

--- a/oriedita/src/main/resources/step_label.properties
+++ b/oriedita/src/main/resources/step_label.properties
@@ -115,6 +115,12 @@ CreaseDeleteOverlapStep.CLICK_DRAG_POINT=Click drag to draw segment
 ContinuousSymmetricDrawStep.SELECT_P1=Select 2 points
 ContinuousSymmetricDrawStep.SELECT_P2=Select 2 points
 
+CreaseMoveStep.CLICK_DRAG_OR_SELECT_POINT=Draw line or select point
+CreaseMoveStep.SELECT_POINT=Select point
+
+CreaseCopyStep.CLICK_DRAG_OR_SELECT_POINT=Draw line or select point
+CreaseCopyStep.SELECT_POINT=Select point
+
 CreaseMove4pStep.SELECT_2_ORIGINAL_POINTS=Select 2 original points
 CreaseMove4pStep.SELECT_2_TARGET_POINTS=Select 2 target points
 

--- a/oriedita/src/main/resources/step_label.properties
+++ b/oriedita/src/main/resources/step_label.properties
@@ -115,11 +115,11 @@ CreaseDeleteOverlapStep.CLICK_DRAG_POINT=Click drag to draw segment
 ContinuousSymmetricDrawStep.SELECT_P1=Select 2 points
 ContinuousSymmetricDrawStep.SELECT_P2=Select 2 points
 
-CreaseMoveStep.CLICK_DRAG_OR_SELECT_POINT=Draw line or select point
-CreaseMoveStep.SELECT_POINT=Select point
+MouseHandlerCreaseMove.Step.CLICK_DRAG_OR_SELECT_POINT=Draw line or select point
+MouseHandlerCreaseMove.Step.SELECT_POINT=Select point
 
-CreaseCopyStep.CLICK_DRAG_OR_SELECT_POINT=Draw line or select point
-CreaseCopyStep.SELECT_POINT=Select point
+MouseHandlerCreaseCopy.Step.CLICK_DRAG_OR_SELECT_POINT=Draw line or select point
+MouseHandlerCreaseCopy.Step.SELECT_POINT=Select point
 
 CreaseMove4pStep.SELECT_2_ORIGINAL_POINTS=Select 2 original points
 CreaseMove4pStep.SELECT_2_TARGET_POINTS=Select 2 target points


### PR DESCRIPTION
When using the copy or move tool you can now select 2 points. The result will be the same as if a line was drawn between the points. This makes it easier to move over long distances. You can also select multiple points by holding Shift. The selection will be copied as if lines were drawn from the first selected point to each consecutive point. 